### PR TITLE
Feature/k2 constants config

### DIFF
--- a/config/kloubak2-subt-estop-lora.json
+++ b/config/kloubak2-subt-estop-lora.json
@@ -10,7 +10,12 @@
             "symmetric": true,
             "max_speed": 0.5,
             "virtual_bumper_sec": 10.0,
-            "virtual_bumper_radius": 0.5
+            "virtual_bumper_radius": 0.5,
+            "wheel_distance": 0.496,
+            "center_axle_distance": 0.348,
+            "ad_center": 419.7,
+            "ad_calibration_deg": 45,
+            "ad_range": -182.5
           }
       },
       "detector": {


### PR DESCRIPTION
Size and joint constants are moved to the config file. Used simple way through global variables (backward compatibility). It is applied on "config/kloubak2-subt-estop-lora.jso" only. What about other configs?