### PR TITLE
Feature/release osgar tools

### DIFF
--- a/osgar/tools/lidarview.py
+++ b/osgar/tools/lidarview.py
@@ -255,7 +255,7 @@ def lidarview(gen, callback=False):
                 break
 
 
-if __name__ == "__main__":
+def main():
     import argparse
 
     parser = argparse.ArgumentParser(description='View lidar scans')
@@ -280,6 +280,9 @@ if __name__ == "__main__":
         lidarview(scans_gen(args.logfile, lidar_name=args.lidar,
                             poses_name=args.poses, camera_name=args.camera),
                   callback=callback)
+
+if __name__ == "__main__":
+    main()
 
 # vim: expandtab sw=4 ts=4 
 

--- a/osgar/tools/log2pcap.py
+++ b/osgar/tools/log2pcap.py
@@ -47,7 +47,7 @@ def log2pcap(input_filepath, output_dir):
             out.write(packet)
 
 
-if __name__ == "__main__":
+def main():
     if len(sys.argv) < 3:
         print(__doc__)
         sys.exit(2)
@@ -55,6 +55,10 @@ if __name__ == "__main__":
     output_dir = sys.argv[-1]
     for filename in sys.argv[1:-1]:
         log2pcap(filename, output_dir)
+
+
+if __name__ == "__main__":
+    main()
 
 # vim: expandtab sw=4 ts=4 
 

--- a/osgar/tools/log2video.py
+++ b/osgar/tools/log2video.py
@@ -44,7 +44,7 @@ def create_video(logfile, stream, outfile, add_time=False, start_time_sec=0, fps
         writer.release()
 
 
-if __name__ == "__main__":
+def main():
     import argparse
 
     parser = argparse.ArgumentParser(description='Convert logfile to AVI video')
@@ -59,6 +59,10 @@ if __name__ == "__main__":
 
     create_video(args.logfile, args.stream, args.out, add_time=args.display_time,
                  start_time_sec=args.start_time_sec, fps=args.fps)
+
+
+if __name__ == "__main__":
+    main()
 
 # vim: expandtab sw=4 ts=4 
 

--- a/setup.py
+++ b/setup.py
@@ -10,22 +10,32 @@ setuptools.setup(
           'pyserial',
           'msgpack>=0.5.0',
       ],
+    extras_require={
+        'tools': ['opencv-python>=3,<4', 'Pygame'],
+    },
     author="Robotika.cz",
     author_email="osgar@robotika.cz",
     description="Open Source Garden/Generic Autonomous Robot / Python library",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/robotika/osgar",
-#    packages=setuptools.find_packages(),
-    packages=['osgar', 'osgar.drivers', 'osgar.lib'],  # TODO use line above after cleanup
+    python_requires=">=3.5",
+    packages=['osgar', 'osgar.drivers', 'osgar.lib', 'osgar.tools'],
     package_data={
         '': ['config/*.json'],
     },
-    classifiers=(
+    entry_points={
+        'console_scripts': [
+            'lidarview = osgar.tools.lidarview:main [tools]',
+            'log2video = osgar.tools.log2video:main [tools]',
+            'log2pcap = osgar.tools.log2pcap:main [tools]',
+        ],
+    },
+    classifiers=[
         "Programming Language :: Python :: 3",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
-    ),
+    ],
 )
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
This PR adds the package `osgar.tools` to the release on pypi (as extras called `tools`). To install osgar including these tools use `pip install osgar[tools]`.

In addition it limits the compatibility to python version >=3.5 since none of us uses anything older.

The package to be released can be tested locally. Just do `pip install dist/osgar-....whl[tools]`.