### PR TITLE
logger.py - provide option to read from selected streams in parallel

### DIFF
--- a/lib/logger.py
+++ b/lib/logger.py
@@ -89,6 +89,14 @@ class LogReader:
 
     def read_gen(self, only_stream_id=None):
         "packed generator - yields (time, stream, data)"
+        if only_stream_id is None:
+            multiple_streams = set()
+        else:
+            try:
+                multiple_streams = set(only_stream_id)
+            except TypeError:
+                multiple_streams = set([only_stream_id])
+
         while True:
             header = self.f.read(8)
             if len(header) < 8:
@@ -96,7 +104,7 @@ class LogReader:
             microseconds, stream_id, size = struct.unpack('IHH', header)
             dt = datetime.timedelta(microseconds=microseconds)
             data = self.f.read(size)
-            if only_stream_id is None or only_stream_id == stream_id:
+            if len(multiple_streams) == 0 or stream_id in multiple_streams:
                 yield dt, stream_id, data
 
     def close(self):

--- a/lib/test_logger.py
+++ b/lib/test_logger.py
@@ -47,4 +47,22 @@ class LoggerTest(unittest.TestCase):
 
         os.remove(log.filename)
 
+    def test_read_two_streams(self):
+        with LogWriter(prefix='tmp2', note='test_read_two_streams') as log:
+            filename = log.filename
+            t1 = log.write(1, b'\x01\x02\x02\x04')
+            time.sleep(0.001)
+            t2 = log.write(3, b'\x05\x06')
+            time.sleep(0.001)
+            t3 = log.write(2, b'\x07\x08')
+
+        with LogReader(filename) as log:
+            arr = []
+            for t, stream_id, data in log.read_gen([1, 2]):
+                self.assertIn(stream_id, [1, 2])
+                arr.append((t, stream_id))
+            self.assertEqual(arr, [(t1, 1), (t3, 2)])
+
+        os.remove(log.filename)
+
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
This PR is just for "suggestions welcome" - I would like to extend LogReader to filter only some streams, i.e. not all and not a single one. I need it for asserting module input & output, where I need to track two streams. I do not like presented solution much - one argument would be probably sufficient ...??
