### PR TITLE
Feature/dualcam

### DIFF
--- a/camera.py
+++ b/camera.py
@@ -9,7 +9,7 @@
 from threading import Thread,Event,Lock
 import time
 import datetime
-import urllib
+import urllib2
 import subprocess
 import select
 import socket
@@ -17,7 +17,11 @@ import sys
 import os
 
 # Default camera URL
-DEFAULT_URL = "http://192.168.1.6/img.jpg"
+DEFAULT_URL = "http://192.168.1.6/image?res=half&quality=12&doublescan=0" # half resolution
+#DEFAULT_URL = "http://192.168.1.6/image?res=full&x0=0&y0=0&x1=2048&y1=1536&quality=12&doublescan=0&ver=HTTP/1.1" # full resolution ~240kB
+DEFAULT_URL_MONO = "http://192.168.1.6/image?channel=mono"
+URL_DAY_NIGHT = "http://192.168.1.6/set?daynight=dual" # auto|day|night|dual
+
 
 # move this to some "common utility"
 def timeName( prefix, ext, index = None ):
@@ -29,86 +33,10 @@ def timeName( prefix, ext, index = None ):
   return prefix + "%02d%02d%02d_%02d%02d%02d" % ( today.year % 100, today.month, today.day, t[0], t[1], t[2] ) + suffix
 
 
-camYTab = (
-      ( 512.0, 0.15 ),
-      ( 452.0, 0.25 ),
-      ( 390.0, 0.35 ),
-      ( 341.0, 0.45 ),
-      ( 306.0, 0.55 ),
-      ( 279.0, 0.65 ),
-      ( 258.0, 0.75 ),
-      ( 243.0, 0.85 ),
-      ( 0.0, 2.0 )
-      )
-
-camXTab = (
-    ( 640.0, -0.6 ),
-    ( 533.0, -0.5 ),
-    ( 513.0, -0.4 ),
-    ( 478.0, -0.3 ),
-    ( 437.0, -0.2 ),
-    ( 389.0, -0.1 ),
-    ( 338.0, 0 ),
-    ( 287.0, 0.1 ),
-    ( 239.0, 0.2 ),
-    ( 198.0, 0.3 ),
-    ( 163.0, 0.4 ),
-    ( 143.0, 0.5 ),
-    ( 36.0, 0.6 ),
-    ( 0.0, 0.7 ) )
-
-def interpolate( val, tab ):
-  for i in range(len(tab)):
-    if val > tab[i][0]:
-      break
-  assert( i > 0 )
-  return tab[i-1][1] + (val - tab[i-1][0])/(tab[i][0]-tab[i-1][0]) * (tab[i][1]-tab[i-1][1])
-
-def img2xy( (x,y) ):
-  "convert image coordinates into robot relative coordinates"
-  front = interpolate( y, camYTab)
-  # (front = 0.55 -> scale 1.0
-  return front, interpolate( x, camXTab )   #*(1+1.3919597989949748*(0.55-front))
-
-
-class ImageProc():
-  def __init__(self, exe = "./king", verbose = 1, priority = None):
-    self.verbose = verbose
-    priority_fn = None if priority is None or not hasattr(os, 'nice') else lambda : os.nice(priority)
-    self.process = subprocess.Popen( exe, shell=True, 
-        stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE, preexec_fn = priority_fn)
-    # Win problem: not supported close_fds=True ... is it critical?
-    # note, that popen2/3 handled incorrect assignment of stdin/stdout
-
-  def processPicture( self, filename ):
-    if self.verbose:
-      if self.verbose == 1:
-        sys.stderr.write('o')
-      else:
-        print "process", filename
-#    self._fout.write( "set roi 0 256 640 256\n" )
-#    self._fout.write( "set roi 0 128 640 256\n" )
-
-    self.process.stdin.write( "file "+filename+"\n" )
-    self.process.stdin.flush()
-    if select.select([self.process.stderr],[],[],0)[0]: # Win problem, and not clear how much I can read?
-      line = self.process.stderr.readline()
-      if not line.startswith( "Corrupt JPEG data:" ):
-        sys.stderr.write( line )
-    return self.process.stdout.readline()
-
-class DummyProc():
-  def __init__( self, sleep = None ):
-    self.sleep = sleep
-  def processPicture( self, filename ):
-    if self.sleep != None:
-      time.sleep( self.sleep )
-
 class Camera( Thread ):
-  def __init__(self, imageProc = None, verbose = 1, url = DEFAULT_URL, sleep = None ):
+  def __init__(self, verbose = 1, url = DEFAULT_URL, sleep = None ):
     Thread.__init__(self)
     self.setDaemon(True)
-    self.imageProc = imageProc
     self.verbose = verbose
     self.lock = Lock()
     self.shouldIRun = Event()
@@ -121,25 +49,14 @@ class Camera( Thread ):
     self._index = 0
     self.url = url
     self.queryCount = 0
-    self.sleepProc = DummyProc( sleep )
     self.sleep = sleep
-    self.pausedProcessing = False
-    self.snapshotOnly = False
 
-  def pauseImageProcessing( self, pause ):
-    self.lock.acquire()
-    self.pausedProcessing = pause
-    self.lock.release()
-
-  def processNextSnapshot( self ):
-    self.lock.acquire()
-    self.pausedProcessing = False
-    self.snapshotOnly = True
-    self.lock.release()
-
-  def getPicture( self, filename ):
+  def getPicture( self, filename, color=True ):
     try:
-      url = urllib.urlopen( self.url )
+      if color:
+        url = urllib2.urlopen( self.url )
+      else:
+        url = urllib2.urlopen( DEFAULT_URL_MONO )
       img = url.read()
       t = time.time()
       file = open( filename, "wb" )
@@ -151,7 +68,14 @@ class Camera( Thread ):
       return None
 
   def run(self):
+    # enable also mono camera view
+    print urllib2.urlopen( URL_DAY_NIGHT ).read()
+
     while self.shouldIRun.isSet():
+      # first read B&W picture (just for reference, not returned to the "system")
+      filename = timeName( "logs/camono", "jpg", index = self._index )
+      result = self.getPicture( filename, color=False )
+      # result is currently ignored
       filename = timeName( "logs/cam", "jpg", index = self._index )
       self._index += 1
       if self.verbose:
@@ -162,19 +86,7 @@ class Camera( Thread ):
       result = self.getPicture( filename )
       if result is not None:
         at, __ = result
-        if self.pausedProcessing:
-          imageProc = self.sleepProc
-        else:
-          imageProc = self.imageProc
-        self.lock.acquire()
-        if self.snapshotOnly:
-          self.snapshotOnly = False
-          self.pausedProcessing = True
-        self.lock.release()
-        if imageProc:
-          tmpResult = imageProc.processPicture( filename )
-        else:
-          tmpResult = filename, None
+        tmpResult = filename, None
         self.lock.acquire()
         self._logFile.write( str(self.queryCount) + '\t' + str(at) + "\n" )
         self.queryCount = 0
@@ -208,109 +120,8 @@ class Camera( Thread ):
     self.shouldIRun.clear()
 
 
-class CameraFromLog:
-  def __init__( self, filename ):
-    self.genLines = open( filename )
-    self.countQuery = int( self.genLines.next() )
-    self.lastResult = (None,None)
-
-  def start( self ):
-    pass
-
-  def requestStop( self ):
-    pass
-
-  def lastResultEx( self ):
-    if self.countQuery > 0:
-      self.countQuery -= 1
-      return self.lastResult
-    line = self.genLines.next()
-    self.lastResult = (" ".join( line.split()[1:]) + "\n", line.split()[0] )
-    self.countQuery = int( self.genLines.next() ) - 1 # this result is reported now -> -1
-    return self.lastResult
-
-class RemoteCamera(Thread):
-  def __init__(self, address, verbose = 0):
-    Thread.__init__(self)
-    self.setDaemon(True)
-
-    self.verbose = verbose
-
-    self.skt = socket.socket()
-    self.skt.connect(address)
-
-    # Send even small packets, do not become late because
-    # of the Naggle's algorithm
-    self.skt.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
-
-    self.io = self.skt.makefile()
-
-    self.lock = Lock()
-    self.__lastResult = None
-    self.__lastResultFile = None
-    self.shouldIRun = Event()
-
-  def sendCmd(self, cmd):
-    if cmd[-1] != '\n':
-      cmd += '\n'
-
-    self.io.write(cmd)
-    self.io.flush()
-
-  def run(self):
-    self.sendCmd('go')
-
-    self.shouldIRun.set()
-
-    while self.shouldIRun.isSet():
-      imgname = self.io.readline()
-      result = self.io.readline()
-      self.lock.acquire()
-      self.__lastResult = result
-      self.__lastResultFile = imgname
-      self.lock.release()
-
-  def lastResult(self):
-    self.lock.acquire()
-    ret = self.__lastResult
-    self.lock.release()
-    return ret
-
-  def lastResultEx(self):
-    self.lock.acquire()
-    ret = (self.__lastResult, self.__lastResultFile)
-    self.lock.release()
-    return ret
-
-  def requestStop(self):
-    self.sendCmd('stop')
-    self.shouldIRun.clear()
-
-
-class DummyCamera():
-  def start( self ):
-    pass
-
-  def requestStop( self ):
-    pass
-
-  def pauseImageProcessing( self, pause ):
-    pass
-
-  def processNextSnapshot( self ):
-    pass
-
-def usage():
-  print __doc__
-
 if __name__ == "__main__": 
-
-#  if len(sys.argv) < 2:
-#    usage()
-#    sys.exit(2)
-
   cam = Camera( verbose = 2, sleep=0.2 )
-  #cam = RemoteCamera(('', 8431))
   cam.start()
   for i in xrange(10):
     print cam.lastResultEx()


### PR DESCRIPTION
This pull request is from "forgotten" commits related to camera.py, in particular collection of B&W images via "night vision" camera.

Proposal 1 - because we already abandoned direct processing in camera module (we want to collect _all_ images for later analysis although only some of them are processed), so the log looks now like:

```
3	1498585128.53
('logs/cam170627_173848_000.jpg', None)
4	1498585128.74
('logs/cam170627_173848_001.jpg', None)
7	1498585129.08
('logs/cam170627_173848_002.jpg', None) 
```

where `None` is the result of the unused procedure. Instead we could use the second slot for names of B&W images?

Proposal 2 - the images would have different name prefix, so the code could guess the name??

Note, that the camera also provides H.264 stream, but we will use that feature probably later (it complicates matter even more because of P-frames require decoding of the whole sequence).

Final note, that camera is not only input device, but rather I/O device. You can select resolution, exposition time, cut from image via ROI (similar to ARDrone3/Katarina code).