### PR TITLE
Read zipfiles in `tools/logparser2.py`.

### DIFF
--- a/tools/logparser2.py
+++ b/tools/logparser2.py
@@ -9,6 +9,7 @@ import math
 import os
 import struct
 import sys
+from zipfile import ZipFile
 
 
 def timestamps_gen(id, stream):
@@ -58,11 +59,38 @@ def sensor_gen(meta_filename, selected=None):
     for a in data:
         yield a
 
+
+def sensor_gen_zip(filepath, selected=None):
+    with ZipFile(filepath) as zip:
+        filenames = zip.namelist()
+        meta_filename = [name for name in filenames if name.startswith('meta_')][0]
+
+        filenames = {}
+        with zip.open(meta_filename) as meta:
+            for line in filter(lambda a: ':' in a, meta): # skip unknown lines
+                sensor, filepath = line.strip().split(':')
+                filenames[sensor] = os.path.basename(filepath)
+
+        if selected is not None:
+            # delete filenames not in selected
+            for key in filenames.viewkeys() ^ selected:
+                del filenames[key]
+
+        # zip multiple generators
+        data = []
+        for sensor, filename in filenames.iteritems():
+            with zip.open(filename) as stream:
+                data.extend(timestamps_gen(sensor, stream))
+
+        data.sort()
+        for a in data:
+            yield a
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print(__doc__)
         sys.exit(2)
-    for timestamp, sensor, data in sensor_gen(sys.argv[1]):
+    for timestamp, sensor, data in sensor_gen_zip(sys.argv[1]):
         print(timestamp, sensor, data[:10])
 
 # vim: expandtab sw=4 ts=4 


### PR DESCRIPTION
Added `sensor_gen_zip` that reads data from zipfile instead of logs directory.

I am starting to feel the need for some `logging` module that will abstract away if we deal with regular files or files within zipfile (or maybe something else in the future). What do you think?