### PR TITLE
bus.py - fix replay with --force parameter

### DIFF
--- a/osgar/replay.py
+++ b/osgar/replay.py
@@ -76,6 +76,7 @@ if __name__ == "__main__":
     module_instance.start()
     # now wait until the module is alive
     module_instance.join()
-    print("maximum delay:", module_instance.bus.max_delay)
+    if not args.force:
+        print("maximum delay:", module_instance.bus.max_delay)
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Otherwise you get for replay with `-F` parameter:
```
Traceback (most recent call last):
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\runpy.py", line 193
, in _run_module_as_main
    "__main__", mod_spec)
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\runpy.py", line 85,
 in _run_code
    exec(code, run_globals)
  File "M:\git\osgar\osgar\replay.py", line 79, in <module>
    print("maximum delay:", module_instance.bus.max_delay)
AttributeError: 'LogBusHandlerInputsOnly' object has no attribute 'max_delay'
```