### PR TITLE
Refactor Bus API

### DIFF
--- a/osgar/drivers/cortexpilot.py
+++ b/osgar/drivers/cortexpilot.py
@@ -27,6 +27,7 @@ def sint32_diff(a, b):
 class Cortexpilot(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
+        bus.register('raw', 'encoders', 'emergency_stop', 'pose2d', 'buttons')
 
         self._buf = b''
 

--- a/osgar/drivers/eduro.py
+++ b/osgar/drivers/eduro.py
@@ -33,6 +33,7 @@ def CAN_triplet(msg_id, data):
 
 class Eduro(Thread):
     def __init__(self, config, bus):
+        bus.register('can', 'buttons', 'voltage', 'emergency_stop', 'encoders', 'pose2d')
         Thread.__init__(self)
         self.setDaemon(True)
 

--- a/osgar/drivers/gps.py
+++ b/osgar/drivers/gps.py
@@ -113,6 +113,7 @@ def split_buffer(data):
 
 class GPS(Thread):
     def __init__(self, config, bus):
+        bus.register('position')
         Thread.__init__(self)
         self.setDaemon(True)
 

--- a/osgar/drivers/imu.py
+++ b/osgar/drivers/imu.py
@@ -33,6 +33,7 @@ def parse_line(line):
 
 class IMU(Thread):
     def __init__(self, config, bus):
+        bus.register('orientation', 'rotation')
         Thread.__init__(self)
         self.setDaemon(True)
 

--- a/osgar/drivers/logserial.py
+++ b/osgar/drivers/logserial.py
@@ -11,6 +11,7 @@ from osgar.bus import BusShutdownException
 
 class LogSerial:
     def __init__(self, config, bus):
+        bus.register('raw')
         self.input_thread = Thread(target=self.run_input, daemon=True)
         self.output_thread = Thread(target=self.run_output, daemon=True)
 

--- a/osgar/drivers/lora.py
+++ b/osgar/drivers/lora.py
@@ -96,6 +96,7 @@ def draw_lora_positions(arr):
 class LoRa(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
+        bus.register('raw', 'cmd')
         self.device_id = config.get('device_id')  # None for "autodetect"
         self.init_sleep = config.get('sleep')  # needed for Windows on start
         self.min_transmit_dt = timedelta(seconds=10)  # TODO config?

--- a/osgar/drivers/lord_imu.py
+++ b/osgar/drivers/lord_imu.py
@@ -151,6 +151,7 @@ def parse_packet(packet, verbose=False):
 class LordIMU(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
+        bus.register('orientation', 'rotation')
         self._buf = b''
         self.raw = None  # not automatically defined yet
         self.verbose = False

--- a/osgar/drivers/rosproxy.py
+++ b/osgar/drivers/rosproxy.py
@@ -65,6 +65,7 @@ class MyXMLRPCServer(Thread):
 
 class ROSProxy(Thread):
     def __init__(self, config, bus):
+        bus.register('cmd_vel', 'imu_data', 'imu_data_addr')
         global NODE_PORT, PUBLISH_PORT
         Thread.__init__(self)
         self.setDaemon(True)

--- a/osgar/drivers/sicklidar.py
+++ b/osgar/drivers/sicklidar.py
@@ -14,6 +14,7 @@ ETX = b'\x03'
 
 class SICKLidar(Thread):
     def __init__(self, config, bus):
+        bus.register('raw', 'scan')
         Thread.__init__(self)
         self.setDaemon(True)
 

--- a/osgar/drivers/spider.py
+++ b/osgar/drivers/spider.py
@@ -22,6 +22,7 @@ def CAN_packet(msg_id, data):
 
 class Spider(Thread):
     def __init__(self, config, bus):
+        bus.register('can', 'status')
         Thread.__init__(self)
         self.setDaemon(True)
 

--- a/osgar/drivers/test_imu.py
+++ b/osgar/drivers/test_imu.py
@@ -2,12 +2,13 @@ import unittest
 from unittest.mock import MagicMock
 
 from osgar.drivers.imu import parse_line, IMU
-from osgar.bus import BusHandler
+from osgar.bus import Bus
 
 
 class IMUTest(unittest.TestCase):
 
     nmea_line = b'$VNYMR,-095.878,+008.933,-009.419,+00.1785,+00.1474,+00.5479,+00.252,-03.706,-03.874,-01.012502,-00.234810,+00.247165*66'
+    orientation = [[-95.878, 8.933, -9.419], [0.1785, 0.1474, 0.5479], [0.252, -3.706, -3.874], [-1.012502, -0.23481, 0.247165]]
 
     def test_parse_line(self):
         # (yaw, pitch, roll), (magx, y, z), (accx, y, z), (gyrox, y, z)
@@ -16,10 +17,8 @@ class IMUTest(unittest.TestCase):
     def test_start_stop(self):
         config = {}
         logger = MagicMock()
-        bus = BusHandler(logger, 
-                         out={'orientation':[], 'rotation':[]},
-                         name='imu')
-        imu = IMU(config, bus=bus)
+        bus = Bus(logger)
+        imu = IMU(config, bus=bus.handle('imu'))
         imu.start()
         imu.request_stop()
         imu.join()
@@ -27,15 +26,22 @@ class IMUTest(unittest.TestCase):
     def test_processing(self):
         config = {}
         logger = MagicMock()
-        robot_bus = BusHandler(logger, out={}, name='robot')
-        bus = BusHandler(logger,
-                         out={'orientation':[(robot_bus.queue, 'orientation')], 'rotation':[]},
-                         name='imu')
-        imu = IMU(config, bus=bus)
+        logger.write = MagicMock(return_value=135)
+        bus = Bus(logger)
+        #robot_bus = BusHandler(logger, out={}, name='robot')
+        #bus = BusHandler(logger,
+        #                 out={'orientation':[(robot_bus.queue, 'orientation')], 'rotation':[]},
+        #                 name='imu')
+        imu = IMU(config, bus=bus.handle('imu'))
+        tester = bus.handle('tester')
+        tester.register('raw')
+        bus.connect('tester.raw', 'imu.raw')
+        bus.connect('imu.orientation', 'tester.orientation')
         imu.start()
-        imu.bus.queue.put((123, 'raw', self.nmea_line))
-        data = robot_bus.listen()
+        tester.publish('raw', self.nmea_line)
         imu.request_stop()
         imu.join()
+        tester.shutdown()
+        self.assertEqual(tester.listen(), (135, 'orientation', self.orientation))
 
 # vim: expandtab sw=4 ts=4

--- a/osgar/drivers/test_logserial.py
+++ b/osgar/drivers/test_logserial.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch, MagicMock
 
 from osgar.drivers.logserial import LogSerial
-from osgar.bus import BusHandler
+from osgar.bus import Bus
 
 
 class LogSerialTest(unittest.TestCase):
@@ -12,10 +12,13 @@ class LogSerialTest(unittest.TestCase):
             instance = mock.return_value
 
             logger = MagicMock()
-            bus = BusHandler(logger)
+            bus = Bus(logger)
             config = {'port':'COM13:', 'speed':4800}
-            device = LogSerial(config=config, bus=bus)
-            bus.queue.put((1, 2, b'bin data'))
+            device = LogSerial(config=config, bus=bus.handle('serial'))
+            tester = bus.handle('tester')
+            tester.register('raw')
+            bus.connect('tester.raw', 'serial.raw')
+            tester.publish('raw', b'bin data')
             device.start()
             device.request_stop()
             device.join()

--- a/osgar/drivers/test_logsocket.py
+++ b/osgar/drivers/test_logsocket.py
@@ -48,8 +48,9 @@ class LogSocketTest(unittest.TestCase):
     def test_tcp_server(self):
         with patch('osgar.drivers.logsocket.socket.socket') as mock:
             instance = mock.return_value
-            instance.accept = MagicMock(return_value=('127.0.0.1', 1234))
-            instance.recv = MagicMock(return_value=b'some bin data')
+            accept = MagicMock()
+            accept.recv = MagicMock(return_value=b'some bin data')
+            instance.accept = MagicMock(return_value=(accept, ('127.0.0.1', 1234)))
 
             logger = MagicMock()
             bus = Bus(logger)
@@ -59,11 +60,14 @@ class LogSocketTest(unittest.TestCase):
             bus.connect('tcp.raw', 'tester.raw')
 
             device.start()
+            tester.listen()
             device.request_stop()
             device.join()
 
             instance.listen.assert_called_once_with(1)
             instance.bind.assert_called_once_with(('192.168.1.2', 8080))
+            instance.accept.assert_called_once_with()
+            accept.recv.assert_called_with(device.bufsize)
 
     def test_dynamic_tcp(self):
         with patch('osgar.drivers.logsocket.socket.socket') as mock:

--- a/osgar/drivers/test_lord_imu.py
+++ b/osgar/drivers/test_lord_imu.py
@@ -3,7 +3,7 @@ import datetime
 from unittest.mock import MagicMock
 
 from osgar.drivers.lord_imu import get_packet, verify_checksum, parse_packet, LordIMU
-from osgar.bus import BusHandler
+from osgar.bus import Bus
 
 
 SAMPLE_DATA = b'\x0e\x06=\xea\x01\x19>\xc3R\xd2>\xdb?V\x1e\x93ue\x80*\x0e\x04<\x87C\x97\xbdF%\xd4\xbf\x7f\xb4\x14\x0e\x05\xba.\xd6S\xba)b\xeb\xb9\xf6\xf7\x80\x0e\x06=\xeaD\x10>\xc3\\\xd5>\xdb4\x1d\xda\x04ue\x80*\x0e\x04<\x9d\x1c\xa3\xbdS\x19\xd9\xbf\x7f\xbc^\x0e\x05\xbas\xd7W\xb9\x15\x03\xa0\xbaD\xffc\x0e\x06=\xea'
@@ -35,20 +35,18 @@ class LordIMUTest(unittest.TestCase):
         # ping         7565 0102 0201 E0C6
 
     def test_node(self):
-        config = {}
-#        q = MagicMock()
         logger = MagicMock()
-        robot_bus = BusHandler(logger, out={}, name='robot')
-        bus = BusHandler(logger,
-                         out={'orientation':[(robot_bus.queue, 'orientation')], 'rotation':[]},
-                         name='imu')
-        imu = LordIMU(config, bus=bus)
+        bus = Bus(logger)
+        tester = bus.handle('tester')
+        tester.register('raw')
+        imu = LordIMU(config={}, bus=bus.handle('lord'))
+        bus.connect('tester.raw', 'lord.raw')
         imu.start()
-        imu.bus.queue.put((123, 'raw', SAMPLE_DATA))
+        tester.publish('raw', SAMPLE_DATA)
         imu.request_stop()
         imu.join()
         self.assertEqual(imu.raw, SAMPLE_DATA)
-#        q.put.assert_called_once_with((135, 'raw', 
+#        q.put.assert_called_once_with((135, 'raw',
 #            b'\x00\x00\x03\x01\x01\xfb'))
 
     def test_parse_gps(self):

--- a/osgar/drivers/test_rosproxy.py
+++ b/osgar/drivers/test_rosproxy.py
@@ -6,7 +6,7 @@ import os
 from xmlrpc.server import SimpleXMLRPCServer
 
 from osgar.drivers.rosproxy import ROSProxy, prefix4BytesLen
-from osgar.bus import BusHandler
+from osgar.bus import Bus
 
 
 # TODO refactor into common testing code
@@ -78,8 +78,7 @@ class ROSProxyTest(unittest.TestCase):
 
     def test_usage(self):
         logger = MagicMock()
-        bus = BusHandler(logger, out={'cmd_vel':[], 'imu_data':[],
-                                      'imu_data_addr':[]})
+        bus = Bus(logger)
         config = {
                 'ros_master_uri': 'http://127.0.0.1:11311',
                 'ros_client_uri': 'http://127.0.0.1:8000',
@@ -92,7 +91,7 @@ class ROSProxyTest(unittest.TestCase):
                 }
 
         master = DummyROSMaster(('127.0.0.1', 11311))
-        proxy = ROSProxy(config=config, bus=bus)
+        proxy = ROSProxy(config=config, bus=bus.handle('ros'))
         with GlobalExceptionWatcher():
             proxy.start()
             proxy.request_stop()

--- a/osgar/drivers/test_sicklidar.py
+++ b/osgar/drivers/test_sicklidar.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from osgar.drivers.sicklidar import SICKLidar
-from osgar.bus import BusHandler
+from osgar.bus import Bus
 
 
 class SICKLidarTest(unittest.TestCase):
@@ -10,8 +10,8 @@ class SICKLidarTest(unittest.TestCase):
     def test_start_stop(self):
         config = {}
         logger = MagicMock()
-        bus = BusHandler(logger, out={'raw':[], 'scan':[]}, name='lidar')
-        lidar = SICKLidar(config, bus=bus)
+        bus = Bus(logger)
+        lidar = SICKLidar(config, bus=bus.handle('lidar'))
         lidar.start()
         lidar.request_stop()
         lidar.join()
@@ -62,12 +62,12 @@ A 130 135 134 13D 138 134 131 131 12C 12A 128 128 126 11B 11C 113 11B 10E 2 2 2
     def test_sleep(self):
         config = {}
         logger = MagicMock()
-        bus = BusHandler(logger, out={'raw':[], 'scan':[]}, name='lidar')
-        lidar = SICKLidar(config, bus=bus)
+        bus = Bus(logger)
+        lidar = SICKLidar(config, bus=bus.handle('lidar'))
         self.assertIsNone(lidar.sleep)
 
         config = {"sleep": 0.1}
-        lidar = SICKLidar(config, bus=bus)
+        lidar = SICKLidar(config, bus=bus.handle('lidar'))
         self.assertAlmostEqual(lidar.sleep, 0.1)
 
     def test_empty_scan(self):
@@ -82,8 +82,8 @@ A 130 135 134 13D 138 134 131 131 12C 12A 128 128 126 11B 11C 113 11B 10E 2 2 2
                 'mask': [1, -1]
                 }
         logger = MagicMock()
-        bus = BusHandler(logger, out={'raw':[], 'scan':[]}, name='lidar')
-        lidar = SICKLidar(config, bus=bus)
+        bus = Bus(logger)
+        lidar = SICKLidar(config, bus=bus.handle('lidar'))
 
         scan = [123] * 270
         masked_scan = lidar.apply_mask(scan)
@@ -97,8 +97,8 @@ A 130 135 134 13D 138 134 131 131 12C 12A 128 128 126 11B 11C 113 11B 10E 2 2 2
                 'blind_zone': 10
                 }
         logger = MagicMock()
-        bus = BusHandler(logger, out={'raw':[], 'scan':[]}, name='lidar')
-        lidar = SICKLidar(config, bus=bus)
+        bus = Bus(logger)
+        lidar = SICKLidar(config, bus=bus.handle('lidar'))
 
         scan = [123] * 269 + [2]
         masked_scan = lidar.apply_mask(scan)

--- a/osgar/drivers/test_spider.py
+++ b/osgar/drivers/test_spider.py
@@ -2,8 +2,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from osgar.drivers.spider import Spider, CAN_packet
-from osgar.bus import BusHandler
-
+from osgar.bus import Bus
 
 class SpiderTest(unittest.TestCase):
 
@@ -26,16 +25,24 @@ class SpiderTest(unittest.TestCase):
 #        bus.write.assert_called_once_with(0, 'ERROR: CAN bridge not initialized yet! [(0, 0)]')
 
     def test_publish_status(self):
-        q = MagicMock()
         logger=MagicMock()
         logger.write = MagicMock(return_value=135)
-        bus = BusHandler(logger=logger, out={'status':[(q, 'status'),], 'can':[]})
-        spider = Spider(config={}, bus=bus)
+        bus = Bus(logger=logger)
+        tester = bus.handle('tester')
+        tester.register('raw')
+        spider = Spider(config={}, bus=bus.handle('spider'))
+        bus.connect('tester.raw', 'spider.raw')
+        bus.connect('spider.status', 'tester.status')
+
         spider.can_bridge_initialized = True  # skip initialization
         self.assertEqual(CAN_packet(0x200, [0, 0x80]), b'@\x02\x00\x80')
-        bus.queue.put((123, 'raw', b'@\x02\x00\x80'))
-        bus.shutdown()
-        spider.run()
-        q.put.assert_called_once_with((135, 'status', ([0x8000, None])))
+        tester.publish('raw', b'@\x02\x00\x80')
+        spider.start()
+        dt, stream, data = tester.listen()
+        spider.request_stop()
+        spider.join()
+        self.assertEqual(dt, 135)
+        self.assertEqual(stream, 'status')
+        self.assertEqual(data, ([0x8000, None]))
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Our Bus API was very leaky abstraction. All tests were touching directly the insides of BusHandler so it was nearly impossible to refactor the implementation without editing all of the tests.

This PR introduces new API aimed at fixing the problem with the leaking abstraction. For example usage please see

https://github.com/robotika/osgar/blob/da62ba8bb0aeec9752379d8b8b6a442791cc7ddb/osgar/record.py#L21-L27

or any of the refactored test cases.

While I was going over the test cases anyway, I fixed also #161 . Oh, and I nuked the `tcp_point_data` compression. Is it still used somewhere?

I realize it is fairly large changeset but it should leave us better prepared for the future (without it, there is no chance to try `trio` for example as that requires adjustments to the bus implementation).