### PR TITLE
eduro.py - fix bug with conversion to Python3

### DIFF
--- a/osgar/drivers/eduro.py
+++ b/osgar/drivers/eduro.py
@@ -137,16 +137,16 @@ class Eduro(Thread):
 
         maxLim = 4000
         if left > maxLim:
-            right = right*maxLim/left
+            right = right*maxLim//left
             left = maxLim
         if left < -maxLim:
-            right = -right*maxLim/left
+            right = -right*maxLim//left
             left = -maxLim
         if right > maxLim:
-            left = left*maxLim/right
+            left = left*maxLim//right
             right = maxLim
         if right < -maxLim:
-            left = -left*maxLim/right
+            left = -left*maxLim//right
             right = -maxLim
 
         self.bus.publish('can', CAN_packet(0x201, [

--- a/osgar/drivers/test_eduro.py
+++ b/osgar/drivers/test_eduro.py
@@ -66,5 +66,15 @@ class EduroTest(unittest.TestCase):
         self.assertEqual(sint32_diff(-0x7FFFFFFF, 0x7FFFFFFF), 2)
         self.assertEqual(sint32_diff(0x7FFFFFFF, -0x7FFFFFFF), -2)
 
+    def test_float_speed_bug(self):
+        bus = MagicMock()
+        eduro = Eduro(config={}, bus=bus)
+        # set internal values before crash
+        eduro.desired_speed = 0.71
+        eduro.desired_angular_speed = 1.6952383024620923
+        eduro._rampLastLeft = 1417
+        eduro._rampLastRight = 3891
+        eduro.send_speed()
+        bus.publish.assert_called_once_with('can', b'@$\xa9\x05\xa0\x0f')
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/root/miniconda3/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/home/robot/git/osgar/osgar/drivers/eduro.py", line 208, in run
    for status in self.process_gen(data):
  File "/home/robot/git/osgar/osgar/drivers/eduro.py", line 199, in process_gen
    self.process_packet(data)
  File "/home/robot/git/osgar/osgar/drivers/eduro.py", line 193, in process_packet
    self.send_speed()
  File "/home/robot/git/osgar/osgar/drivers/eduro.py", line 153, in send_speed
    left&0xff, (left>>8)&0xff,
TypeError: unsupported operand type(s) for &: 'float' and 'int'