### PR TITLE
Add --gui and --margin, show area.

### DIFF
--- a/osgar/tools/log2apriltag.py
+++ b/osgar/tools/log2apriltag.py
@@ -14,6 +14,8 @@ def main():
     parser = argparse.ArgumentParser(description='')
     parser.add_argument('log', help='filepaths', nargs='+')
     parser.add_argument('--threads', help='how many threads to use', type=int, default=1)
+    parser.add_argument('--gui', help='show found tags', default=False, action='store_true')
+    parser.add_argument('--margin', help='apriltag decision margin threshold', default=30, type=int)
 
     args = parser.parse_args()
     detector = apriltag.apriltag('tag16h5', threads=args.threads)
@@ -41,11 +43,27 @@ def main():
                 np_jpeg = numpy.frombuffer(jpeg, dtype='u1')
                 gray = cv2.imdecode(np_jpeg, cv2.IMREAD_GRAYSCALE)
                 found = detector.detect(gray)
+                found = [tag for tag in found if tag['margin'] > args.margin and tag['hamming'] == 0]
                 if len(found) > 0:
-                    ids = list(tag['id'] for tag in found if tag['hamming'] == 0)
-                    if (len(ids) > 0):
-                        print(dt, end=' ')
-                        pprint(ids)
+                    ids = list(tag['id'] for tag in found)
+                    print(dt, end=' ')
+                    if args.gui:
+                        img = cv2.imdecode(np_jpeg, cv2.IMREAD_COLOR)
+                    for tag in found:
+                        rect = tag['lb-rb-rt-lt'].astype('float32')
+                        area = cv2.contourArea(rect)
+                        print('{:2d}: {{margin: {:3d}, area: {:4d}}}'.format(tag['id'], int(tag['margin']), int(area)), end=' ')
+                        center = tuple(tag['center'].astype(int))
+                        poly = rect.astype('int32')
+                        if args.gui:
+                            cv2.circle(img, center, 3, (0, 0 ,255), -1)
+                            cv2.polylines(img, [poly], True, (0, 255, 255), 3)
+                    print()
+                    if args.gui:
+                        cv2.imshow('image', img)
+                        key = cv2.waitKey(0)
+                        if key == 27:
+                            return
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
For eduro logs I recommend to run it with `2>/dev/null` to dump the `Corrupt JPEG data: 11 extraneous bytes before marker 0xd9` messages.

Continue to the next detection by pressing any key, exit by pressing `Esc`.