### PR TITLE
Forgotten filling and mapping navpat options

### DIFF
--- a/config/fill-pattern-15x5.json
+++ b/config/fill-pattern-15x5.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "johndeere": {
+    "TURN_ANGLE_OFFSET": 0.05585053606381855
+  },
+  "localization": {
+    "pose": [4.0, 0.0, 0.0],
+    "cones": [[0.0, 0.0], [15.0, 0.0], [15.0, 5.0], [0.0, 5.0]]
+  },
+  "navpat": {
+    "pattern": "fill",
+    "step": 1.0
+  }
+}
+

--- a/config/mapit.json
+++ b/config/mapit.json
@@ -1,0 +1,15 @@
+{
+  "version": 1,
+  "johndeere": {
+    "TURN_ANGLE_OFFSET": 0.05585053606381855
+  },
+  "localization": {
+    "pose": [0.5, 0.0, 0.0],
+    "cones": []
+  },
+  "navpat": {
+    "pattern": "mapping",
+    "step": 1.0
+  }
+}
+

--- a/helper.py
+++ b/helper.py
@@ -35,7 +35,6 @@ def camera_data_extension(robot, id, data):
 def proc_data_extension(robot, id, data):
     if id=='proc':
         robot.proc_data = data
-        print("Received", robot.proc_data)
 
 
 def attach_sensor(robot, sensor_name, metalog):

--- a/navpat.py
+++ b/navpat.py
@@ -16,6 +16,7 @@ optional arguments:
 import math
 import numpy as np
 import cv2
+import itertools
 
 from johndeere import emergency_stop_extension, EmergencyStopException
 
@@ -85,21 +86,29 @@ class LaserDetector:
             x, y, heading = robot.localization.pose()
             laser_pose = x + math.cos(heading)*LASER_OFFSET[0], y + math.sin(heading)*LASER_OFFSET[0], heading
 
+            selected = []
             for raw_angle, raw_dist, raw_width in self.prev_cones:
                 dist = raw_dist/1000.0
                 angle = math.radians(raw_angle/2 - 135)
                 xx, yy, _ = getCombinedPose(laser_pose, (math.cos(angle)*dist, math.sin(angle)*dist, 0))
                 color = (0xFF, 0x80, 0)
                 colors = [(0xFF, 0xFF, 0xFF), (0xFF, 0, 0), (0, 0xFF, 0), (0, 0, 0xFF)]
-                for cone_xy, cone_color in zip(robot.localization.global_map, colors):
+                for i, cone in enumerate(zip(robot.localization.global_map, colors)):
+                    cone_xy, cone_color = cone
                     if math.hypot(xx-cone_xy[0], yy-cone_xy[1]) < 2.0:
                         color = cone_color
+                        selected.append( (i, (raw_angle, raw_dist)) )
 
                 width = raw_width * math.radians(0.5) * raw_dist/1000.0  # in meters
                 print("width", width)
                 if width < 0.05 or width > 0.5:
                     color = (128, 128, 128)  # gray
                 viewer_scans_append( ( (xx, yy, 0), -1.5, color) ) # color param
+
+            if len(selected) >= 2:
+                finder = ConeLandmarkFinder()
+                for a, b in itertools.combinations(sorted(selected), 2):
+                    print("selected\t%f\t%d\t%d\t%f\n" % (robot.time, a[0], b[0], finder.pair_distance(a[1], b[1])))
 
 
 def follow_line(robot, line, speed=None, timeout=None):

--- a/navpat.py
+++ b/navpat.py
@@ -159,6 +159,19 @@ def run_there_and_back(robot, long_side, speed):
     turn_back(robot, speed)
 
 
+def run_fill_pattern(robot, long_side, speed, conf):
+    STEP = conf['step']
+    RAD1 = 2.0
+    RAD2 = RAD1 + STEP/2.0
+    SAFETY = 2.0
+    for i in range(10):
+        Y = i * STEP
+        follow_line(robot, Line((RAD1+SAFETY, Y), (long_side-RAD2-SAFETY, Y)), speed=speed, timeout=60)
+        turn(robot, math.radians(180), radius=RAD2, speed=speed, with_stop=True, timeout=60.0)
+        follow_line(robot, Line((long_side-RAD2-SAFETY, Y+2*RAD2), (RAD1+SAFETY, Y+2*RAD2)), speed=speed, timeout=60)
+        turn(robot, math.radians(180), radius=RAD1, speed=speed, with_stop=True, timeout=60.0)
+
+
 def image_callback(data):
     assert len(data) > 1
     filename = data[0]
@@ -189,7 +202,12 @@ def navigate_pattern(robot, metalog, conf, viewer=None):
 
         for i in range(10):
 #            run_oval(robot, speed)
-            run_there_and_back(robot, long_side, speed)
+            if conf is None:
+                run_there_and_back(robot, long_side, speed)
+            elif conf['pattern'] == 'fill':
+                run_fill_pattern(robot, long_side, speed, conf)
+            else:
+                assert False, conf['pattern']  # unknown pattern
 
     except NearObstacle:
         print("Near Exception Raised!")
@@ -206,6 +224,7 @@ def navigate_pattern(robot, metalog, conf, viewer=None):
 
 if __name__ == "__main__":
     with parse_and_launch() as (robot, metalog, config, viewer):
+        config = config.data.get('navpat')  # TODO move this to launcher
         navigate_pattern(robot, metalog, config, viewer)
 
 # vim: expandtab sw=4 ts=4 


### PR DESCRIPTION
These parts are from forgotten branch test/test171024, when we experiment with automatic cone mapping. The goal is to navigate to the nearest cone in front of you turn 90deg left and repeat.

The second pattern is filling, now with external parameters in config file.

Finally there are two commits related to debug real and mapped cone distances, and removal of unnecessary prints.

p.s. now I see issue in:
`cones = prev_cones  # TODO use robot.prev_cones instead of global variable`
which is no longer valid after Python3 refactoring