### PR TITLE
log2video.py - add stream ID as optional parameter

### DIFF
--- a/osgar/tools/log2video.py
+++ b/osgar/tools/log2video.py
@@ -18,9 +18,9 @@ from osgar.logger import LogReader, lookup_stream_id
 from osgar.lib.serialize import deserialize
 
 
-def create_video(logfile, outfile, add_time=False, start_time_sec=0, fps=25):
+def create_video(logfile, stream, outfile, add_time=False, start_time_sec=0, fps=25):
     assert outfile.endswith(".avi"), outFilename
-    only_stream = lookup_stream_id(logfile, 'camera.raw')
+    only_stream = lookup_stream_id(logfile, stream)
     with LogReader(logfile) as log:
         writer = None
         for timestamp, stream_id, data in log.read_gen(only_stream):
@@ -49,6 +49,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description='Convert logfile to AVI video')
     parser.add_argument('logfile', help='recorded log file')
+    parser.add_argument('--stream', help='stream ID or name', default='camera.raw')
     parser.add_argument('--out', '-o', help='output AVI file', default='out.avi')
     parser.add_argument('--display-time', '-t', help='add timestamp info', action='store_true')
     parser.add_argument('--start-time-sec', '-s', help='start video at later time (sec)',
@@ -56,7 +57,7 @@ if __name__ == "__main__":
     parser.add_argument('--fps', help='frames per second', type=int, default=25)
     args = parser.parse_args()
 
-    create_video(args.logfile, args.out, add_time=args.display_time,
+    create_video(args.logfile, args.stream, args.out, add_time=args.display_time,
                  start_time_sec=args.start_time_sec, fps=args.fps)
 
 # vim: expandtab sw=4 ts=4 


### PR DESCRIPTION
This is just a small PR, so that I can easily generate videos from OSGAR ROS Proxy for SubT ...
```
python -m osgar.tools.log2video subt-181216_165025.log -o follow-wall.avi --stream=rosmsg_image.image
```