### PR TITLE
Feature/log env path

### DIFF
--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -32,6 +32,7 @@
 import datetime
 import struct
 import os
+import logging
 from threading import RLock
 from ast import literal_eval
 
@@ -48,6 +49,8 @@ class LogWriter:
         if ENV_OSGAR_LOGS in os.environ:
             os.makedirs(os.environ[ENV_OSGAR_LOGS], exist_ok=True)
             self.filename = os.path.join(os.environ[ENV_OSGAR_LOGS], self.filename)
+        else:
+            logging.warning('Environment variable %s is not set - using working directory' % ENV_OSGAR_LOGS)
         self.f = open(self.filename, 'wb')
         self.f.write(b'Pyr\x00')
 

--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -31,11 +31,13 @@
 
 import datetime
 import struct
+import os
 from threading import RLock
 from ast import literal_eval
 
 
 INFO_STREAM_ID = 0
+ENV_OSGAR_LOGS = 'OSGAR_LOGS'
 
 
 class LogWriter:
@@ -43,9 +45,12 @@ class LogWriter:
         self.lock = RLock()
         self.start_time = datetime.datetime.utcnow()
         self.filename = prefix + self.start_time.strftime("%y%m%d_%H%M%S.log")
+        if ENV_OSGAR_LOGS in os.environ:
+            os.makedirs(os.environ[ENV_OSGAR_LOGS], exist_ok=True)
+            self.filename = os.path.join(os.environ[ENV_OSGAR_LOGS], self.filename)
         self.f = open(self.filename, 'wb')
         self.f.write(b'Pyr\x00')
-        
+
         t = self.start_time
         self.f.write(struct.pack('HBBBBBI', t.year, t.month, t.day,
                 t.hour, t.minute, t.second, t.microsecond))

--- a/osgar/test_logger.py
+++ b/osgar/test_logger.py
@@ -9,7 +9,12 @@ from osgar.logger import (LogWriter, LogReader, LogAsserter, INFO_STREAM_ID,
 
 
 class LoggerTest(unittest.TestCase):
-    
+
+    def setUp(self):
+        ref = os.environ.get('OSGAR_LOGS')
+        if ref is not None:
+            del os.environ['OSGAR_LOGS']
+
     def test_writer_prefix(self):
         log = LogWriter(prefix='tmp')
         self.assertTrue(log.filename.startswith('tmp'))
@@ -133,6 +138,21 @@ class LoggerTest(unittest.TestCase):
             self.assertEqual([len(x) for x in arr],
                              [100000, 65535, 0, 3, 200000])
 
+        os.remove(log.filename)
+
+    def test_environ(self):
+        with LogWriter(prefix='tmp5', note='test_filename_before') as log:
+            self.assertTrue(log.filename.startswith('tmp5'))
+        os.remove(log.filename)
+
+        os.environ['OSGAR_LOGS'] = 'tmp_dir'
+        with LogWriter(prefix='tmp6', note='test_filename_after') as log:
+            self.assertTrue(log.filename.startswith('tmp_dir'))
+        os.remove(log.filename)
+
+        del os.environ['OSGAR_LOGS']
+        with LogWriter(prefix='tmp7', note='test_filename_after2') as log:
+            self.assertTrue(log.filename.startswith('tmp7'))
         os.remove(log.filename)
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Use environment variable `OSGAR_LOGS` to define root for logger output. (this issue was reported after OSGAR Emily/Cogito test)