### PR TITLE
Allow multiple names in `selected` for tools/logparser2.py

### DIFF
--- a/tools/logparser2.py
+++ b/tools/logparser2.py
@@ -2,25 +2,32 @@
 """
   Log parser - 2nd generation (timestamps based)
   usage:
-       ./meta2view.py <metalog>
+       ./logparser2.py <metalog>
 """
+import ast
 import math
 import os
 import struct
 import sys
 
 
-def timestamps_gen(filename):
-    timestamp = None
-    for i, line in enumerate(open(filename)):
+def timestamps_gen(id, stream):
+    if id == 'can': # binary log, not implemented
+        return
+    if id == 'timestamps':
+        for line in stream:
+            line = ast.literal_eval(line)
+            assert len(line) == 3
+            yield float(line[0]), 'can', line[1:]
+    for i, line in enumerate(stream):
         if i % 2 == 1:
-            data = eval(line)
-            yield timestamp, data
+            data = ast.literal_eval(line)
+            yield timestamp, id, data
         else:
-            if len(line.split()) > 1:
-                timestamp = float(line.split()[1])
-            else:
-                timestamp = None
+            vals = line.split()
+            if len(vals) != 2: # only at the end of file
+                return
+            timestamp = float(vals[1])
 
 
 def sensor_gen(meta_filename, selected=None):
@@ -28,37 +35,34 @@ def sensor_gen(meta_filename, selected=None):
       Yield timestamp ordered data from all selected sensors.
       Use None for all available sensors
     """
-    meta_dir = os.path.split(meta_filename)[0]
+    meta_dir = os.path.dirname(meta_filename)
     filenames = {}
-    for line in open(meta_filename):
-        print(line)
-        if ':' in line:
-            sensor = line.split(':')[0]
-            filename = os.path.split(line.split()[1])[1]
+    with open(meta_filename, 'rb') as meta:
+        for line in filter(lambda a: ':' in a, meta): # skip unknown lines
+            sensor, filepath = line.strip().split(':')
+            filename = os.path.basename(filepath)
             filenames[sensor] = os.path.join(meta_dir, filename)
 
-    print filenames
     if selected is not None:
-        # filter filenames via selected
-        tmp = {}
-        for key in selected:
-            if key in filenames:
-                tmp[key] = filenames[key]
-        filenames = tmp
+        # delete filenames not in selected
+        for key in filenames.viewkeys() ^ selected:
+            del filenames[key]
 
     # zip multiple generators
-    assert len(filenames) == 1, filenames  # not implemented yet
-    sensor, filename = filenames.items()[0]
+    data = []
+    for sensor, filename in filenames.iteritems():
+        with open(filename, 'rb') as stream:
+            data.extend(timestamps_gen(sensor, stream))
 
-    for timestamp, data in timestamps_gen(filename):
-        yield timestamp, sensor, data
+    data.sort()
+    for a in data:
+        yield a
 
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(__doc__)
         sys.exit(2)
-    for timestamp, sensor, data in sensor_gen(sys.argv[1], ['camera']):
-        pass
+    for timestamp, sensor, data in sensor_gen(sys.argv[1]):
+        print(timestamp, sensor, data[:10])
 
 # vim: expandtab sw=4 ts=4 
-


### PR DESCRIPTION
`sensor_gen` now properly implements `selected` where it can contain
any number of sensor names. The output stream is `timestamp`
sorted and contains (`timestamp`, sensor name, `data`).