### PR TITLE
SubT STIX - add tool for manual artifact report

### DIFF
--- a/examples/subt/report_artf.py
+++ b/examples/subt/report_artf.py
@@ -1,0 +1,57 @@
+"""
+   Report artifact for STIX in Colorado April 2019
+"""
+import requests
+
+
+URL_BASE = "http://localhost:8000"
+ARTF_TYPES = ['Survivor', 'Backpack', 'Cell Phone', 'Drill', 'Fire Extinguisher']
+
+json_headers = {
+    "Authorization" : "Bearer subttesttoken123",
+    "Content-Type" : "application/json",
+}
+
+
+def get_status():
+    print('Get Status')
+    url = URL_BASE + "/api/status/"
+
+    # Correct GET /api/status/ request
+    response = requests.get(url, headers=json_headers)
+    assert response.status_code == 200
+    print(response.content)
+
+
+def report_artf(artf_type, x, y, z):
+    artifact_report_data = {
+        "x": x,
+        "y": y,
+        "z": z,
+        "type": artf_type,
+    }
+    print('Report', artifact_report_data)
+    url = URL_BASE + "/api/artifact_reports/"
+
+    # Correct POST /api/artifact_reports/ request
+    response = requests.post(url, json=artifact_report_data, headers=json_headers)
+    assert response.status_code == 201
+    print(response.content)
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Report artifact to server')
+    parser.add_argument('artf_type', help='Type of artifact', choices=ARTF_TYPES)
+    parser.add_argument('x', help='X coordinate in meters', type=float)
+    parser.add_argument('y', help='Y coordinate in meters', type=float)
+    parser.add_argument('z', help='Z coordinate in meters', type=float)
+    args = parser.parse_args()
+
+    get_status()
+    report_artf(args.artf_type, args.x, args.y, args.z)
+    get_status()
+
+# vim: expandtab sw=4 ts=4
+


### PR DESCRIPTION
Simple tool for manual artifact report (STIX, April 2019). Tested on sample server from DARPA.

```
martind@martind-Lenovo-G580:~/subt_ws/osgar/examples/subt$ python3 report_artf.py "backpack" 1 2 3
Get Status
b'{"run_clock":25.98,"score":9000,"remaining_reports":6,"current_team":"subt"}'
Report {'x': 1.0, 'y': 2.0, 'z': 3.0, 'type': 'backpack'}
b'{"run":"identifier for the run","url":"some url string","run_clock":3.14,"submitted_datetime":"2019-03-28T05:37:37.291139+00:00","score_change":1,"report_status":"scored","team":"subt","y":2.0,"x":1.0,"z":3.0,"type":"backpack","id":9}'
Get Status
b'{"run_clock":25.98,"score":9000,"remaining_reports":6,"current_team":"subt"}'
```
