### PR TITLE
bus.py - no_output and compressed_output

### DIFF
--- a/osgar/lib/serialize.py
+++ b/osgar/lib/serialize.py
@@ -2,12 +2,25 @@
   serialization of messages
 """
 import msgpack
+import zlib
+
+MSGPACK_ZLIB_CODE = 42
 
 
-def serialize(data):
+def serialize(data, compress=False):
+    if compress:
+        packed_data = zlib.compress(msgpack.packb(data, use_bin_type=True))
+        return msgpack.packb(msgpack.ExtType(MSGPACK_ZLIB_CODE, packed_data), use_bin_type=True)
+
     return msgpack.packb(data, use_bin_type=True)
 
 
 def deserialize(bytes_data):
-    return msgpack.unpackb(bytes_data, raw=False)
+    data = msgpack.unpackb(bytes_data, raw=False)
+    if isinstance(data, msgpack.ExtType):
+        assert data.code == MSGPACK_ZLIB_CODE, data.code
+        data = zlib.decompress(data.data)
+        data = msgpack.unpackb(data, raw=False)
+    return data
 
+# vim: expandtab sw=4 ts=4

--- a/osgar/lib/test_serialize.py
+++ b/osgar/lib/test_serialize.py
@@ -1,14 +1,24 @@
 import unittest
 
-from osgar.lib.serialize import serialize
+from osgar.lib.serialize import serialize, deserialize
 
 
 class SerializeTest(unittest.TestCase):
 
     def test_serialization(self):
-            self.assertEqual(serialize(b'\x01\x02'), b'\xc4\x02\x01\x02')
-            position = (51749517, 180462688)
-            self.assertEqual(serialize(position), b'\x92\xce\x03\x15\xa2\x8d\xce\n\xc1\xa4`')
-            self.assertEqual(serialize((123.4, 'Hi')), b'\x92\xcb@^\xd9\x99\x99\x99\x99\x9a\xa2Hi')
+        self.assertEqual(serialize(b'\x01\x02'), b'\xc4\x02\x01\x02')
+        position = (51749517, 180462688)
+        self.assertEqual(serialize(position), b'\x92\xce\x03\x15\xa2\x8d\xce\n\xc1\xa4`')
+        self.assertEqual(serialize((123.4, 'Hi')), b'\x92\xcb@^\xd9\x99\x99\x99\x99\x9a\xa2Hi')
+
+    def test_packed_data(self):
+        data = [0]*1000
+        packet = serialize(data)
+        self.assertEqual(len(packet), 1003)
+        self.assertEqual(deserialize(packet), data)
+
+        compressed_packet = serialize(data, compress=True)
+        self.assertEqual(len(compressed_packet), 22)
+        self.assertEqual(deserialize(compressed_packet), data)
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
- controlled via names with suffix :null and :gz