### PR TITLE
Reformat drivers/__init__.py

### DIFF
--- a/osgar/drivers/__init__.py
+++ b/osgar/drivers/__init__.py
@@ -1,22 +1,23 @@
 # dictionary of all available drivers
-all_drivers = dict(gps="osgar.drivers.gps:GPS"
-    , imu="osgar.drivers.imu:IMU"
-    , spider="osgar.drivers.spider:Spider"
-    , serial="osgar.drivers.logserial:LogSerial"
-    , can="osgar.drivers.canserial:CANSerial"
-    , simulator="osgar.drivers.simulator:SpiderSimulator"
-    , tcp="osgar.drivers.logsocket:LogTCPStaticIP"
-    , tcpdynamic="osgar.drivers.logsocket:LogTCPDynamicIP"
-    , tcpserver="osgar.drivers.logsocket:LogTCPServer"
-    , udp="osgar.drivers.logsocket:LogUDP"
-    , http="osgar.drivers.logsocket:LogHTTP"
-    , lidar="osgar.drivers.sicklidar:SICKLidar"
-    , eduro="osgar.drivers.eduro:Eduro"
-    , cortexpilot="osgar.drivers.cortexpilot:Cortexpilot"
-    , usb="osgar.drivers.logusb:LogUSB"
-    , replay="osgar.drivers.replay:ReplayDriver"
-    , lordimu="osgar.drivers.lord_imu:LordIMU"
-    , pcan="osgar.drivers.pcan:PeakCAN"
-    , kloubak="osgar.drivers.kloubak:RobotKloubak"
+all_drivers = dict(
+    gps="osgar.drivers.gps:GPS",
+    imu="osgar.drivers.imu:IMU",
+    spider="osgar.drivers.spider:Spider",
+    serial="osgar.drivers.logserial:LogSerial",
+    can="osgar.drivers.canserial:CANSerial",
+    simulator="osgar.drivers.simulator:SpiderSimulator",
+    tcp="osgar.drivers.logsocket:LogTCPStaticIP",
+    tcpdynamic="osgar.drivers.logsocket:LogTCPDynamicIP",
+    tcpserver="osgar.drivers.logsocket:LogTCPServer",
+    udp="osgar.drivers.logsocket:LogUDP",
+    http="osgar.drivers.logsocket:LogHTTP",
+    lidar="osgar.drivers.sicklidar:SICKLidar",
+    eduro="osgar.drivers.eduro:Eduro",
+    cortexpilot="osgar.drivers.cortexpilot:Cortexpilot",
+    usb="osgar.drivers.logusb:LogUSB",
+    replay="osgar.drivers.replay:ReplayDriver",
+    lordimu="osgar.drivers.lord_imu:LordIMU",
+    pcan="osgar.drivers.pcan:PeakCAN",
+    kloubak="osgar.drivers.kloubak:RobotKloubak",
 )
 


### PR DESCRIPTION
The comma at the beginning is probably not PEP8 and for example PyCharm
permanently reformates this file - hopefully fixed.