### PR TITLE
Feature/fix replay ro2018

### DIFF
--- a/osgar/ro2018.py
+++ b/osgar/ro2018.py
@@ -142,10 +142,7 @@ class RoboOrienteering2018:
 # move to drivers/bus??
 class LogBusHandler:
     def __init__(self, log, inputs, outputs):
-        if outputs is None:
-            self.reader = log.read_gen(inputs.keys())
-        else:
-            self.reader = log.read_gen(list(inputs.keys()) + list(outputs.keys()))
+        self.reader = log.read_gen(list(inputs.keys()) + list(outputs.keys()))
         self.inputs = inputs
         self.outputs = outputs
         self.buffer_queue = Queue()
@@ -162,16 +159,32 @@ class LogBusHandler:
             return dt, channel, np.frombuffer(data, dtype=GPS_MSG_DTYPE)
 
     def publish(self, channel, data):
-        if self.outputs is not None:
-            assert channel in self.outputs.values(), (channel, self.outputs.values())
+        assert channel in self.outputs.values(), (channel, self.outputs.values())
+        dt, stream_id, raw_data = next(self.reader)
+        while stream_id not in self.outputs:
+            assert stream_id in self.inputs, stream_id
+            self.buffer_queue.put((dt, stream_id, raw_data))
             dt, stream_id, raw_data = next(self.reader)
-            while stream_id not in self.outputs:
-                assert stream_id in self.inputs, stream_id
-                self.buffer_queue.put((dt, stream_id, raw_data))
-                dt, stream_id, raw_data = next(self.reader)
-            assert channel == self.outputs[stream_id], (channel, self.outputs[stream_id])  # wrong channel
-            ref_data = literal_eval(raw_data.decode('ascii'))
-            assert data == ref_data, (data, ref_data)
+        assert channel == self.outputs[stream_id], (channel, self.outputs[stream_id])  # wrong channel
+        ref_data = literal_eval(raw_data.decode('ascii'))
+        assert data == ref_data, (data, ref_data)
+
+
+class LogBusHandlerInputsOnly:
+    def __init__(self, log, inputs):
+        self.reader = log.read_gen(inputs.keys())
+        self.inputs = inputs
+
+    def listen(self):
+        dt, stream_id, data = next(self.reader)
+        channel = self.inputs[stream_id]
+        try:
+            return dt, channel, literal_eval(data.decode('ascii'))
+        except ValueError:
+            return dt, channel, np.frombuffer(data, dtype=GPS_MSG_DTYPE)
+
+    def publish(self, channel, data):
+        pass
 
 
 if __name__ == "__main__":
@@ -192,13 +205,14 @@ if __name__ == "__main__":
         print(next(log.read_gen(0))[-1])  # old arguments
         config_str = next(log.read_gen(0))[-1]
         config = literal_eval(config_str.decode('ascii'))
+
+        inputs={2:'position', 4:'orientation', 7:'status'}  # TODO map names
         if args.force:
-            outputs = None
+            bus = LogBusHandlerInputsOnly(log, inputs=inputs)
         else:
-            outputs = {1:'move'}
-        bus = LogBusHandler(log,
-                            inputs={2:'position', 4:'orientation', 7:'status'},
-                            outputs=outputs)  # TODO map names
+            bus = LogBusHandler(log,
+                                inputs=inputs,
+                                outputs={1:'move'})  # TODO map names
         game = RoboOrienteering2018(config={}, bus=bus)
         game.play()
 

--- a/osgar/test_ro2018.py
+++ b/osgar/test_ro2018.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 import math
 from datetime import timedelta
 
-from osgar.ro2018 import geo_length, geo_angle, LogBusHandler
+from osgar.ro2018 import geo_length, geo_angle, LogBusHandler, LogBusHandlerInputsOnly
 
 
 class RO2018Test(unittest.TestCase):
@@ -62,5 +62,19 @@ class RO2018Test(unittest.TestCase):
         with self.assertRaises(AssertionError) as e:
             bus.publish('can3', [1, 2])
         self.assertEqual(str(e.exception), "('can3', dict_values(['can', 'can2']))")
+
+    def test_log_bus_handler_inputs_onlye(self):
+        log = MagicMock()
+        log_data = [
+            (timedelta(microseconds=10), 1, b'(1,2)'),
+            (timedelta(microseconds=11), 1, b'(3,4,5)'),
+            (timedelta(microseconds=30), 2, b'[8,9]'),
+        ]
+        log.read_gen = MagicMock(return_value=iter(log_data))
+        inputs = {1:'raw'}
+        bus = LogBusHandlerInputsOnly(log, inputs)
+        self.assertEqual(bus.listen(), (timedelta(microseconds=10), 'raw', (1, 2)))
+        bus.publish('new_channel', b'some data')
+        self.assertEqual(bus.listen(), (timedelta(microseconds=11), 'raw', (3, 4, 5)))
 
 # vim: expandtab sw=4 ts=4

--- a/osgar/test_ro2018.py
+++ b/osgar/test_ro2018.py
@@ -1,7 +1,9 @@
 import unittest
+from unittest.mock import MagicMock
 import math
+from datetime import timedelta
 
-from osgar.ro2018 import geo_length, geo_angle
+from osgar.ro2018 import geo_length, geo_angle, LogBusHandler
 
 
 class RO2018Test(unittest.TestCase):
@@ -24,5 +26,41 @@ class RO2018Test(unittest.TestCase):
         self.assertIsNone(
                 geo_angle((51749517, 180462688), (51749518, 180462688)))
                 # for too small distance
+
+    def test_log_bus_handler(self):
+        log = MagicMock()
+        log_data = [
+            (timedelta(microseconds=10), 1, b'(1,2)'),
+            (timedelta(microseconds=11), 1, b'(3,4,5)'),
+            (timedelta(microseconds=30), 2, b'[8,9]'),
+        ]
+        log.read_gen = MagicMock(return_value=iter(log_data))
+        inputs = {1:'raw'}
+        outputs = {2:'can'}
+        bus = LogBusHandler(log, inputs, outputs)
+        bus.listen()
+        with self.assertRaises(AssertionError) as e:
+            bus.publish('can', b'parsed data')
+        self.assertEqual(str(e.exception), "(b'parsed data', [8, 9])")
+
+    def test_wrong_publish_channel(self):
+        log = MagicMock()
+        log_data = [
+            (timedelta(microseconds=10), 1, b'(1,2)'),
+            (timedelta(microseconds=30), 2, b'[8,9]'),
+            (timedelta(microseconds=35), 3, b'[8,9]'),
+        ]
+        log.read_gen = MagicMock(return_value=iter(log_data))
+        inputs = {1:'raw'}
+        outputs = {2:'can', 3:'can2'}
+        bus = LogBusHandler(log, inputs, outputs)
+        bus.listen()
+        with self.assertRaises(AssertionError) as e:
+            bus.publish('can2', [8, 9])
+        self.assertEqual(str(e.exception), "('can2', 'can')")
+
+        with self.assertRaises(AssertionError) as e:
+            bus.publish('can3', [1, 2])
+        self.assertEqual(str(e.exception), "('can3', dict_values(['can', 'can2']))")
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Here are some tweaks from the last test (turn wheels to the south & move to destination) + fixed replay of logs (reference file is at http://osgar.robotika.cz/ro2018-180313_154620.log).
p.s. I am not sure what you meant in email, that publish for `outputs=None` should generate error? How would you specify to ignore outputs? Or two classes one with assert and one with 
```
def publish(channel, data):
   pass
```
?