### PR TITLE
Change LogSerial to two way communication

### DIFF
--- a/config/test-spider-gps-imu.json
+++ b/config/test-spider-gps-imu.json
@@ -36,7 +36,8 @@
           "driver": "serial",
           "in": ["raw"],
           "out": ["raw"],
-          "init": {"port": "/dev/ttyS0", "speed": 115200}
+          "init": {"port": "/dev/ttyS0", "speed": 115200,
+                           "rtscts":true, "reset":true}
       }
     },
     "links": [["gps_serial.raw", "gps.raw"],

--- a/config/test-spider.json
+++ b/config/test-spider.json
@@ -12,7 +12,8 @@
           "driver": "serial",
           "in": ["raw"],
           "out": ["raw"],
-          "init": {"port": "/dev/ttyS0", "speed": 115200}
+          "init": {"port": "/dev/ttyS0", "speed": 115200,
+                   "rtscts":true, "reset":true}
       }
     },
     "links": [["spider_serial.raw", "spider.raw"], 

--- a/drivers/bus.py
+++ b/drivers/bus.py
@@ -18,6 +18,7 @@ class BusHandler:
         for publish_name in out.keys():
             idx = self.logger.register('.'.join([self.name, publish_name]))
             self.stream_id[publish_name] = idx
+        self._is_alive = True
 
     def publish(self, channel, data):
         with self.logger.lock:
@@ -33,7 +34,11 @@ class BusHandler:
         timestamp, channel, data = packet
         return timestamp, channel, data
 
+    def is_alive(self):
+        return self._is_alive
+
     def shutdown(self):
+        self._is_alive = False
         self.queue.put(None)
 
 

--- a/drivers/logserial.py
+++ b/drivers/logserial.py
@@ -26,8 +26,14 @@ class LogSerial:
         self.output_thread = Thread(target=self.run_output, daemon=True)
 
         if 'port' in config:
-            self.com = serial.Serial(config['port'], config['speed'])
-            self.com.timeout = 0.01  # expects updates < 100Hz
+            if config.get('rtscts'):
+                self.com = serial.Serial(config['port'], config['speed'], rtscts=True)
+                self.com.setRTS()
+            else:
+                self.com = serial.Serial(config['port'], config['speed'])
+            self.com.timeout = config.get('timeout', 0.01)  # default expects updates < 100Hz
+            if config.get('reset'):
+                self.com.setDTR(0)
         else:
             self.com = None
         self.bus = bus

--- a/drivers/test_bus.py
+++ b/drivers/test_bus.py
@@ -49,4 +49,11 @@ class BusHandlerTest(unittest.TestCase):
         bus.publish('raw', b'bin data')
         logger.write.assert_called_once_with(1, b'bin data')
 
+    def test_alive(self):
+        logger = MagicMock()
+        bus = BusHandler(logger, out={})
+        self.assertTrue(bus.is_alive())
+        bus.shutdown()
+        self.assertFalse(bus.is_alive())
+
 # vim: expandtab sw=4 ts=4

--- a/drivers/test_logserial.py
+++ b/drivers/test_logserial.py
@@ -1,22 +1,25 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import patch, MagicMock
 
-from drivers.logserial import LogSerialOut
+from drivers.logserial import LogSerial
 from drivers.bus import BusHandler
 
 
 class LogSerialTest(unittest.TestCase):
 
-    def test_output(self):
-        logger = MagicMock()
-        bus = BusHandler(logger)
-        serial = MagicMock()
-        device = LogSerialOut(config=None, bus=bus, com=serial)
-        bus.queue.put((1, 2, b'bin data'))
-        device.start()
-        device.request_stop()
-        device.join()
-        serial.write.assert_called_once_with(b'bin data')
+    def test_twoway_communication(self):
+        with patch('drivers.logserial.serial.Serial') as mock:
+            instance = mock.return_value
+
+            logger = MagicMock()
+            bus = BusHandler(logger)
+            config = {'port':'COM13:', 'speed':4800}
+            device = LogSerial(config=config, bus=bus)
+            bus.queue.put((1, 2, b'bin data'))
+            device.start()
+            device.request_stop()
+            device.join()
+            instance.write.assert_called_once_with(b'bin data')
 
 
 # vim: expandtab sw=4 ts=4

--- a/drivers/test_logserial.py
+++ b/drivers/test_logserial.py
@@ -21,5 +21,23 @@ class LogSerialTest(unittest.TestCase):
             device.join()
             instance.write.assert_called_once_with(b'bin data')
 
+    def test_timeout_config(self):
+        with patch('drivers.logserial.serial.Serial', autospec=True) as mock:
+            instance = mock.return_value
+            bus = MagicMock()
+            config = {'port':'COM13:', 'speed':4800, 'timeout':2.0}
+            device = LogSerial(config=config, bus=bus)
+            mock.assert_called_once_with('COM13:', 4800)
+            self.assertAlmostEqual(instance.timeout, 2.0)
+
+    def test_config_reset(self):
+        with patch('drivers.logserial.serial.Serial', autospec=True) as mock:
+            instance = mock.return_value
+            bus = MagicMock()
+            config = {'port':'COM10:', 'speed':9600, 'rtscts':True, 'reset':True}
+            device = LogSerial(config=config, bus=bus)
+            mock.assert_called_once_with('COM10:', 9600, rtscts=True)
+            instance.setRTS.assert_called_once_with()
+            instance.setDTR.assert_called_once_with(0)
 
 # vim: expandtab sw=4 ts=4

--- a/test_robot.py
+++ b/test_robot.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import patch, MagicMock
 import time
+import json
+import os
 
 from robot import Robot
 
@@ -46,14 +48,24 @@ class RobotTest(unittest.TestCase):
 
     def test_spider_config(self):
         # first example with loop spider <-> serial
-        import json
-        import os
-
         with open(os.path.dirname(__file__) + '/config/test-spider.json') as f:
             config = json.loads(f.read())
 
         with patch('drivers.logserial.serial.Serial') as mock:
             logger = MagicMock()
             robot = Robot(config=config['robot'], logger=logger)
+
+
+    def test_all_supported_config_files(self):
+        supported = ['test-spider.json', 'test-gps-imu.json',
+                'test-spider-gps-imu.json', 'test-windows-gps.json']
+
+        with patch('drivers.logserial.serial.Serial') as mock:
+            logger = MagicMock()
+            for filename in supported:
+                with open(os.path.join(os.path.dirname(__file__), 'config',
+                                   filename)) as f:
+                    config = json.loads(f.read())
+                robot = Robot(config=config['robot'], logger=logger)
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Implemented two thread solution in `LogSerial`, as discussed during #50 . This PR should be merged after #51, because complete removal of `LogSerialOut` is necessary.

Note, that opening two ways communication always means creating two channels in log (which is not necessary for modules like GPS or IMU) - do we want it? Or do we want conditional creation based on configuration?