### PR TITLE
Bugfix/lora

### DIFF
--- a/osgar/drivers/lora.py
+++ b/osgar/drivers/lora.py
@@ -26,6 +26,7 @@ from osgar.node import Node
 from osgar.bus import BusShutdownException
 
 ALIVE_MESSAGE = b'alive'
+ALLOWED_DEVICE_IDS = [1, 2, 3, 4, 5]
 
 
 def parse_lora_packet(packet):
@@ -37,10 +38,13 @@ def parse_lora_packet(packet):
     """
     s = packet.split(b'|')
     try:
-        return [int(x) for x in s[:-1]], s[-1].strip()
+        addr, data = [int(x) for x in s[:-1]], s[-1].strip()
     except ValueError:
-        print('Invalid LoRa packet:', packet)
         return None, packet
+
+    if len(addr) < 1 or not min([a in ALLOWED_DEVICE_IDS for a in addr]):
+        return None, packet
+    return addr, data
 
 
 def split_lora_buffer(buf):

--- a/osgar/drivers/lora.py
+++ b/osgar/drivers/lora.py
@@ -59,6 +59,7 @@ class LoRa(Node):
         self.raw = b''  # should be defined by Node
         self.last_transmit = None
         self.recent_packets = []
+        self.verbose = False
 
     def send_data(self, data):
         self.last_transmit = self.publish('raw', data + b'\n')
@@ -68,14 +69,16 @@ class LoRa(Node):
         self.recent_packets = []
         channel = super().update()  # define self.time
         if channel == 'raw':
-            print(self.time, "update", channel, self.raw)
+            if self.verbose:
+                print(self.time, "update", channel, self.raw)
 
             self.buf, packet = split_lora_buffer(self.buf + self.raw)
             while len(packet) > 0:
                 self.recent_packets.append(packet)
                 addr, data = parse_lora_packet(packet)
                 if addr is not None and self.device_id is not None and self.device_id not in addr:
-                    print('re-transmit')
+                    if self.verbose:
+                        print('re-transmit')
                     self.send_data(packet.strip())  # re-transmit data from other robots
                 self.buf, packet = split_lora_buffer(self.buf)
 

--- a/osgar/drivers/test_lora.py
+++ b/osgar/drivers/test_lora.py
@@ -58,4 +58,17 @@ class LoRaTest(unittest.TestCase):
         c.join()
         self.assertEqual(c.device_id, 4)
 
+    def test_3rd_party_packet(self):
+        # there are internal debug messages and also 3rd party packets, which we definetely
+        # do not want to re-transmmit and process
+        # In particular there was a bug that missing '|' generated empty addr list
+        self.assertIsNone(parse_lora_packet(b'dhcps: send_off')[0])
+
+        self.assertIsNone(parse_lora_packet(b'0|data')[0])
+        self.assertIsNone(parse_lora_packet(b'6|data')[0])
+        self.assertIsNone(parse_lora_packet(b'42|data')[0])
+
+        # validate all addresses in chain
+        self.assertIsNone(parse_lora_packet(b'4|6|data')[0])
+
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
LoRa is widely used so it is possible that we receive also some 3rd party messages. There was a bug, that if packet did not contain any '|' it returned empty address list was thus it was re-transmitted. Now there is stronger restriction to format and return `None` as address if it does not fit.