### PR TITLE
Add raw_channels parameter to LogBusHandler

### DIFF
--- a/osgar/test_ro2018.py
+++ b/osgar/test_ro2018.py
@@ -78,6 +78,20 @@ class RO2018Test(unittest.TestCase):
         bus.publish('new_channel', b'some data')
         self.assertEqual(bus.listen(), (timedelta(microseconds=11), 'raw', (3, 4, 5)))
 
+    def test_log_bus_handler_raw_channels(self):
+        log = MagicMock()
+        log_data = [
+            (timedelta(microseconds=10), 1, b'(1,2)'),
+            (timedelta(microseconds=11), 1, b'(3,4,5)'),
+            (timedelta(microseconds=30), 2, b'[8,9]'),
+        ]
+        log.read_gen = MagicMock(return_value=iter(log_data))
+        inputs = {1:'raw'}
+        bus = LogBusHandlerInputsOnly(log, inputs, raw_channels=['raw'])
+        self.assertEqual(bus.listen(), (timedelta(microseconds=10), 'raw', b'(1,2)'))
+        bus.publish('new_channel', b'some data')
+        self.assertEqual(bus.listen(), (timedelta(microseconds=11), 'raw', b'(3,4,5)'))
+
     def test_latlon2xy(self):
         self.assertEqual(latlon2xy(50.128246666666, 14.3748658333333), (51749517, 180462688 - 1000))
 


### PR DESCRIPTION
This is workaround to interpret some channels as raw binary data and others as Python `str()` data.