### PR TITLE
Feature/lora report artifact

### DIFF
--- a/config/eduro-subt-estop-lora-wifi.json
+++ b/config/eduro-subt-estop-lora-wifi.json
@@ -154,6 +154,7 @@
               ["lora_serial.raw", "lora.raw"],
               ["lora.raw", "lora_serial.raw"],
               ["app.pose2d", "lora.pose2d"],
-              ["lora.cmd", "app.cmd"]]
+              ["lora.cmd", "app.cmd"],
+              ["app.artf_xyz", "lora.artf"]]
   }
 }

--- a/config/eduro-subt-estop-lora.json
+++ b/config/eduro-subt-estop-lora.json
@@ -146,6 +146,7 @@
               ["lora_serial.raw", "lora.raw"],
               ["lora.raw", "lora_serial.raw"],
               ["app.pose2d", "lora.pose2d"],
-              ["lora.cmd", "app.cmd"]]
+              ["lora.cmd", "app.cmd"],
+              ["app.artf_xyz", "lora.artf"]]
   }
 }

--- a/config/kloubak2-subt-estop-lora.json
+++ b/config/kloubak2-subt-estop-lora.json
@@ -167,7 +167,8 @@
               ["lora_serial.raw", "lora.raw"],
               ["lora.raw", "lora_serial.raw"],
               ["app.pose2d", "lora.pose2d"],
-              ["lora.cmd", "app.cmd"]
+              ["lora.cmd", "app.cmd"],
+              ["app.artf_xyz", "lora.artf"]
       ]
   }
 }

--- a/osgar/drivers/lora.py
+++ b/osgar/drivers/lora.py
@@ -144,6 +144,10 @@ class LoRa(Node):
         elif channel == 'cmd':
             assert len(self.cmd) == 2, self.cmd
             self.send_data(b'%d:%s:%d' % (self.cmd[0], self.cmd[1], int(self.time.total_seconds())))
+        elif channel == 'artf':
+            # send data as they are, ignore transmit time, ignore transmit failure
+            for artf_item in self.artf:
+                self.send_data(bytes(str(artf_item), encoding='ascii'))
         else:
             assert False, channel  # not supported
         return channel

--- a/osgar/drivers/test_lora.py
+++ b/osgar/drivers/test_lora.py
@@ -115,8 +115,8 @@ class LoRaTest(unittest.TestCase):
             c.raw = b"3|['TYPE_BACKPACK', 3506, -18369, -752]\n"
             c.update()
             self.assertEqual(bus.method_calls,
-                             [call.register('raw', 'cmd', 'robot_status'),
-                              call.publish('robot_status', [3, ['TYPE_BACKPACK', 3506, -18369, -752], b'running']),
+                             [call.register('raw', 'cmd', 'robot_status', 'artf'),
+                              call.publish('artf', [3, ['TYPE_BACKPACK', 3506, -18369, -752]]),
                               call.publish('raw', b"3|['TYPE_BACKPACK', 3506, -18369, -752]\n")]
                              )
 

--- a/subt/control_center_qt.py
+++ b/subt/control_center_qt.py
@@ -331,7 +331,7 @@ class MainWindow(QMainWindow):
 
 
 def record(view, cfg):
-    with osgar.logger.LogWriter(prefix='control-center-') as log:
+    with osgar.logger.LogWriter(prefix='control-center-', note=str(sys.argv)) as log:
         log.write(0, bytes(str(cfg), 'ascii'))
         recorder = osgar.record.Recorder(config=cfg['robot'], logger=log)
         cc = recorder.modules['cc']

--- a/subt/control_center_qt.py
+++ b/subt/control_center_qt.py
@@ -44,6 +44,7 @@ CFG_LORA = {
     "links": [["lora_serial.raw", "lora.raw"],
               ["lora.raw", "lora_serial.raw"],
               ["lora.robot_status", "cc.robot_status"],
+              ["lora.artf", "cc.artf"],
               ["cc.cmd", "lora.cmd"]]
   }
 }
@@ -200,6 +201,10 @@ class OsgarControlCenter:
                 robot_id, (x, y, heading), status = data
                 pose2d = [x/1000, y/1000, math.radians(heading/100)]
                 self.view.robot_status.emit(robot_id, pose2d, status)
+            elif channel == "artf":
+                robot_id, (artf, x, y, z) = data
+                print(robot_id, artf, (x, y, z))
+                # TODO draw it into map (x, y)
 
     def pause_mission(self):
         self.bus.publish('cmd', [0, b'Pause'])

--- a/subt/main.py
+++ b/subt/main.py
@@ -443,7 +443,8 @@ class SubTChallenge:
             # filter out elements on staging area
             self.stdout(self.time, 'Robot at:', (ax, ay, az))
         else:
-            self.maybe_remember_artifact(artifact_data, (ax, ay, az))
+            if self.maybe_remember_artifact(artifact_data, (ax, ay, az)):
+                self.bus.publish('artf_xyz', [[artifact_data, round(ax*1000), round(ay*1000), round(az*1000)]])
 
     def update(self):
         packet = self.bus.listen()

--- a/subt/main.py
+++ b/subt/main.py
@@ -191,8 +191,9 @@ class SubTChallenge:
             if distance3D((x, y, z), artifact_xyz) < 4.0:
                 # in case of uncertain type, rather report both
                 if stored_data == artifact_data:
-                    return
+                    return False
         self.artifacts.append((artifact_data, artifact_xyz))
+        return True
 
     def go_straight(self, how_far, timeout=None):
         print(self.time, "go_straight %.1f (speed: %.1f)" % (how_far, self.max_speed), self.last_position)

--- a/subt/test_subt.py
+++ b/subt/test_subt.py
@@ -1,6 +1,7 @@
 import unittest
+from unittest.mock import MagicMock
 
-from subt.main import Trace
+from subt.main import Trace, SubTChallenge
 
 
 class SubTChallengeTest(unittest.TestCase):
@@ -39,6 +40,19 @@ class SubTChallengeTest(unittest.TestCase):
 
         st.prune()
         self.assertEqual(len(st.trace), 4)
+
+    def test_maybe_remember_artifact(self):
+        config = {'max_speed': 0.5, 'walldist': 0.9, 'timeout': 600, 'symmetric': True,
+                  'right_wall': True}
+        bus = MagicMock()
+        game = SubTChallenge(config, bus)
+
+        artf_data = ['TYPE_BACKPACK', -1614, 1886]
+        artf_xyz = (0, 0, 0)
+        self.assertTrue(game.maybe_remember_artifact(artf_data, artf_xyz))
+
+        # 2nd report should be ignored
+        self.assertEqual(game.maybe_remember_artifact(artf_data, artf_xyz), False)
 
 # vim: expandtab sw=4 ts=4
 


### PR DESCRIPTION
This is the first step towards reporting artifacts also during their discovery. Surprisingly the change was relatively simple, only the Control Center needs better handling. At the moment it receives the data, print it into console:
```
recording started
continue mission
['TYPE_BACKPACK', 3506, -18369, -752]
['TYPE_BACKPACK', -3902, -19879, -1141]
go home
['TYPE_BACKPACK', 5052, -11916, -414]
stop mission
```
and draw (x,y) of robot (should be different).