### PR TITLE
Feature/slot timestamp

### DIFF
--- a/osgar/bus.py
+++ b/osgar/bus.py
@@ -37,7 +37,7 @@ class BusHandler:
             for queue, input_channel in self.out[channel]:
                 queue.put((timestamp, input_channel, data))
             for slot in self.slots.get(channel, []):
-                slot(data)
+                slot(timestamp, data)
         return timestamp
 
     def listen(self):
@@ -81,7 +81,7 @@ class LogBusHandler:
             channel = self.inputs[stream_id]
             data = deserialize(bytes_data)
             if channel.startswith("slot_"):
-                getattr(self.node, channel)(data)
+                getattr(self.node, channel)(dt, data)
             else:
                 break
         return dt, channel, data
@@ -93,7 +93,7 @@ class LogBusHandler:
             input_name = self.inputs[stream_id]
             if input_name.startswith("slot_"):
                 data = deserialize(bytes_data)
-                getattr(self.node, input_name)(data)
+                getattr(self.node, input_name)(dt, data)
             else:
                 self.buffer_queue.append((dt, stream_id, bytes_data))
             dt, stream_id, bytes_data = next(self.reader)

--- a/osgar/bus.py
+++ b/osgar/bus.py
@@ -124,6 +124,8 @@ class LogBusHandlerInputsOnly:
         self.time = dt
         channel = self.inputs[stream_id]
         data = deserialize(bytes_data)
+        if channel.startswith("slot_"):
+            channel = channel[len('slot_'):]  # workaround for non-slot run
         return dt, channel, data
 
     def publish(self, channel, data):

--- a/osgar/drivers/canserial.py
+++ b/osgar/drivers/canserial.py
@@ -240,12 +240,12 @@ class CANSerial(Thread):
                 yield ret
             self.buf, packet = self.split_buffer(self.buf)  # i.e. process only existing buffer now
 
-    def slot_raw(self, data):
+    def slot_raw(self, timestamp, data):
         if len(data) > 0:
             for packet in self.process_gen(data):
                 self.bus.publish('can', packet)
 
-    def slot_can(self, data):
+    def slot_can(self, timestamp, data):
         if self.can_bridge_initialized:
             # at the moment is can serial just forwarding raw packets
             self.bus.publish('raw', data)
@@ -257,9 +257,9 @@ class CANSerial(Thread):
             while True:
                 dt, channel, data = self.bus.listen()
                 if channel == 'raw':
-                    self.slot_raw(data)
+                    self.slot_raw(dt, data)
                 elif channel == 'can':
-                    self.slot_can(data)
+                    self.slot_can(dt, data)
                 else:
                     assert False, channel  # unsupported input channel
         except BusShutdownException:

--- a/osgar/drivers/eduro.py
+++ b/osgar/drivers/eduro.py
@@ -206,13 +206,13 @@ class Eduro(Thread):
         self.process_packet(data)
         yield None
 
-    def slot_can(self, data):
+    def slot_can(self, timestamp, data):
         if len(data) > 0:
             for status in self.process_gen(data):
                 if status is not None:
                     self.bus.publish('can', status)  # TODO
 
-    def slot_desired_speed(self, data):
+    def slot_desired_speed(self, timestamp, data):
         self.desired_speed, self.desired_angular_speed = data[0]/1000.0, math.radians(data[1]/100.0)
 
     def run(self):
@@ -220,9 +220,9 @@ class Eduro(Thread):
             while True:
                 self.time, channel, data = self.bus.listen()
                 if channel == 'can':
-                    self.slot_can(data)
+                    self.slot_can(self.time, data)
                 elif channel == 'desired_speed':
-                    self.slot_desired_speed(data)
+                    self.slot_desired_speed(self.time, data)
                 else:
                     assert False, channel  # unsupported channel
         except BusShutdownException:

--- a/osgar/drivers/logserial.py
+++ b/osgar/drivers/logserial.py
@@ -43,14 +43,14 @@ class LogSerial:
             if len(data) > 0:
                 self.bus.publish('raw', data)
 
-    def slot_raw(self, data):
+    def slot_raw(self, timestamp, data):
         self.com.write(data)
 
     def run_output(self):
         try:
             while True:
-                __, __, data = self.bus.listen()
-                self.slot_raw(data)
+                dt, __, data = self.bus.listen()
+                self.slot_raw(dt, data)
         except BusShutdownException:
             pass
 


### PR DESCRIPTION
It was not possible to find out what is the time if slots were used - fixed as the first parameter. Tested on robot Kloubak. Also there was not possible to replay slots with -F option so there is a small workaround (not perfect but at least the functions are called).
I may squash all commits or keep them separately ...?