### PR TITLE
Add driver for Timer with integration test

### DIFF
--- a/config/test-timer.json
+++ b/config/test-timer.json
@@ -1,0 +1,14 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "timer": {
+          "driver": "timer",
+          "in": [],
+          "out": ["tick"],
+          "init": {"sleep": 0.1}
+      }
+    },
+    "links": []
+  }
+}

--- a/osgar/drivers/__init__.py
+++ b/osgar/drivers/__init__.py
@@ -6,10 +6,12 @@ from .canserial import CANSerial
 from .simulator import SpiderSimulator
 from .logsocket import LogTCP, LogUDP, LogHTTP
 from .sicklidar import SICKLidar
+from .timer import Timer
 
 # dictionary of all available drivers
 all_drivers = dict(gps=GPS, imu=IMU, spider=Spider, serial=LogSerial,
                    can=CANSerial, simulator=SpiderSimulator,
                    tcp=LogTCP, udp=LogUDP, http=LogHTTP,
+                   timer=Timer,
                    lidar=SICKLidar)
 

--- a/osgar/drivers/test_timer.py
+++ b/osgar/drivers/test_timer.py
@@ -1,0 +1,39 @@
+import unittest
+import time
+from unittest.mock import MagicMock
+
+from osgar.drivers.timer import Timer
+from osgar.bus import BusHandler
+
+
+class TimerTest(unittest.TestCase):
+   
+    def test_usage(self):
+        config = {'sleep': 0.2}
+        logger = MagicMock()
+        bus = BusHandler(logger, out={'tick':[]}, name='timer')
+        bus.publish = MagicMock()
+
+        timer = Timer(config, bus=bus)
+        timer.start()
+        time.sleep(0.1)
+        timer.request_stop()
+        timer.join()
+        bus.publish.assert_called_with('tick', 0)
+
+    def test_fast_timer(self):
+        config = {'sleep': 0.01}
+        logger = MagicMock()
+        bus = BusHandler(logger, out={'tick':[]}, name='timer')
+        bus.publish = MagicMock()
+
+        timer = Timer(config, bus=bus)
+        timer.start()
+        time.sleep(0.1)
+        timer.request_stop()
+        timer.join()
+
+        # small tolerance for system performance
+        self.assertIn(len(bus.publish.call_args_list), [9, 10, 11])
+
+# vim: expandtab sw=4 ts=4

--- a/osgar/drivers/timer.py
+++ b/osgar/drivers/timer.py
@@ -1,0 +1,31 @@
+"""
+  Timer event trigger
+"""
+
+from threading import Thread
+import time
+
+from osgar.bus import BusShutdownException
+
+
+class Timer(Thread):
+    def __init__(self, config, bus):
+        Thread.__init__(self)
+        self.setDaemon(True)
+        self.bus = bus
+        self.sleep_time = config['sleep']
+
+    def run(self):
+        try:
+            count = 0
+            while self.bus.is_alive():
+                self.bus.publish('tick', count)
+                time.sleep(self.sleep_time)
+                count += 1
+        except BusShutdownException:
+            pass
+
+    def request_stop(self):
+        self.bus.shutdown()
+
+# vim: expandtab sw=4 ts=4


### PR DESCRIPTION
This is an alternative mentioned in #81 to trigger (potentially "synchronously") some data collection tasks and to avoid `time.sleep()` calls in the implementation of modules. If this is the preferred way then I would first merge this PR and rebase #81 on it.