### PR TITLE
Feature/named channels

### DIFF
--- a/drivers/bus.py
+++ b/drivers/bus.py
@@ -9,14 +9,19 @@ class BusShutdownException(Exception):
 
 
 class BusHandler:
-    def __init__(self, logger, out={}):
+    def __init__(self, logger, name='', out={}):
         self.logger = logger
         self.queue = Queue()
+        self.name = name
         self.out = out
+        self.stream_id = {}
+        for publish_name in out.keys():
+            idx = self.logger.register('.'.join([self.name, publish_name]))
+            self.stream_id[publish_name] = idx
 
     def publish(self, channel, data):
         with self.logger.lock:
-            stream_id = channel  # TODO local maping of indexes
+            stream_id = self.stream_id[channel]  # local maping of indexes
             timestamp = self.logger.write(stream_id, data)
             for queue, input_channel in self.out[channel]:
                 queue.put((timestamp, input_channel, data))

--- a/drivers/gps.py
+++ b/drivers/gps.py
@@ -18,7 +18,7 @@ from drivers.bus import BusShutdownException
 
 
 GPS_MSG_DTYPE = [('lon', 'i4'), ('lat', 'i4')]
-INVALID_COORDINATES = np.array((0x7FFF, 0x7FFF), dtype=GPS_MSG_DTYPE)
+INVALID_COORDINATES = np.array((0x7FFFFFFF, 0x7FFFFFFF), dtype=GPS_MSG_DTYPE)
 
 
 def checksum(s):

--- a/drivers/logserial.py
+++ b/drivers/logserial.py
@@ -36,7 +36,6 @@ class LogSerial(Thread):
         else:
             self.com = com
         self.bus = bus
-        self.stream_id = config['stream_id']
 
         self.buf = b''
 
@@ -44,7 +43,7 @@ class LogSerial(Thread):
         while self.should_run.isSet():
             data = self.com.read(1024)
             if len(data) > 0:
-                self.bus.publish(self.stream_id, data)
+                self.bus.publish('raw', data)
 
     def request_stop(self):
         self.should_run.clear()
@@ -80,9 +79,9 @@ if __name__ == "__main__":
     import time
     from drivers.bus import BusHandler
 
-    config = { 'port': 'COM5', 'speed': 4800, 'stream_id': 1 }
+    config = { 'port': 'COM5', 'speed': 4800 }
     log = LogWriter(prefix='test-')
-    device = LogSerial(config, bus=BusHandler(log, out={1:[]}))
+    device = LogSerial(config, bus=BusHandler(log, out={'raw':[]}))
     device.start()
     time.sleep(2)
     device.request_stop()

--- a/drivers/test_bus.py
+++ b/drivers/test_bus.py
@@ -11,12 +11,12 @@ class BusHandlerTest(unittest.TestCase):
         logger = MagicMock()
         bus = BusHandler(logger)
         with self.assertRaises(KeyError):
-            bus.publish(1, b'some binary data')
-        logger.write.assert_called_once_with(1, b'some binary data')
+            bus.publish('raw', b'some binary data')
 
         logger = MagicMock()
-        bus = BusHandler(logger, out={1:[]})
-        bus.publish(1, b'some binary data 2nd try')
+        logger.register = MagicMock(return_value=1)
+        bus = BusHandler(logger, out={'raw':[]})
+        bus.publish('raw', b'some binary data 2nd try')
         logger.write.assert_called_once_with(1, b'some binary data 2nd try')
 
     def test_listen(self):
@@ -28,10 +28,10 @@ class BusHandlerTest(unittest.TestCase):
     def test_two_modules(self):
         logger = MagicMock()
         handler2 = BusHandler(logger)
-        handler1 = BusHandler(logger, out={1:[(handler2.queue, 42)]})
+        handler1 = BusHandler(logger, out={'raw':[(handler2.queue, 42)]})
 
         logger.write = MagicMock(return_value=123)
-        handler1.publish(1, b"Hello!")
+        handler1.publish('raw', b"Hello!")
 
         self.assertEqual(handler2.listen(), (123, 42, b"Hello!"))
 
@@ -41,5 +41,12 @@ class BusHandlerTest(unittest.TestCase):
         handler.shutdown()
         with self.assertRaises(BusShutdownException):
             handler.listen()
+
+    def test_named_publish(self):
+        logger = MagicMock()
+        logger.register = MagicMock(return_value=1)
+        bus = BusHandler(logger, name='gps_serial', out={'raw':[]})
+        bus.publish('raw', b'bin data')
+        logger.write.assert_called_once_with(1, b'bin data')
 
 # vim: expandtab sw=4 ts=4

--- a/lib/logger.py
+++ b/lib/logger.py
@@ -34,7 +34,7 @@ import struct
 from threading import RLock
 
 
-INFO_STREM_ID = 0
+INFO_STREAM_ID = 0
 
 
 class LogWriter:
@@ -50,7 +50,15 @@ class LogWriter:
                 t.hour, t.minute, t.second, t.microsecond))
         self.f.flush()
         if len(note) > 0:
-            self.write(stream_id=INFO_STREM_ID, data=bytes(note, encoding='utf-8'))
+            self.write(stream_id=INFO_STREAM_ID, data=bytes(note, encoding='utf-8'))
+        self.names = []
+
+    def register(self, name):
+        with self.lock:
+            assert name not in self.names, (name, self.names)
+            self.names.append(name)
+            self.write(stream_id=INFO_STREAM_ID, data=bytes(str({'names': self.names}), encoding='ascii'))
+            return len(self.names)
 
     def write(self, stream_id, data):
         with self.lock:


### PR DESCRIPTION
Here is the first sketch for naming channels. The logger keeps history of all registered names and BusHandler keeps the indexes (this will be maybe part of discussion?). Nevertheless as usual there are couple "unknowns":

1) how should we handle duplicity names in `register`? Currently assert is raised.

2) what about backward compatibility, i.e. can you publish on `int` channel? Now it is supported with dummy 1:1 map (but it is rather side-effect)

3) should we store call of publish on not registered channel? Now it raises exception but the data are not stored - maybe some error in channel 0? (BTW I started to use dictionary record in channel 0 for "names" ... so maybe we could add "error" record?)

4) should we somehow highlight identification of IDs used for publishing? I used `PUBLISH_NAME` constant for GPS and LogSerial, but ... suggestion? (note, that this used to be in config, but there was another "name" redirection ('stream_id" or "stream_id_out"))

Currently only write/log operation is completed. Replay log is hacked only for GPS (with hard coded stream IDs).