### PR TITLE
Use trio instead of threading.Thread

### DIFF
--- a/config/test-opencv-camera.json
+++ b/config/test-opencv-camera.json
@@ -3,9 +3,9 @@
   "robot": {
     "modules": {
       "camera": {
-          "driver": "osgar.drivers.opencv:LogOpenCVCamera",
+          "driver": "osgar.drivers.opencv:opencv",
           "in": [],
-          "out": ["raw"],
+          "out": ["jpg"],
           "init": {
               "port": 0,
               "sleep": 1.0

--- a/osgar/drivers/__init__.py
+++ b/osgar/drivers/__init__.py
@@ -24,6 +24,6 @@ all_drivers = dict(
     rosmsg="osgar.drivers.rosmsg:ROSMsgParser",
     lora="osgar.drivers.lora:LoRa",
     vesc="osgar.drivers.vesc:MotorDriverVESC",
-    opencv="osgar.drivers.opencv:LogOpenCVCamera",
+    opencv="osgar.drivers.opencv:opencv",
 )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ pyserial==3.4
 msgpack==0.5.6
 pyusb==1.0.2
 opencv-python==3.4.5.20
-requests==2.22.0
+requests==2.22.0 # subt/report_artf.py


### PR DESCRIPTION
First try on using [trio](https://trio.readthedocs.io/) (shown on opencv camera driver).

What works (anything else most likely does not):

- `python -m osgar.drivers.opencv`
- `python -m osgar.record config/test-opencv-camera.json --duration 3`.

For context see 

- https://vorpus.org/blog/notes-on-structured-concurrency-or-go-statement-considered-harmful/
- https://www.youtube.com/watch?v=i-R704I8ySE

To wrap up - trio is a python library to make concurrent programming easy. The tasks don't run in parallel, but do run concurrently. The idea is to get rid of `threading.Thread` and replace them with trio tasks. The end result should be a single threaded run with minimal overhead, hopefully resulting in improved latency, thus obliterating the need for a slot-like solution.

To understand the code I suggest looking at the actual resulting code - the diff is fairly large and it seems somewhat confusing at first sight.