### PR TITLE
pygame sound mixer uses 100% cpu, init only display.

### DIFF
--- a/osgar/tools/lidarview.py
+++ b/osgar/tools/lidarview.py
@@ -193,7 +193,7 @@ class History:
 def lidarview(gen, caption_filename, callback=False):
     global g_scale
 
-    pygame.init()    
+    pygame.display.init()
     screen = pygame.display.set_mode(WINDOW_SIZE)
 
     # create backgroud


### PR DESCRIPTION
https://github.com/pygame/pygame/issues/331 it is a known issue of pygame on linux :disappointed: 

The solution (for now) is to init only display submodule.