### PR TITLE
Implement ReplayDriver for reprocessing of logfiles

### DIFF
--- a/config/test-replay-node.json
+++ b/config/test-replay-node.json
@@ -1,0 +1,22 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "replay": {
+          "driver": "replay",
+          "in": [],
+          "out": ["pose2d", "scan", "jpeg", "rotation"],
+          "init": {
+            "filename": "d:\\md\\osgar\\logs\\subt\\eduro\\190305\\wall-190305_203603.log",
+            "pins": {
+              "eduro.pose2d": "pose2d",
+              "lidar.scan": "scan",
+              "imu.rot": "rotation",
+              "camera.raw": "jpeg"
+            }
+          }
+      }
+    },
+    "links": []
+  }
+}

--- a/osgar/drivers/__init__.py
+++ b/osgar/drivers/__init__.py
@@ -10,6 +10,7 @@ from .sicklidar import SICKLidar
 from .eduro import Eduro
 from .cortexpilot import Cortexpilot
 from .logusb import LogUSB
+from .replay import ReplayDriver
 
 # dictionary of all available drivers
 all_drivers = dict(gps=GPS, imu=IMU, spider=Spider, serial=LogSerial,
@@ -20,5 +21,6 @@ all_drivers = dict(gps=GPS, imu=IMU, spider=Spider, serial=LogSerial,
                    eduro=Eduro,
                    cortexpilot=Cortexpilot,
                    usb=LogUSB,
+                   replay=ReplayDriver,
                    )
 

--- a/osgar/drivers/replay.py
+++ b/osgar/drivers/replay.py
@@ -1,0 +1,45 @@
+"""
+  Driver "replay" replaying old logfile
+"""
+
+from threading import Thread
+
+from osgar.logger import LogReader, lookup_stream_names
+from osgar.lib.serialize import deserialize
+from osgar.bus import BusShutdownException
+
+
+class ReplayDriver:
+    def __init__(self, config, bus):
+        self.input_thread = Thread(target=self.run_input, daemon=True)
+        self.bus = bus
+
+        self.filename = config['filename']
+        self.pins = config['pins']
+
+    def start(self):
+        self.input_thread.start()
+
+    def join(self, timeout=None):
+        self.input_thread.join(timeout=timeout)
+
+    def run_input(self):
+        names = lookup_stream_names(self.filename)
+        print(names)
+        ids = [i + 1 for i, name in enumerate(names) if name in self.pins]
+        print(ids)
+        for timestamp, channel_index, data_raw in LogReader(self.filename,
+                only_stream_id=ids):
+            if not self.bus.is_alive():
+                break
+            channel = names[channel_index - 1]
+            assert channel in self.pins
+            data = deserialize(data_raw)
+            # TODO reuse timestamp
+            self.bus.publish(self.pins[channel], data)
+        print('Replay completed!')
+
+    def request_stop(self):
+        self.bus.shutdown()
+
+# vim: expandtab sw=4 ts=4


### PR DESCRIPTION
This is the first step into logfile reprocessing (i.e. it will generate a new logfile based on old logfile). I realized that even in in ADTF you need special configuration (diagram) for "replay" from "hard disk player" and it is almost straightforward in OSGAR. I also created this PR to let you know, that tried that with goal of reprocessed fusion pose2d for Eduro robot.

Comments are welcome.

Usage:
`python -m osgar.record config\test-replay-node.json --duration 1`

and the result you can see for example via
`python -m osgar.tools.lidarview test-replay-node-190319_052614.log
--poses replay.pose2d --lidar replay.scan --camera replay.jpeg`

So as side-effect it filters and renames streams. :)
Yes, there are many TODOs like reuse of timestamp, proper termination (duration 1s is used to terminate the recording/reprocessing), easier filename specification, probably more suitable name for driver and `self.pins` ... etc. But it is the first step and that is usually not perfect ...
