### PR TITLE
Feature/pulutof1

### DIFF
--- a/config/test-pulutof1.json
+++ b/config/test-pulutof1.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "pulutof1": {
+          "driver": "tcp",
+          "in": ["raw"],
+          "out": ["raw"],
+          "init": {
+            "host": "169.254.78.166",
+            "port": 22222,
+            "bufsize": 10000
+          }
+      }
+    },
+    "links": []
+  }
+}

--- a/osgar/drivers/logsocket.py
+++ b/osgar/drivers/logsocket.py
@@ -20,6 +20,7 @@ class LogTCP:
         self.socket.connect((host, port))
         if 'timeout' in config:
             self.socket.settimeout(config['timeout'])
+        self.bufsize = config.get('bufsize', 1024)
 
         self.bus = bus
         self.buf = b''
@@ -35,7 +36,7 @@ class LogTCP:
     def run_input(self):
         while self.bus.is_alive():
             try:
-                data = self.socket.recv(1024)
+                data = self.socket.recv(self.bufsize)
                 if len(data) > 0:
                     self.bus.publish('raw', data)
             except socket.timeout:


### PR DESCRIPTION
This is rather example that even "foreign" devices can be logged by OSGAR (in this case TOF sensor from Pulurobotics Finland). My motivation for merge to master is change LogTCP to support "bufsize" parameter. I plan to modify/extend this `logsocket.py` to support also UDP stream logging (for Velodyne).