### PR TITLE
Extend tool log2video.py with display time, FPS and start time options

### DIFF
--- a/osgar/tools/log2video.py
+++ b/osgar/tools/log2video.py
@@ -2,6 +2,8 @@
 """
   Convert logfile to AVI video
 """
+from datetime import timedelta
+
 try:
     import cv2
 except ImportError:
@@ -16,7 +18,7 @@ from osgar.logger import LogReader, lookup_stream_id
 from osgar.lib.serialize import deserialize
 
 
-def create_video(logfile, outfile):
+def create_video(logfile, outfile, add_time=False, start_time_sec=0, fps=25):
     assert outfile.endswith(".avi"), outFilename
     only_stream = lookup_stream_id(logfile, 'camera.raw')
     with LogReader(logfile) as log:
@@ -27,10 +29,18 @@ def create_video(logfile, outfile):
             if writer is None:
                 height, width = img.shape[:2]
                 writer = cv2.VideoWriter(outfile,
-                                         cv2.VideoWriter_fourcc('F', 'M', 'P', '4'), 
-                                         5, 
+                                         cv2.VideoWriter_fourcc('F', 'M', 'P', '4'),
+                                         fps,
                                          (width, height))
-            writer.write(img)
+            if add_time:
+                x, y = 800, 100
+                # clip microseconds to miliseconds
+                s = str(timestamp-timedelta(seconds=start_time_sec))[:-3]
+                cv2.putText(img, s, (x, y), cv2.FONT_HERSHEY_PLAIN, 
+                            5.0, (255, 255, 255), thickness=5)
+
+            if timestamp.total_seconds() > start_time_sec:
+                writer.write(img)
         writer.release()
 
 
@@ -40,9 +50,14 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Convert logfile to AVI video')
     parser.add_argument('logfile', help='recorded log file')
     parser.add_argument('--out', '-o', help='output AVI file', default='out.avi')
+    parser.add_argument('--display-time', '-t', help='add timestamp info', action='store_true')
+    parser.add_argument('--start-time-sec', '-s', help='start video at later time (sec)',
+                        type=float, default=0.0)
+    parser.add_argument('--fps', help='frames per second', type=int, default=25)
     args = parser.parse_args()
 
-    create_video(args.logfile, args.out)
+    create_video(args.logfile, args.out, add_time=args.display_time,
+                 start_time_sec=args.start_time_sec, fps=args.fps)
 
 # vim: expandtab sw=4 ts=4 
 


### PR DESCRIPTION
Added extra params for log2video conversion. I dropped the "similarity" feature used for SICK Robot Day video, because as soon as the robot moves similarity is useless (it was OK for stationary "waiting for transporter"). I am not 100% sure about --start-time-sec, if that should automatically cut also the timestamp - again it was used for SICK, that it was clear when 10min match started.

Low priority PR