### PR TITLE
Add HTTP driver for IP camera

### DIFF
--- a/config/test-ip-camera.json
+++ b/config/test-ip-camera.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "camera": {
+          "driver": "http",
+          "in": [],
+          "out": ["raw"],
+          "init": {
+              "url": "http://192.168.1.6/image?res=half&quality=12&doublescan=0"
+          }
+      }
+    },
+    "links": []
+  }
+}

--- a/config/test-ip-camera.json
+++ b/config/test-ip-camera.json
@@ -7,7 +7,7 @@
           "in": [],
           "out": ["raw"],
           "init": {
-              "url": "http://192.168.1.6/image?res=half&quality=12&doublescan=0"
+              "url": "http://192.168.0.99/image?res=half&quality=12&doublescan=0"
           }
       }
     },

--- a/osgar/drivers/__init__.py
+++ b/osgar/drivers/__init__.py
@@ -4,11 +4,12 @@ from .spider import Spider
 from .logserial import LogSerial
 from .canserial import CANSerial
 from .simulator import SpiderSimulator
-from .logsocket import LogTCP, LogUDP
+from .logsocket import LogTCP, LogUDP, LogHTTP
 from .sicklidar import SICKLidar
 
 # dictionary of all available drivers
 all_drivers = dict(gps=GPS, imu=IMU, spider=Spider, serial=LogSerial,
                    can=CANSerial, simulator=SpiderSimulator,
-                   tcp=LogTCP, udp=LogUDP, lidar=SICKLidar)
+                   tcp=LogTCP, udp=LogUDP, http=LogHTTP,
+                   lidar=SICKLidar)
 


### PR DESCRIPTION
This is driver for Eduro IP camera. It uses `urllib.request` as older John Deere. I put the code together with `LogTCP` and `LogUDP` drivers, as I hope for some overlap?? I did a quick test with a local `robotika.cz` to get some image, but I hit the OSGAR limitation :(

```
m:\git\osgar>python osgar\robot.py run config\test-ip-camera.json
Exception in thread Thread-1:
Traceback (most recent call last):
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\threading.py", line
 916, in _bootstrap_inner
    self.run()
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\threading.py", line
 864, in run
    self._target(*self._args, **self._kwargs)
  File "m:\git\osgar\osgar\drivers\logsocket.py", line 100, in run_input
    self.bus.publish('raw', data)
  File "m:\git\osgar\osgar\bus.py", line 28, in publish
    timestamp = self.logger.write(stream_id, serialize(data))
  File "m:\git\osgar\osgar\logger.py", line 70, in write
    assert len(bytes_data) < 0x10000, len(bytes_data)  # large data blocks are n
ot supported yet
AssertionError: 213450
```
but for smaller images it is probably working. At the moment no timeout is handled and also `IOErrors` are not catched.