### PR TITLE
Bugfix/record app node

### DIFF
--- a/osgar/record.py
+++ b/osgar/record.py
@@ -63,7 +63,7 @@ def record(config_filename, log_prefix, duration_sec=None, application=None):
     recorder.start()
     if application is not None:
         game = recorder.modules['app']  # TODO nicer reference
-        game.run()  # if application would be Node then it would be already running TODO
+        game.join()  # wait for application termination
     else:
         if duration_sec is None:
             while True:


### PR DESCRIPTION
Fix replay for `osgar.explore` which was already using `Node`. Refactor other applications `go1m` and `followme` to also use `Node`.

Test on real machine is required (I will do it tomorrow night).

p.s. I would consider to move `self.verbose = False` to `Node.__init__()`