### PR TITLE
lora.py - fix hacked state to be bytes instead of str

### DIFF
--- a/osgar/drivers/lora.py
+++ b/osgar/drivers/lora.py
@@ -126,7 +126,7 @@ class LoRa(Node):
                 addr, data = parse_lora_packet(packet)
                 if addr is not None and data.startswith(b'['):
                     pose2d = literal_eval(data.decode('ascii'))
-                    self.publish('robot_status', [addr[-1], pose2d, 'running'])
+                    self.publish('robot_status', [addr[-1], pose2d, b'running'])  # TODO read it from robot
                     if self.verbose:
                         self.debug_robot_poses.append((self.time.total_seconds(), addr[-1], pose))
                 cmd = parse_my_cmd(self.device_id, data)


### PR DESCRIPTION
```
M:\git\osgar>python subt\control_center_qt.py
WARNING:root:Environment variable OSGAR_LOGS is not set - using working director
y
Running self-detection... waiting for b'alive-281016'
recording started
pause mission
Exception in thread Thread-4:
Traceback (most recent call last):
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\threading.py", line
 916, in _bootstrap_inner
    self.run()
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\threading.py", line
 864, in run
    self._target(*self._args, **self._kwargs)
  File "M:\git\osgar\subt\control_center_qt.py", line 202, in run
    self.view.robot_status.emit(robot_id, pose2d, status)
TypeError: View.robot_status[int, list, bytes].emit(): argument 3 has unexpected
 type 'str'
```