### PR TITLE
Move `application` handling from `record` to `config.load`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ python:
     - "3.6"
     - "3.7"
 script:
-    - python -m unittest discover subt
-    - python -m unittest discover osgar
+    - python -m unittest discover --top-level-directory . --start-directory subt
+    - python -m unittest discover --top-level-directory . --start-directory osgar
 branches:
   only:
     - master

--- a/examples/sick2018/sick2018.py
+++ b/examples/sick2018/sick2018.py
@@ -25,7 +25,7 @@ from osgar.lib.config import config_load
 from osgar.lib.mathex import normalizeAnglePIPI
 from osgar.record import Recorder
 
-from scan_feature import detect_box, detect_transporter
+from .scan_feature import detect_box, detect_transporter
 
 
 # TODO shared place for multiple applications
@@ -290,7 +290,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     if args.command == 'replay':
-        from replay import replay
+        from osgar.replay import replay
         args.module = 'app'
         game = replay(args, application=SICKRobot2018)
         game.verbose = args.verbose
@@ -298,9 +298,9 @@ if __name__ == "__main__":
 
     elif args.command == 'run':
         with LogWriter(prefix='eduro-', note=str(sys.argv)) as log:
-            config = config_load(*args.config)
+            config = config_load(*args.config, application=SICKRobot2018)
             log.write(0, bytes(str(config), 'ascii'))  # write configuration
-            robot = Recorder(config=config['robot'], logger=log, application=SICKRobot2018)
+            robot = Recorder(config=config['robot'], logger=log)
             game = robot.modules['app']  # TODO nicer reference
             robot.start()
             game.play()

--- a/osgar/go.py
+++ b/osgar/go.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
 
     elif args.command == 'run':
         prefix = 'go-' + os.path.basename(args.config[0]).split('.')[0] + '-'
-        config = config_load(*args.config)
+        config = config_load(*args.config, application=Go)
 
         # apply overrides from command line
         config['robot']['modules']['app']['init']['dist'] = args.dist
@@ -100,7 +100,7 @@ if __name__ == "__main__":
 
         with LogWriter(prefix=prefix, note=str(sys.argv)) as log:
             log.write(0, bytes(str(config), 'ascii'))  # write configuration
-            robot = Recorder(config=config['robot'], logger=log, application=Go)
+            robot = Recorder(config=config['robot'], logger=log)
             game = robot.modules['app']
             robot.start()
             game.join()

--- a/osgar/lib/test_config.py
+++ b/osgar/lib/test_config.py
@@ -54,5 +54,13 @@ class ConfigTest(unittest.TestCase):
         node = get_class_by_name('udp')
         self.assertNotEqual(node, LogTCP)
 
+    def test_application(self):
+        conf_dir = '../../config'
+        filename = test_data('ro2018-spider-gps-imu.json', conf_dir)
+        conf = config_load(filename, application=MyTestRobot)
+        self.assertTrue(conf['robot']['modules']['app']['driver'].endswith('lib.test_config:MyTestRobot'))
+        conf = config_load(filename, application='osgar.lib.test_config:MyTestRobot')
+        self.assertTrue(conf['robot']['modules']['app']['driver'].endswith('lib.test_config:MyTestRobot'))
+
 # vim: expandtab sw=4 ts=4
 

--- a/osgar/replay.py
+++ b/osgar/replay.py
@@ -18,7 +18,7 @@ def replay(args, application=None):
     config_str = next(log)[-1]
     config = literal_eval(config_str.decode('ascii'))
     if args.config is not None:
-        config = config_load(*args.config)
+        config = config_load(*args.config, application=application)
 
     names = logger.lookup_stream_names(args.logfile)
     print("stream names:")
@@ -53,11 +53,7 @@ def replay(args, application=None):
         bus = LogBusHandler(log, inputs=inputs, outputs=outputs)
 
     driver_name = module_config['driver']
-    if driver_name == 'application':
-        assert application is not None
-        module_class = application
-    else:
-        module_class = get_class_by_name(driver_name)
+    module_class = get_class_by_name(driver_name)
     module_instance = module_class(module_config['init'], bus=bus)
     bus.node = module_instance
     return module_instance

--- a/osgar/ro2018.py
+++ b/osgar/ro2018.py
@@ -227,9 +227,9 @@ if __name__ == "__main__":
 
     elif args.command == 'run':
         with LogWriter(prefix='ro2018-', note=str(sys.argv)) as log:
-            config = config_load(*args.config)
+            config = config_load(*args.config, application=RoboOrienteering2018)
             log.write(0, bytes(str(config), 'ascii'))  # write configuration
-            robot = Recorder(config=config['robot'], logger=log, application=RoboOrienteering2018)
+            robot = Recorder(config=config['robot'], logger=log)
             app = robot.modules['app']  # TODO nicer reference
             robot.start()
             app.play()

--- a/osgar/test_record.py
+++ b/osgar/test_record.py
@@ -68,17 +68,5 @@ class RecorderTest(unittest.TestCase):
                     config = json.loads(f.read())
                 recorder = Recorder(config=config['robot'], logger=logger)
 
-    def test_application(self):
-        # plug-in external application
-        with open(os.path.dirname(__file__) + '/../config/ro2018-spider-gps-imu.json') as f:
-            config = json.loads(f.read())
-
-        class DummyApp:
-            def __init__(self, config, bus):
-                self.bus = bus  # needed for linkage
-
-        with patch('osgar.drivers.logserial.serial.Serial') as mock:
-            logger = MagicMock()
-            recorder = Recorder(config=config['robot'], logger=logger, application=DummyApp)
 
 # vim: expandtab sw=4 ts=4

--- a/osgar/turn.py
+++ b/osgar/turn.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
 
     elif args.command == 'run':
         prefix = 'turn-' + os.path.basename(args.config[0]).split('.')[0] + '-'
-        config = config_load(*args.config)
+        config = config_load(*args.config, application=Turn)
 
         # apply overrides from command line
         config['robot']['modules']['app']['init']['angle_deg'] = args.angle
@@ -122,7 +122,7 @@ if __name__ == "__main__":
 
         with LogWriter(prefix=prefix, note=str(sys.argv)) as log:
             log.write(0, bytes(str(config), 'ascii'))  # write configuration
-            robot = Recorder(config=config['robot'], logger=log, application=Turn)
+            robot = Recorder(config=config['robot'], logger=log)
             game = robot.modules['app']
             robot.start()
             game.join()

--- a/subt/main.py
+++ b/subt/main.py
@@ -618,7 +618,7 @@ def main():
 
         # support simultaneously multiple platforms
         prefix = os.path.basename(args.config[0]).split('.')[0] + '-'
-        config = config_load(*args.config)
+        config = config_load(*args.config, application=SubTChallenge)
 
         # apply overrides from command line
         config['robot']['modules']['app']['init']['walldist'] = args.walldist
@@ -629,7 +629,7 @@ def main():
 
         with LogWriter(prefix=prefix, note=str(sys.argv)) as log:
             log.write(0, bytes(str(config), 'ascii'))  # write configuration
-            robot = Recorder(config=config['robot'], logger=log, application=SubTChallenge)
+            robot = Recorder(config=config['robot'], logger=log)
             app = robot.modules['app']  # TODO nicer reference
             robot.start()
             app.play()


### PR DESCRIPTION
With this change any module (including the application) can be replayed
using generic `replay` facility (one step closer to unified launcher).

Fixes #251 