### PR TITLE
SubT - test E-STOP master

### DIFF
--- a/config/subt-e-stop-windows-A24.json
+++ b/config/subt-e-stop-windows-A24.json
@@ -1,0 +1,23 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "estop": {
+          "driver": "estop:EStop",
+          "in": ["raw"],
+          "out": ["raw", "emergency_stop"],
+          "init": {
+            "master": true
+          }
+      },
+      "estop_serial": {
+          "driver": "serial",
+          "in": ["raw"],
+          "out": ["raw"],
+          "init": {"port": "COM31", "speed": 9600}
+      }
+    },
+    "links": [["estop_serial.raw", "estop.raw"],
+              ["estop.raw", "estop_serial.raw"]]
+  }
+}


### PR DESCRIPTION
Simple test with DARPA E-STOP. I used config "master": true to send the STOP. Tested with two devices and two terminals:
```
M:\git\osgar\examples\subt>python -m osgar.record ..\..\config\subt-e-stop-windo
ws.json --duration 30 --note "connected both, after reset, slave"
WARNING:root:Environment variable OSGAR_LOGS is not set - using working director
y
packet: 15 7e000b8801495300010002000000d7
packet: 15 7e000b8801495300010002000000d7
packet: 15 7e000b8801495300010002000000d7
packet: 15 7e000b8801495300010002000000d7
packet: 15 7e000b8801495300010002000000d7
packet: 15 7e000b8801495300010002000000d7
packet: 15 7e000b8801495300010002000000d7
packet: 15 7e000b8801495300010002000000d7
packet: 15 7e000b8801495300010002000000d7
packet: 15 7e000b8801495300010002000002d5
```
after that it "hangs", i.e. similar behavior as on STIX, but at least confirmed that XBee modules behave also as transmitters.