### PR TITLE
Logging of raw laser data + fixup for turning off in navpat

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -69,6 +69,7 @@ def attach_sensor(robot, sensor_name, metalog):
                 function2 = SourceLogger(None, remission_log_name).get
         else:
             robot.laser = LaserIP(remission=True)
+            robot.laser.stopOnExit = False  # for faster boot-up
             function = SourceLogger(robot.laser.scan, laser_log_name).get
             function2 = SourceLogger(robot.laser.remission, remission_log_name).get
         robot.laser_data = None

--- a/laser.py
+++ b/laser.py
@@ -11,6 +11,9 @@ import socket
 import time
 from threading import Thread,Event,Lock
 
+from camera import timeName  # hack
+import struct
+
 
 # TIM310
 #import usb.core
@@ -130,16 +133,30 @@ class LaserUSB( Laser ):
   def configureScanDataOutput( self ):
     pass
 
+
+def write_timestamp(f):
+  """write time.time() in sec/frac into a binary file"""
+  t = time.time()
+  sec = int(t)
+  frac = int(0x10000*(t-sec))
+  f.write(struct.pack('IH', sec, frac))
+
+
 class LaserIP( Laser ):
   def __init__( self, **kw ):
     self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     self.socket.connect((HOST, PORT))
+    self.raw_log = open(timeName('logs/laserraw_', 'bin'), 'wb')
+    self.raw_log.write(struct.pack('HH', 0xF472, 2))  # magic number + version 2 with timestamps
+    write_timestamp(self.raw_log)
+    self.raw_log.flush()
     self._buffer = ""
     Laser.__init__( self, **kw )
     self.sendCmd( 'sMN SetAccessMode 03 F4724744' )
 
   def __del__( self ):
     self.socket.close()
+    self.raw_log.close()
 
   def receive( self ):
     data = self._buffer
@@ -148,6 +165,11 @@ class LaserIP( Laser ):
       if pos >= 0:
         break
       data = self.socket.recv(1024)
+      if len(data) > 0:
+        write_timestamp(self.raw_log)
+        self.raw_log.write(struct.pack('HH', 1, len(data)))  # 1 = input
+        self.raw_log.write(data)
+        self.raw_log.flush()
       self._buffer += data
 
     pos = self._buffer.find(ETX)
@@ -157,7 +179,12 @@ class LaserIP( Laser ):
     return data
 
   def sendCmd( self, cmd ):
-    self.socket.send( STX + cmd + ETX)
+    data = STX + cmd + ETX
+    self.socket.send(data)
+    write_timestamp(self.raw_log)
+    self.raw_log.write(struct.pack('HH', 0, len(data)))
+    self.raw_log.write(data)
+    self.raw_log.flush()
     return self.receive()
 
   def internalScan( self ):

--- a/tools/parse_laserraw.py
+++ b/tools/parse_laserraw.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+"""
+  parse debug laser data
+    ./parse_laserraw.py <laserraw filename>
+"""
+
+import sys
+import struct
+
+
+def parse_laserraw(filename):
+    version = 1
+    block_header_size = 4
+    timestamp = None
+    with open(filename, 'rb') as f:
+        buf = f.read(4)
+        if len(buf) == 4:
+            magic, version = struct.unpack('HH', buf)
+            if magic != 0:  # old version was first sending data, no header
+                assert magic == 0xf472, hex(magic)
+                assert version == 2, version # with timestamps
+                buf = f.read(6) # read extra timestamp when laser was connected
+                time_sec, time_frac = struct.unpack('IH', buf)
+                start_time = time_sec + float(time_frac)/0x10000
+                start_time = 0 # hack to have absolute time for now
+                block_header_size = 6 + 4  # timestamp + dir + len
+                buf = f.read(block_header_size)
+        while len(buf) == block_header_size:
+            if version == 1:
+                io, size = struct.unpack('HH', buf)
+            else:
+                time_sec, time_frac, io, size = struct.unpack('IHHH', buf)
+                timestamp = time_sec + float(time_frac)/0x10000
+            assert io in [0, 1]
+            data = f.read(size)
+            if timestamp is not None:
+                print '%.03f' % (timestamp-start_time), data[:60]
+            else:
+                print data
+            buf = f.read(block_header_size)
+
+
+if __name__ == "__main__": 
+    if len(sys.argv) < 2:
+        print(__doc__)
+        sys.exit(2)
+
+    parse_laserraw(sys.argv[1])
+
+# vim: expandtab sw=4 ts=4 
+


### PR DESCRIPTION
This is the second pull request from recent feature/testYYMMDD related to laser logging and debugging issue with 20s gaps. They were caused by previously turned off laser, but detailed logging of communication could be useful also in the future (and now I would need it also for Velodyne, so some kind of reuse is expected).