### PR TITLE
Implement Peak CAN driver

### DIFF
--- a/config/test-pcan.json
+++ b/config/test-pcan.json
@@ -1,0 +1,14 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "can": {
+          "driver": "pcan",
+          "in": ["can"],
+          "out": ["can"],
+          "init": {}
+      }
+    },
+    "links": []
+  }
+}

--- a/osgar/drivers/__init__.py
+++ b/osgar/drivers/__init__.py
@@ -17,5 +17,6 @@ all_drivers = dict(gps="osgar.drivers.gps:GPS"
     , usb="osgar.drivers.logusb:LogUSB"
     , replay="osgar.drivers.replay:ReplayDriver"
     , lordimu="osgar.drivers.lord_imu:LordIMU"
+    , pcan="osgar.drivers.pcan:PeakCAN"
 )
 

--- a/osgar/drivers/pcan.py
+++ b/osgar/drivers/pcan.py
@@ -1,0 +1,65 @@
+"""
+  Wrapper for PeakCAN USB device
+"""
+#
+# pip install python-can
+# https://python-can.readthedocs.io/en/2.1.0/interfaces/pcan.html
+#
+# https://www.peak-system.com/
+# https://www.peak-system.com/fileadmin/media/files/pcan-basic.zip
+# http://www.peak-system.com/quick/BasicLinux
+#
+# https://en.wikipedia.org/wiki/CAN_bus
+#
+# The new CAN messages will contain arbitration_id, data and flags
+#  http://docs.ros.org/melodic/api/can_msgs/html/msg/Frame.html
+#
+
+import struct
+
+import can
+from threading import Thread
+
+from osgar.bus import BusShutdownException
+
+IS_EXTENDED_ID_MASK = 0x1
+
+class PeakCAN:
+    def __init__(self, config, bus):
+        self.bus = bus
+        self.canbus = can.interface.Bus(bustype='pcan', channel='PCAN_USBBUS1', bitrate=500000)
+        self.input_thread = Thread(target=self.run_input, daemon=True)
+        self.output_thread = Thread(target=self.run_output, daemon=True)
+
+    def start(self):
+        self.input_thread.start()
+        self.output_thread.start()
+
+    def join(self, timeout=None):
+        self.input_thread.join(timeout=timeout)
+        self.output_thread.join(timeout=timeout)
+
+    def run_input(self):
+        while self.bus.is_alive():
+            msg = self.canbus.recv()  # TODO timeout
+            flags = IS_EXTENDED_ID_MASK if msg.is_extended_id else 0
+            self.bus.publish('can', [msg.arbitration_id, msg.data, flags])
+
+    def slot_raw(self, timestamp, packet):
+        arbitration_id, data, flags = packet
+        msg = can.Message(arbitration_id, data, is_extended_id=(flags & IS_EXTENDED_ID_MASK))
+        self.canbus.send(msg)  # TODO timeout, locks?!
+
+    def run_output(self):
+        try:
+            while True:
+                dt, __, data = self.bus.listen()
+                self.slot_raw(dt, data)
+        except BusShutdownException:
+            pass
+
+    def request_stop(self):
+        self.bus.shutdown()
+
+
+# vim: expandtab sw=4 ts=4


### PR DESCRIPTION
This is implementation of OSGAR Node for USB Peak CAN for Windows. It was used for data collection on robot Kloubak via
```
python -m osgar.record config\test-pcan.json --duration 10
```
And here is corresponding log: http://osgar.robotika.cz/test-pcan-190625_193434.log

The next plan is to use/test/create driver for Linux, and later replace OSGAR CAN messages with 3-tupple [address ID, data, flags].

Note, that only data collection was tested.