### PR TITLE
Feature/osgar xmlrpc

### DIFF
--- a/osgar/drivers/logrpc.py
+++ b/osgar/drivers/logrpc.py
@@ -1,0 +1,45 @@
+"""
+  Wrapper & XML RPC (both client and server)
+"""
+import xmlrpc.client
+
+
+class LogTransportParser:
+    def __init__(self, bus, parser):
+        self.bus = bus
+        self.p = parser
+
+    def feed(self, data):
+        self.bus.publish('raw', data)
+        self.p.feed(data)
+
+    def close(self):
+        self.p.close()
+
+
+class LogTransport(xmlrpc.client.Transport):
+    def __init__(self, bus):
+        self.bus = bus
+        super().__init__()
+
+    def make_connection(self, host):
+        self.bus.publish('make_connection', host)
+        h = super().make_connection(host)
+        return h
+
+    def send_request(self, connection, handler, request_body, debug):
+        self.bus.publish('send_request', request_body)
+        return super().send_request(connection, handler, request_body, debug)
+
+    def getparser(self):
+        p, u = super().getparser()
+        return LogTransportParser(self.bus, p), u
+
+
+class LogServerProxy(xmlrpc.client.ServerProxy):
+    def __init__(self, bus, uri):
+        super().__init__(uri, LogTransport(bus))
+
+
+# vim: expandtab sw=4 ts=4
+

--- a/osgar/drivers/test_logrpc.py
+++ b/osgar/drivers/test_logrpc.py
@@ -1,0 +1,41 @@
+import unittest
+from threading import Thread
+from unittest.mock import patch, MagicMock, call
+from xmlrpc.server import SimpleXMLRPCServer
+
+from osgar.drivers.logrpc import LogServerProxy
+from osgar.bus import BusHandler
+
+
+def adder_function(x,y):
+    return x + y
+
+
+class MyTestRPCServer(Thread):
+    def __init__(self):
+        super().__init__()
+        self.setDaemon(True)
+        
+        # Create server
+        self.server = SimpleXMLRPCServer(("localhost", 8000))
+        self.server.register_function(adder_function, 'add')
+        self.start()
+
+    def run(self):
+        self.server.serve_forever()
+
+
+class LogServerProxyTest(unittest.TestCase):
+
+    def test_usage(self):
+        server = MyTestRPCServer()
+        bus = MagicMock()
+        s = LogServerProxy(bus, 'http://localhost:8000')
+        self.assertEqual(s.add(2, 3), 5)
+        self.assertEqual(bus.publish.call_args_list, [
+            call('send_request', b"<?xml version='1.0'?>\n<methodCall>\n<methodName>add</methodName>\n<params>\n<param>\n<value><int>2</int></value>\n</param>\n<param>\n<value><int>3</int></value>\n</param>\n</params>\n</methodCall>\n"),
+            call('make_connection', 'localhost:8000'),
+            call('raw', b"<?xml version='1.0'?>\n<methodResponse>\n<params>\n<param>\n<value><int>5</int></value>\n</param>\n</params>\n</methodResponse>\n")
+            ])
+
+# vim: expandtab sw=4 ts=4


### PR DESCRIPTION
This PR is for discussion about logging/patching XML RPC server necessary for `ROSProxy`. Patch of `xmlrpc.client.SafeTransport` was failing due to SSL error:

```
ERROR: test_rpc_client (osgar.drivers.test_logrpc.LogRPCTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "m:\git\osgar\osgar\drivers\test_logrpc.py", line 67, in test_rpc_client
    self.assertEqual(s.add(2, 3), 5)
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\xmlrpc\client.py",
line 1112, in __call__
    return self.__send(self.__name, args)
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\xmlrpc\client.py",
line 1452, in __request
    verbose=self.__verbose
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\xmlrpc\client.py",
line 1154, in request
    return self.single_request(host, handler, request_body, verbose)
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\xmlrpc\client.py",
line 1166, in single_request
    http_conn = self.send_request(host, handler, request_body, verbose)
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\xmlrpc\client.py",
line 1279, in send_request
    self.send_content(connection, request_body)
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\xmlrpc\client.py",
line 1309, in send_content
    connection.endheaders(request_body)
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\http\client.py", li
ne 1234, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\http\client.py", li
ne 1026, in _send_output
    self.send(msg)
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\http\client.py", li
ne 964, in send
    self.connect()
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\http\client.py", li
ne 1400, in connect
    server_hostname=server_hostname)
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\ssl.py", line 401,
in wrap_socket
    _context=self, _session=session)
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\ssl.py", line 808,
in __init__
    self.do_handshake()
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\ssl.py", line 1061,
 in do_handshake
    self._sslobj.do_handshake()
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\ssl.py", line 683,
in do_handshake
    self._sslobj.do_handshake()
ssl.SSLError: [SSL: UNKNOWN_PROTOCOL] unknown protocol (_ssl.c:748)
```
which is maybe related to old Python only??

At the moment only reasonable/working experiment is with `patch` and `wraps`.