### PR TITLE
Feature/logger duration unlimited

### DIFF
--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -173,7 +173,10 @@ class LogAsserter(LogReader):
 def lookup_stream_names(filename):
     names = []
     with LogReader(filename) as log:
-        for __, __, line in log.read_gen(0):
+        for __, channel, line in log.read_gen():
+            # optimization - all names are defined BEFORE other data on other channels
+            if channel != 0:
+                break
             if b'Errno' in line:
                 continue
             d = literal_eval(line.decode('ascii'))

--- a/osgar/test_logger.py
+++ b/osgar/test_logger.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import time
+import datetime
 
 import numpy as np
 
@@ -153,6 +154,14 @@ class LoggerTest(unittest.TestCase):
         del os.environ['OSGAR_LOGS']
         with LogWriter(prefix='tmp7', note='test_filename_after2') as log:
             self.assertTrue(log.filename.startswith('tmp7'))
+        os.remove(log.filename)
+
+    def test_time_overflow(self):
+        with LogWriter(prefix='tmp8', note='test_time_overflow') as log:
+            log.start_time = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+            with self.assertRaises(AssertionError) as e:
+                t1 = log.write(1, b'\x01\x02')
+            self.assertEqual(str(e.exception), "1:00:00")
         os.remove(log.filename)
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
This is another "spin-off" PR from SubT ver0 development and it is related to #118. For low resolution camera the files are not that big (500MB after 2hours?) so it still can be one file, but the overflow has to be properly handled. The hidden assumption is that the gap is not longer than 1 hour (I should add assert and unit test for it).

I also added commit for optimization of reading names of all streams. They are static, so in order to extract them it is not necessary to load whole (say 2 hours) log file. (sorry, this should be probably separate PR).

Finally note, that I was not able to write proper patch for unittest, sigh - I will try to do it now, when the stress is not so big any more. Suggestions welcome, because I am sure I do there some stupid mistake ...
