### PR TITLE
John Deere with Python3 OSGAR driver (ver -5)

### DIFF
--- a/config/test-johndeere-gps2x.json
+++ b/config/test-johndeere-gps2x.json
@@ -1,0 +1,56 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "jd": {
+          "driver": "johndeere",
+          "in": ["can"],
+          "out": ["can"],
+          "init": {}
+      },
+      "can": {
+          "driver": "can",
+          "in": ["raw", "can"],
+          "out": ["can", "raw"],
+          "init": {"speed": 250000, "canopen":true}
+      },
+      "serial": {
+          "driver": "serial",
+          "in": ["raw"],
+          "out": ["raw"],
+          "init": {"port": "/dev/ttyS0", "speed": 115200,
+                   "rtscts":true, "reset":true}
+      },
+      "gps": {
+          "driver": "gps",
+          "in": ["raw"],
+          "out": ["position"],
+          "init": {}
+      },
+      "gps_serial": {
+          "driver": "serial",
+          "in": [],
+          "out": ["raw"],
+          "init": {"port": "/dev/ttyUSB0", "speed": 4800}
+      },
+      "dgps": {
+          "driver": "gps",
+          "in": ["raw"],
+          "out": ["position"],
+          "init": {}
+      },
+      "dgps_serial": {
+          "driver": "serial",
+          "in": [],
+          "out": ["raw"],
+          "init": {"port": "/dev/ttyACM0", "speed": 115200}
+      }
+    },
+    "links": [["serial.raw", "can.raw"], 
+              ["can.raw", "serial.raw"],
+              ["jd.can", "can.can"],
+              ["can.can", "jd.can"],
+              ["gps_serial.raw", "gps.raw"],
+              ["dgps_serial.raw", "dgps.raw"]]
+  }
+}

--- a/config/test-johndeere.json
+++ b/config/test-johndeere.json
@@ -1,0 +1,30 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "jd": {
+          "driver": "johndeere",
+          "in": ["can"],
+          "out": ["can"],
+          "init": {}
+      },
+      "can": {
+          "driver": "can",
+          "in": ["raw", "can"],
+          "out": ["can", "raw"],
+          "init": {"speed": 250000, "canopen":true}
+      },
+      "serial": {
+          "driver": "serial",
+          "in": ["raw"],
+          "out": ["raw"],
+          "init": {"port": "/dev/ttyS0", "speed": 115200,
+                   "rtscts":true, "reset":true}
+      }
+    },
+    "links": [["serial.raw", "can.raw"], 
+              ["can.raw", "serial.raw"],
+              ["jd.can", "can.can"],
+              ["can.can", "jd.can"]]
+  }
+}

--- a/osgar/drivers/__init__.py
+++ b/osgar/drivers/__init__.py
@@ -6,9 +6,11 @@ from .canserial import CANSerial
 from .simulator import SpiderSimulator
 from .logsocket import LogTCP
 from .sicklidar import SICKLidar
+from .johndeere import JohnDeere
 
 # dictionary of all available drivers
 all_drivers = dict(gps=GPS, imu=IMU, spider=Spider, serial=LogSerial,
                    can=CANSerial, simulator=SpiderSimulator,
-                   tcp=LogTCP, lidar=SICKLidar)
+                   tcp=LogTCP, lidar=SICKLidar,
+                   johndeere=JohnDeere)
 

--- a/osgar/drivers/canserial.py
+++ b/osgar/drivers/canserial.py
@@ -13,8 +13,13 @@ from osgar.bus import BusShutdownException
 CAN_BRIDGE_READY = b'\xfe\x10'  # CAN bridge is ready to accept configuration commands
 CAN_BRIDGE_SYNC = b'\xFF'*10    # CAN bridge synchronization bytes
 CAN_SPEED_1MB = b'\xfe\x57'     # configure CAN bridge to communicate on 1Mb CAN network
+CAN_SPEED_250KB = b'\xfe\x54'   #                                      250Kb CAN network
 CAN_BRIDGE_START = b'\xfe\x31'  # start bridge
 
+CAN_SPEED = {
+                250000: CAN_SPEED_250KB,
+                1000000: CAN_SPEED_1MB
+            }
 
 def CAN_packet(msg_id, data):
     header = [(msg_id>>3) & 0xff, (msg_id<<5) & 0xe0 | (len(data) & 0xf)]
@@ -46,6 +51,9 @@ class CANSerial(Thread):
         self.bus = bus
         self.buf = b''
 
+        speed = config.get('speed', 1000000)  # default 1Mbit
+        self.can_speed_cmd = CAN_SPEED[speed]
+        self.is_canopen = config.get('canopen', False)
         self.can_bridge_initialized = False
 
     @staticmethod
@@ -67,9 +75,11 @@ class CANSerial(Thread):
     def process_packet(self, packet):
         if packet == CAN_BRIDGE_READY:
             self.bus.publish('raw', CAN_BRIDGE_SYNC)
-            self.bus.publish('raw', CAN_SPEED_1MB)
+            self.bus.publish('raw', self.can_speed_cmd)
             self.bus.publish('raw', CAN_BRIDGE_START)
             self.can_bridge_initialized = True
+            if self.is_canopen:
+                self.bus.publish('raw', CAN_packet(0, [1, 0]))  # operational
             return None
         return packet
 
@@ -101,6 +111,8 @@ class CANSerial(Thread):
             pass
 
     def request_stop(self):
+        if self.is_canopen:
+            self.bus.publish('raw', CAN_packet(0, [128, 0]))  # pre-operational
         self.bus.shutdown()
 
 

--- a/osgar/drivers/johndeere.py
+++ b/osgar/drivers/johndeere.py
@@ -1,0 +1,91 @@
+"""
+  John Deere Driver
+"""
+
+
+import ctypes
+import serial
+import struct
+from threading import Thread
+
+from osgar.logger import LogWriter, LogReader
+from osgar.bus import BusShutdownException
+
+
+CAN_ID_ENCODERS = 0x284
+
+
+def sint16_diff(a, b):
+    '''clip integer value (a - b) to signed int16'''
+    assert 0 <= a <= 0xFFFF, a
+    assert 0 <= b <= 0xFFFF, b
+    return ctypes.c_short(a - b).value
+
+
+class JohnDeere(Thread):
+    def __init__(self, config, bus):
+        Thread.__init__(self)
+        self.setDaemon(True)
+
+        self.bus = bus
+
+        self.desired_speed = 0.0  # m/s
+        self.desired_steering = None  # not specified, no need to change
+
+        self.prev_enc_raw = None
+        self.dist_left_raw = 0
+        self.dist_right_raw = 0
+
+    def update_encoders(self, data):
+        print('ENC', data)
+        assert len(data) == 4, data
+        arr = [data[2*i+1]*256 + data[2*i] for i in range(2)]
+        if self.prev_enc_raw is not None:
+            diffL = sint16_diff(arr[0], self.prev_enc_raw[0])
+            diffR = sint16_diff(arr[1], self.prev_enc_raw[1])
+
+            if abs(diffL) > 128:
+                print("ERR-L\t{}\t{}\t{}".format(self.dist_left_raw, self.prev_enc_raw[0], arr[0]))
+            else:
+                self.dist_left_raw += diffL
+
+            if abs(diffR) > 128:
+                print("ERR-R\t{}\t{}\t{}".format(self.dist_right_raw, self.prev_enc_raw[1], arr[1]))
+            else:
+                self.dist_right_raw += diffR
+        self.prev_enc_raw = arr
+
+    def process_packet(self, packet, verbose=False):
+        if len(packet) >= 2:
+            msg_id = ((packet[0]) << 3) | (((packet[1]) >> 5) & 0x1f)
+            print(hex(msg_id), packet[2:])
+            if msg_id == CAN_ID_ENCODERS:
+                self.update_encoders(packet[2:])
+#TODO                self.bus.publish('encoders', (self.dist_left_raw,  self.dist_right_raw))
+
+    def process_gen(self, data, verbose=False):
+        self.process_packet(data)
+        yield None
+
+    def run(self):
+        try:
+            while True:
+                dt, channel, data = self.bus.listen()
+                if channel == 'can':
+                    if len(data) > 0:
+                        for status in self.process_gen(data):
+                            if status is not None:
+                                self.bus.publish('can', status)  # TODO
+                elif channel == 'desired_speed':
+                    self.desired_speed = data
+                elif channel == 'desired_steering':
+                    self.desired_steering = data
+                else:
+                    assert False, channel  # unsupported channel
+        except BusShutdownException:
+            pass
+
+    def request_stop(self):
+        self.bus.shutdown()
+
+# vim: expandtab sw=4 ts=4


### PR DESCRIPTION
This is rather preparation step for John Deere integration into newer OSGAR library. JD has different CAN bus speed (250kbs instead of 1Mbs on Spider) and is CANOpen, i.e. requires switching to operational state.

The code for JD is rather "preliminary". It would be good to have SICK laser integrated for safety reasons (motivation for rebase on master), and also CAN configuration can be used for Eduro. 