### PR TITLE
bus.py - introduce almost_equal() for replay of float data

### DIFF
--- a/osgar/bus.py
+++ b/osgar/bus.py
@@ -12,6 +12,19 @@ from osgar.lib.serialize import serialize, deserialize
 # restrict replay time from given input
 ASSERT_QUEUE_DELAY = timedelta(seconds=.1)
 
+def almost_equal(data, ref_data):
+    if isinstance(data, float) and isinstance(ref_data, float):
+        return abs(data - ref_data) < 1e-6
+    if isinstance(data, list) and isinstance(ref_data, list):
+        if len(data) != len(ref_data):
+            return False
+        for a, b in zip(data, ref_data):
+            if not(almost_equal(a, b)):
+                return False
+        return True
+    # default - use exact match
+    return data == ref_data
+
 
 class BusShutdownException(Exception):
     pass
@@ -106,7 +119,7 @@ class LogBusHandler:
             if delay > ASSERT_QUEUE_DELAY:
                 print("maximum delay overshot:", delay)
         ref_data = deserialize(bytes_data)
-        assert data == ref_data, (data, ref_data, dt)
+        assert almost_equal(data, ref_data), (data, ref_data, dt)
         return dt
 
     def sleep(self, secs):

--- a/osgar/test_bus.py
+++ b/osgar/test_bus.py
@@ -4,7 +4,8 @@ from queue import Queue
 from datetime import timedelta
 
 from osgar.bus import (BusHandler, BusShutdownException,
-                       LogBusHandler, LogBusHandlerInputsOnly)
+                       LogBusHandler, LogBusHandlerInputsOnly,
+                       almost_equal)
 
 from osgar.lib.serialize import serialize, deserialize
 
@@ -137,5 +138,15 @@ class BusHandlerTest(unittest.TestCase):
 
         bus = LogBusHandlerInputsOnly(logger, inputs={})
         bus.sleep(0.1)
+
+    def test_almost_equal(self):
+        self.assertTrue(almost_equal(-0.27335569599868276, -0.2733556959986828))
+        self.assertFalse(almost_equal(-0.27, 0.42))
+        self.assertTrue(almost_equal(
+            [[-0.27335569599868276, 2.625292235055242, -0.14962045778119396], [0.7263869464850868, 0.0064504746910471825, -0.007071867505754647, 0.6873936102882865]], 
+            [[-0.2733556959986828,  2.625292235055242, -0.14962045778119396], [0.7263869464850868, 0.0064504746910471825, -0.007071867505754647, 0.6873936102882865]]
+            ))
+        self.assertFalse(almost_equal([1.23], []))
+        self.assertFalse(almost_equal([-0.27], [0.42]))
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Workaround for issue with replay `subt.py` of `pose3d` containing lists of floats.