### PR TITLE
Feature/simple spider simulator

### DIFF
--- a/config/ro2018-simulation.json
+++ b/config/ro2018-simulation.json
@@ -1,0 +1,26 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "app": {
+          "driver": "application",
+          "in": ["position", "orientation", "status"],
+          "out": ["move"],
+          "init": {}
+      },
+      "spider": {
+          "driver": "simulator",
+          "in": ["move"],
+          "out": ["position", "orientation", "status"],
+          "init": {
+            "position":[51748232, 180462052],
+            "duration": 200.0
+        }
+      }
+    },
+    "links": [["spider.position", "app.position"],
+              ["spider.orientation", "app.orientation"],
+              ["spider.status", "app.status"],
+              ["app.move", "spider.move"]]
+  }
+}

--- a/osgar/drivers/__init__.py
+++ b/osgar/drivers/__init__.py
@@ -3,8 +3,9 @@ from .imu import IMU
 from .spider import Spider
 from .logserial import LogSerial
 from .canserial import CANSerial
+from .simulator import SpiderSimulator
 
 # dictionary of all available drivers
 all_drivers = dict(gps=GPS, imu=IMU, spider=Spider, serial=LogSerial,
-                   can=CANSerial)
+                   can=CANSerial, simulator=SpiderSimulator)
 

--- a/osgar/drivers/simulator.py
+++ b/osgar/drivers/simulator.py
@@ -1,0 +1,87 @@
+"""
+  Simple Spider Simulator
+"""
+import math
+from threading import Thread
+from time import sleep
+from datetime import timedelta
+
+from osgar.lib.mathex import normalizeAnglePIPI
+from osgar.drivers.bus import BusShutdownException
+
+
+class SpiderSimulator(Thread):
+    def __init__(self, config, bus):
+        Thread.__init__(self)
+        self.setDaemon(True)
+        self.bus = bus
+        self.ref_position = config['position']  # WGS84, milliseconds, [lon, lat]
+        self.duration = timedelta(seconds=config.get('duration', 300))  # default 5min
+        self.rel_pose = (0, 0, 0)  # rel pose to GPS position
+        self.wheel_angle = 0.0  # math orientation, radians
+        self.status = 0x3  # running
+        self.desired_speed, self.desired_wheel_angle = None, None
+
+    def run(self):
+        try:
+            self.bus.publish('status', [0x0, None])  # trigger "pump"
+            self.bus.publish('position', self.get_position())
+            self.bus.publish('orientation', [[0, 0, 0]]*4)  # "valid" IMU
+            while True:
+                timestamp, channel, data = self.bus.listen()
+#                print(timestamp, channel, data)
+                if timestamp > self.duration:
+                    self.status = 0x0  # STOP
+                if channel == 'move':
+                    self.desired_speed, raw_angle = data
+                    self.desired_wheel_angle = -math.pi * raw_angle / 256.0
+                    self.bus.publish('status', [self.status, self.get_wheels_angles_raw()])
+
+                    # update position at 10Hz
+                    if self.status & 0x8000 == 0x0:
+                        self.bus.publish('position', self.get_position())
+                else:
+                    assert False, channel  # unsupported channel
+
+                dt = 0.05
+                sleep(dt)  # slow down basic cycle (for now)
+                self.step(dt)
+        except BusShutdownException:
+            pass
+
+    def request_stop(self):
+        self.bus.shutdown()
+
+    def step(self, dt):
+        if abs(self.desired_speed) > 0:
+            dist = dt  # i.e. 1m/s
+            if abs(self.desired_speed) <= 1.0:
+                dist = 0.0  # turn in place
+            x, y, heading = self.rel_pose
+            a = heading + self.wheel_angle
+            self.rel_pose = x + dist*math.cos(a), y + dist*math.sin(a), heading
+
+            diff = normalizeAnglePIPI(self.desired_wheel_angle - self.wheel_angle)
+            if abs(diff) > math.radians(1):
+                if diff > 0:
+                    corr = math.radians(10)  # 10deg/s
+                else:
+                    corr = math.radians(-10)
+                self.wheel_angle += dt*corr
+        self.status ^= 0x8000
+
+    def get_position(self):
+        "combine pose with ref GPS position"
+        lon, lat = self.ref_position
+        x_scale = math.cos(math.radians(lon/3600000))
+        scale = 40000000/(360*3600000)
+        x, y, __ = self.rel_pose
+        return [int(lon + x/(scale*x_scale)), int(lat + y/scale)]
+
+    def get_wheels_angles_raw(self):
+        # Spider has 512 ticks per 360 degrees, clockwise
+        raw = (-int(256 * self.wheel_angle / math.pi)) & 0x1FF
+        return [raw] * 4
+
+# vim: expandtab sw=4 ts=4
+

--- a/osgar/drivers/test_simulator.py
+++ b/osgar/drivers/test_simulator.py
@@ -1,0 +1,63 @@
+import unittest
+import math
+
+from osgar.drivers.simulator import SpiderSimulator
+from osgar.drivers.bus import BusHandler
+
+
+class SpiderSimulatorTest(unittest.TestCase):
+
+    def test_usage(self):
+        config = {'position': [51748232, 180462051]}
+        bus = None  # BusHandler(logger)
+        spider = SpiderSimulator(config, bus)
+
+        spider.desired_speed = 0
+        spider.desired_wheel_angle = 0
+        spider.step(0.1)
+        self.assertEqual(spider.rel_pose, (0, 0, 0))
+
+        spider.desired_speed = 10
+        spider.desired_wheel_angle = 0
+        spider.step(2.0)
+        self.assertGreater(spider.rel_pose[0], 0.0)
+
+        spider.desired_speed = 1
+        spider.desired_wheel_angle = math.radians(45)
+        spider.status = 0x3
+        spider.step(1.0)
+        self.assertGreater(spider.wheel_angle, 0.0)
+        self.assertEqual(spider.status, 0x8003)  # alive bit
+        spider.step(1.0)
+        self.assertEqual(spider.status, 0x3)
+
+    def test_get_position(self):
+        config = {'position': [51748232, 180462051]}
+        spider = SpiderSimulator(config=config, bus=None)
+        p = spider.get_position()
+        self.assertEqual(p, [51748232, 180462051])
+
+        spider.rel_pose = (100, 0, 0)  # 100m to East
+        p = spider.get_position()
+        self.assertEqual(p, [51748232 + 3344, 180462051])
+
+        spider.rel_pose = (0, -1, 0)  # 1m to South
+        p = spider.get_position()
+        self.assertEqual(p, [51748232, 180462051 - 33])
+
+        spider.rel_pose = (100, 0, 0)  # 100m to East on eqator
+        spider.ref_position = [0, 180462051]
+        p = spider.get_position()
+        self.assertEqual(p, [3240, 180462051])
+
+    def test_get_wheels_angles_raw(self):
+        config = {'position': [51748232, 180462051]}
+        spider = SpiderSimulator(config=config, bus=None)
+        angles = spider.get_wheels_angles_raw()
+        self.assertEqual(angles, [0, 0, 0, 0])
+
+        spider.wheel_angle = math.radians(270)
+        angles = spider.get_wheels_angles_raw()
+        self.assertEqual(angles, [128, 128, 128, 128])
+
+# vim: expandtab sw=4 ts=4

--- a/osgar/lib/mathex.py
+++ b/osgar/lib/mathex.py
@@ -1,0 +1,14 @@
+"""
+  Extra math routines
+"""
+import math
+
+
+def normalizeAnglePIPI( angle ):
+    while angle < -math.pi:
+        angle += 2*math.pi
+    while angle > math.pi:
+        angle -= 2*math.pi
+    return angle 
+
+# vim: expandtab sw=4 ts=4

--- a/osgar/ro2018.py
+++ b/osgar/ro2018.py
@@ -10,6 +10,7 @@ from queue import Queue
 
 from osgar.lib.logger import LogWriter, LogReader
 from osgar.lib.config import load as config_load
+from osgar.lib.mathex import normalizeAnglePIPI
 from osgar.drivers import all_drivers
 from osgar.robot import Robot
 
@@ -29,14 +30,6 @@ def geo_angle(pos1, pos2):
         return None
     x_scale = math.cos(math.radians(pos1[0]/3600000))
     return math.atan2(pos2[1] - pos1[1], (pos2[0] - pos1[0])*x_scale)
-
-
-def normalizeAnglePIPI( angle ):
-    while angle < -math.pi:
-        angle += 2*math.pi
-    while angle > math.pi:
-        angle -= 2*math.pi
-    return angle 
 
 
 def latlon2xy(lat, lon):

--- a/osgar/ro2018.py
+++ b/osgar/ro2018.py
@@ -176,18 +176,17 @@ class RoboOrienteering2018:
         self.last_position_angle = self.last_position
         gps_angle = None
         while geo_length(self.last_position, goal) > 1.0 and self.time - start_time < timeout:
+            desired_heading = normalizeAnglePIPI(geo_angle(self.last_position, goal))
             step = geo_length(self.last_position, self.last_position_angle)
             if step > 1.0:
                 gps_angle = normalizeAnglePIPI(geo_angle(self.last_position_angle, self.last_position))
                 print('step', step, math.degrees(gps_angle))
                 self.last_position_angle = self.last_position
+                desired_wheel_heading = normalizeAnglePIPI(desired_heading - gps_angle + self.wheel_heading)
 
-            desired_heading = normalizeAnglePIPI(geo_angle(self.last_position, goal))
             if gps_angle is None or self.wheel_heading is None:
                 spider_heading = normalizeAnglePIPI(math.radians(180 - self.last_imu_yaw - 35.5))
                 desired_wheel_heading = normalizeAnglePIPI(desired_heading-spider_heading)
-            else:
-                desired_wheel_heading = normalizeAnglePIPI(desired_heading - gps_angle + self.wheel_heading)
 
             self.set_speed(self.maxspeed, desired_wheel_heading)
 


### PR DESCRIPTION
This PR contains implementation of simple Spider3rider simulator. The main purpose is remote debugging
of `ro2018.py`. The first commit is refactoring of `normalizeAnglePIPI()` used also in simulator.
The final commit is fix of ro2018.py, which shoud navigate now much smoothly.

To run simulation use:
```
python osgar\ro2018.py run config\ro2018-czu-waypoints.json config\ro2018-simulation.json
```

A new logfile is created, which can be analyzed via `logger`:
```
python osgar\lib\logger.py ro2018-180508_090739.log --times
```
or the simulation can be replayed with:
```
python osgar\replay.py --module spider ro2018-180508_090739.log
```

There is an interesting issue with `time.sleep()` in simulation: current time is defined by `BusHandler`
which is using real PC time. Simulation is as slow as in motion in reality, which does not have to be.
Also replay is slow, which is bad. I would address this in some separate PR, maybe with introduction
of "timer" module??
