### PR TITLE
Bugfix/replay outputs

### DIFF
--- a/osgar/replay.py
+++ b/osgar/replay.py
@@ -41,16 +41,13 @@ def replay(args, application=None):
     for edge_from, edge_to in config['robot']['links']:
         if edge_to.split('.')[0] == module:
             inputs[1 + names.index(edge_from)] = edge_to.split('.')[1]
-    #print(inputs)
-
-    outputs = dict([(1 + names.index('.'.join([module, name])), name) for name in output_names])
-    #print(outputs)
 
     # start reading log from the beginning again
     if args.force:
         log = LogReader(args.logfile, only_stream_id=inputs.keys())
         bus = LogBusHandlerInputsOnly(log, inputs=inputs)
     else:
+        outputs = dict([(1 + names.index('.'.join([module, name])), name) for name in output_names])
         streams = list(inputs.keys()) + list(outputs.keys())
         log = LogReader(args.logfile, only_stream_id=streams)
         bus = LogBusHandler(log, inputs=inputs, outputs=outputs)

--- a/osgar/replay.py
+++ b/osgar/replay.py
@@ -70,9 +70,11 @@ if __name__ == "__main__":
     parser.add_argument('--force', '-F', dest='force', action='store_true', help='force replay even for failing output asserts')
     parser.add_argument('--config', nargs='+', help='force alternative configuration file')
     parser.add_argument('--module', help='module name for analysis', required=True)  # TODO default "all"
+    parser.add_argument('--verbose', '-v', help="verbose mode", action='store_true')
     args = parser.parse_args()
 
     module_instance = replay(args)
+    module_instance.verbose = args.verbose
 
     module_instance.start()
     # now wait until the module is alive


### PR DESCRIPTION
* support `--verbose` option as for launcher also for `osgar.replay`
* ignore outputs with `--force` option, so alternative config with different outputs can be replayed