### PR TITLE
Feature/udp marina2

### DIFF
--- a/config/test-marina2.json
+++ b/config/test-marina2.json
@@ -9,7 +9,8 @@
           "init": {
             "host": "169.254.88.144",
             "port": 9999,
-            "bufsize": 10000
+            "bufsize": 10000,
+            "timeout": 2.0
           }
       }
     },

--- a/config/test-marina2.json
+++ b/config/test-marina2.json
@@ -1,0 +1,18 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "marina": {
+          "driver": "udp",
+          "in": ["raw"],
+          "out": ["raw"],
+          "init": {
+            "host": "169.254.88.144",
+            "port": 9999,
+            "bufsize": 10000
+          }
+      }
+    },
+    "links": []
+  }
+}

--- a/config/test-marina2.json
+++ b/config/test-marina2.json
@@ -2,6 +2,12 @@
   "version": 2,
   "robot": {
     "modules": {
+      "app": {
+          "driver": "application",
+          "in": ["raw"],
+          "out": ["raw"],
+          "init": {}
+      },
       "marina": {
           "driver": "udp",
           "in": ["raw"],
@@ -14,6 +20,6 @@
           }
       }
     },
-    "links": []
+    "links": [["marina.raw", "app.raw"], ["app.raw", "marina.raw"]]
   }
 }

--- a/osgar/drivers/__init__.py
+++ b/osgar/drivers/__init__.py
@@ -4,11 +4,11 @@ from .spider import Spider
 from .logserial import LogSerial
 from .canserial import CANSerial
 from .simulator import SpiderSimulator
-from .logsocket import LogTCP
+from .logsocket import LogTCP, LogUDP
 from .sicklidar import SICKLidar
 
 # dictionary of all available drivers
 all_drivers = dict(gps=GPS, imu=IMU, spider=Spider, serial=LogSerial,
                    can=CANSerial, simulator=SpiderSimulator,
-                   tcp=LogTCP, lidar=SICKLidar)
+                   tcp=LogTCP, udp=LogUDP, lidar=SICKLidar)
 

--- a/osgar/drivers/logsocket.py
+++ b/osgar/drivers/logsocket.py
@@ -23,7 +23,6 @@ class LogTCP:
         self.bufsize = config.get('bufsize', 1024)
 
         self.bus = bus
-        self.buf = b''
 
     def start(self):
         self.input_thread.start()

--- a/osgar/drivers/logsocket.py
+++ b/osgar/drivers/logsocket.py
@@ -63,7 +63,7 @@ class LogUDP(LogTCP):
         host = config['host']
         port = config['port']
         self.pair = (host, port)
-        self.socket.bind(self.pair)
+        self.socket.bind(('', port))
         if 'timeout' in config:  # TODO check - UDP timeout works
             self.socket.settimeout(config['timeout'])
         self.bufsize = config.get('bufsize', 1024)

--- a/osgar/drivers/logsocket.py
+++ b/osgar/drivers/logsocket.py
@@ -53,6 +53,10 @@ class LogTCP:
         self.bus.shutdown()
 
 
+class LogUDP(LogTCP):
+    pass
+
+
 if __name__ == "__main__":
     import time
     from osgar.bus import BusHandler


### PR DESCRIPTION
This is again rather WIP pull request. It works for Marina2 (https://robotika.cz/robots/marina/cs#180825), but you may have some suggestions how to refactor `logsocket.py`? Maybe one base class and inherited `LogTCP` and `LogUDP`? The overlap is big and the only difference are initial socket configuration, call of "bind" and `sendto` instead of `send`.

One more point regarding configuration - there is dummy app in order to send some data to the boat. That way boat/server learns where are the listening clients and start to stream sensor data. Any suggestion here?
thanks
m.
p.s. I will squash commits into two at the end (UDP change and new config)