### PR TITLE
artifacts.py - workaround for missing scan

### DIFF
--- a/subt/artifacts.py
+++ b/subt/artifacts.py
@@ -79,6 +79,8 @@ def count_yellow(img):
 
 def artf_in_scan(scan, img_x_min, img_x_max, verbose=False):
     """return precise artefact angle and distance for lidar & camera combination"""
+    if scan is None:
+        return 0, 0
     # the scan is already in mm, so angle is modified to int deg*100, ready to send
     x_min, x_max = img_x_min, img_x_max
 

--- a/subt/test_artifacts.py
+++ b/subt/test_artifacts.py
@@ -94,5 +94,9 @@ class ArtifactDetectorTest(unittest.TestCase):
         img = cv2.imread(str(curdir/'test_data/artf-electrical-box.jpg'))
         #self.assertEqual(count_white(img), (865248, 1266, 959, 0, 1266))
 
+    def test_missing_scan(self):
+        deg_100th, dist_mm = artf_in_scan(scan=None, img_x_min=100, img_x_max=200)
+        self.assertEqual((deg_100th, dist_mm), (0, 0))
+
 # vim: expandtab sw=4 ts=4
 


### PR DESCRIPTION
It is still valuable to have info, that in particular image an artifact was detected. It is position
is ignored and set to (0, 0).