### PR TITLE
Remove flush inside LogWriter.write.

### DIFF
--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -88,7 +88,6 @@ class LogWriter:
             self.f.write(struct.pack('IHH', time_frac,
                          stream_id, len(bytes_data) - index))
             self.f.write(bytes_data[index:])
-            self.f.flush()
         return dt
 
     def close(self):


### PR DESCRIPTION
The flush guards us against hard python crashes (segfaults) but our overall
aim is to run segfault free. Flushing the internal python cashes disables
any write-combining python might be able to do for us, thus leaving a lot
of disk throughput on the table, especially for small writes.