### PR TITLE
Implement sleep for OpenCV driver (in order to slow down FPS)

### DIFF
--- a/config/test-opencv-camera.json
+++ b/config/test-opencv-camera.json
@@ -7,7 +7,8 @@
           "in": [],
           "out": ["raw"],
           "init": {
-              "port": 0
+              "port": 0,
+              "sleep": 1.0
           }
       }
     },

--- a/osgar/drivers/opencv.py
+++ b/osgar/drivers/opencv.py
@@ -16,6 +16,7 @@ class LogOpenCVCamera:
 
         port = config.get('port', 0)
         self.cap = cv2.VideoCapture(port)
+        self.sleep = config.get('sleep')
 
     def start(self):
         self.input_thread.start()
@@ -31,6 +32,8 @@ class LogOpenCVCamera:
                 retval, data = cv2.imencode('*.jpeg', frame)
                 if len(data) > 0:
                     self.bus.publish('raw', data.tobytes())
+                if self.sleep is not None:
+                    self.bus.sleep(self.sleep)
         self.cap.release()
 
     def request_stop(self):


### PR DESCRIPTION
This is mainly for Robik, so that we can slow down 15Hz to 4Hz (?) via trivial `self.bus.sleep()`.
(tested on USB camera with 1s sleep, 20s recording of a clock)