### PR TITLE
logsocket.py - report timeout source

### DIFF
--- a/osgar/drivers/logsocket.py
+++ b/osgar/drivers/logsocket.py
@@ -82,7 +82,11 @@ class LogTCPStaticIP(LogTCPBase):
     """
     def __init__(self, config, bus):
         super().__init__(config, bus)
-        self.socket.connect(self.pair)
+        try:
+            self.socket.connect(self.pair)
+        except socket.timeout as e:
+            print('Timeout', self.pair)
+            raise
 
 
 class LogTCPDynamicIP(LogTCPBase):


### PR DESCRIPTION
There are 4 devices connected over the Ethernet and it is not clear which one failed if you see:
```
(base) root@voyage:/home/robot/git/osgar# python -m subt run config/kloubak2-subt-estop-lora.json --side right --note "test v hale K2, master po Virtualu"
Kloubak mode: DriveMode.ALL num_axis: 2
Traceback (most recent call last):
  File "/root/miniconda3/lib/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/root/miniconda3/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/robot/git/osgar/subt/__main__.py", line 2, in <module>
    main()
  File "/home/robot/git/osgar/subt/main.py", line 916, in main
    record(cfg, prefix)
  File "/home/robot/git/osgar/osgar/record.py", line 52, in record
    with Recorder(config=config['robot'], logger=log) as recorder:
  File "/home/robot/git/osgar/osgar/record.py", line 24, in __init__
    self.modules[module_name] = klass(module_config['init'], bus=bus.handle(module_name))
  File "/home/robot/git/osgar/osgar/drivers/logsocket.py", line 85, in __init__
    self.socket.connect(self.pair)
socket.timeout: timed out
```

This version will add line
```
Timeout ('192.168.1.82', 2111)
```

Caused by wrongly running K2 code on K3 robot.