### PR TITLE
ro2018.py - fix print for close positions where geo_angle is None

### DIFF
--- a/osgar/ro2018.py
+++ b/osgar/ro2018.py
@@ -161,7 +161,11 @@ class RoboOrienteering2018:
             with EmergencyStopMonitor(self):
                 for goal in self.goals:
                     print("Goal at %.2fm" % geo_length(self.last_position, goal))
-                    print("Heading %.1fdeg, imu" % math.degrees(geo_angle(self.last_position, goal)), self.last_imu_yaw)
+                    angle = geo_angle(self.last_position, goal)
+                    if angle is not None:
+                        print("Heading %.1fdeg, imu" % math.degrees(angle), self.last_imu_yaw)
+                    else:
+                        print("Heading None, imu", self.last_imu_yaw)
                     self.navigate_to_goal(goal, timedelta(seconds=200))
         except EmergencyStopException:
             print("EMERGENCY STOP (wait 3s)")


### PR DESCRIPTION
Fixes:
```
Goal at 0.68m
Traceback (most recent call last):
  File "ro2018.py", line 225, in <module>
    game.play()
  File "ro2018.py", line 164, in play
    print("Heading %.1fdeg, imu" % math.degrees(geo_angle(self.last_position, go
al)), self.last_imu_yaw)
TypeError: must be real number, not NoneType
```
which was caused by duplicity of waypoints.