### PR TITLE
Bugfix/compare and replay

### DIFF
--- a/osgar/ro2018.py
+++ b/osgar/ro2018.py
@@ -135,7 +135,7 @@ class RoboOrienteering2018:
 
     def play(self):
         print("Waiting for valid GPS position...")
-        while self.last_position is None or self.last_position == INVALID_COORDINATES:
+        while self.last_position is None or np.array_equal(self.last_position, INVALID_COORDINATES):
             self.update()
         print(self.last_position)
 


### PR DESCRIPTION
This is another "work in progress" PR. The primary motivation was to get rid of warning:
```
osgar\ro2018.py:108: FutureWarning: elementwise == comparison failed and returning scalar instead; this will raise an error or perform elementwise comparison in the future.
  while self.last_position is None or self.last_position == INVALID_COORDINATES:
```
and to find the root cause of error from the last test:
```
Exception in thread Thread-7:
Traceback (most recent call last):
  File "/root/miniconda3/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/robot/git/osgar/osgar/drivers/spider.py", line 128, in run
    for status in self.process_gen(data):
  File "/home/robot/git/osgar/osgar/drivers/spider.py", line 117, in process_gen
    ret = self.process_packet(packet, verbose=verbose)
  File "/home/robot/git/osgar/osgar/drivers/spider.py", line 89, in process_packet
    self.send((self.desired_speed, self.desired_angle))
  File "/home/robot/git/osgar/osgar/drivers/spider.py", line 165, in send
    packet = CAN_packet(0x401, [0x80 + 80, angle_cmd])
  File "/home/robot/git/osgar/osgar/drivers/spider.py", line 22, in CAN_packet
    return bytes(header + data)
ValueError: bytes must be in range(0, 256)
```

The first one is trivial fix (first commit), while the second required to recover replay framework. Now the problem can be reproduced via:
```
python osgar\replay.py d:\md\osgar\logs\czu180320\spider4\ro2018-180320_195142.log --module spider
```
withe result
```
SPIDER MODE
DIFF 183
Exception in thread Thread-1:
Traceback (most recent call last):
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\threading.py", line
 916, in _bootstrap_inner
    self.run()
  File "m:\git\osgar\osgar\drivers\spider.py", line 128, in run
    for status in self.process_gen(data):
  File "m:\git\osgar\osgar\drivers\spider.py", line 117, in process_gen
    ret = self.process_packet(packet, verbose=verbose)
  File "m:\git\osgar\osgar\drivers\spider.py", line 89, in process_packet
    self.send((self.desired_speed, self.desired_angle))
  File "m:\git\osgar\osgar\drivers\spider.py", line 165, in send
    packet = CAN_packet(0x401, [0x80 + 80, angle_cmd])
  File "m:\git\osgar\osgar\drivers\spider.py", line 22, in CAN_packet
    return bytes(header + data)
ValueError: bytes must be in range(0, 256)
```

The second bug is not fixed yet, although the cause is known (if you switch to "Car Mode" then `ro2018.py` does not expect it and still sends desired angles instead of turns).

Issues:
- we do not have terminator for each log stream (I think you mentioned it sooner, that we should also log "shutdown")
- it is not clear if the data are "raw bytes" or Python basic types. Now there is hack in `ro2018.py` based on channel name.

Maybe we could add 3rd parameter in configuration of links ... but the output type is the same for all links from given output ... any suggestion? For now we need only to distinguish "raw" and "str()" data (yeah and "my" numpy `tobytes()` maybe).