### PR TITLE
Bugfix/kloubak k3 6 encoders

### DIFF
--- a/osgar/drivers/kloubak.py
+++ b/osgar/drivers/kloubak.py
@@ -49,8 +49,8 @@ INDEX_FRONT_LEFT = 1
 INDEX_FRONT_RIGHT = 0
 INDEX_REAR_LEFT = 3
 INDEX_REAR_RIGHT = 2
-INDEX_REAR_K3_L = 5
-INDEX_REAR_K3_R = 4
+INDEX_REAR_K3_LEFT = 5
+INDEX_REAR_K3_RIGHT = 4
 
 MIN_SPEED = 0.3
 
@@ -410,7 +410,7 @@ class RobotKloubak(Node):
                 ret, pose, motion = self.compute_pose(diff[INDEX_FRONT_LEFT], diff[INDEX_FRONT_RIGHT])
         elif self.num_axis == 3:
             if self.desired_speed >= 0:
-                ret, pose, motion = self.compute_pose(diff[INDEX_REAR_K3_L], diff[INDEX_REAR_K3_R])
+                ret, pose, motion = self.compute_pose(diff[INDEX_REAR_K3_LEFT], diff[INDEX_REAR_K3_RIGHT])
             else:
                 ret, pose, motion = self.compute_pose(diff[INDEX_FRONT_LEFT], diff[INDEX_FRONT_RIGHT])
         else:

--- a/osgar/drivers/kloubak.py
+++ b/osgar/drivers/kloubak.py
@@ -492,9 +492,18 @@ class RobotKloubak(Node):
                 self.can_errors += 1
         if msg_id == CAN_ID_ENCODERS:
             diff = [e - prev for e, prev in zip(self.encoders, self.last_pose_encoders)]
-            self.publish('encoders',
-                    [diff[INDEX_FRONT_LEFT], diff[INDEX_FRONT_RIGHT],
-                     diff[INDEX_REAR_LEFT], diff[INDEX_REAR_RIGHT]])
+            # note, that this craziness is necessary only because the motor indexes
+            # are assigned first right and then left
+            if len(diff) == 4:
+                self.publish('encoders',
+                        [diff[INDEX_FRONT_LEFT], diff[INDEX_FRONT_RIGHT],
+                         diff[INDEX_REAR_LEFT], diff[INDEX_REAR_RIGHT]])
+            else:
+                assert len(diff) == 6, len(diff)  # Kloubak K3
+                self.publish('encoders',
+                        [diff[INDEX_FRONT_LEFT], diff[INDEX_FRONT_RIGHT],
+                         diff[INDEX_REAR_LEFT], diff[INDEX_REAR_RIGHT],
+                         diff[INDEX_REAR_K3_LEFT], diff[INDEX_REAR_K3_RIGHT]])
             if self.update_pose():
                 self.send_pose()
 


### PR DESCRIPTION
Fixed name and publishing of 6 encoders:
```
M:\git\osgar>python -m osgar.replay --module kloubak e:\osgar\logs\czu200208\k3\
kloubak3-subt-estop-lora-200208_210437.log
original args: b"['/home/robot/git/osgar/subt/__main__.py', 'run', 'config/kloub
ak3-subt-estop-lora.json', '--side', 'left', '--note', 'publish join angle']"
Kloubak mode: DriveMode.ALL num_axis: 3
Exception in thread Thread-1:
Traceback (most recent call last):
  File "D:\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\threading.py", line
 916, in _bootstrap_inner
    self.run()
  File "M:\git\osgar\osgar\drivers\kloubak.py", line 727, in run
    self.time, channel, data = self.listen()
  File "M:\git\osgar\osgar\node.py", line 23, in listen
    return self.bus.listen()
  File "M:\git\osgar\osgar\bus.py", line 149, in listen
    getattr(self.node, channel)(dt, data)
  File "M:\git\osgar\osgar\drivers\kloubak.py", line 706, in slot_can
    self.update_drive_three_axles(timestamp, data)
  File "M:\git\osgar\osgar\drivers\kloubak.py", line 536, in update_drive_three_
axles
    if self.process_packet(data):
  File "M:\git\osgar\osgar\drivers\kloubak.py", line 506, in process_packet
    diff[INDEX_REAR_K3_LEFT], diff[INDEX_REAR_K3_RIGHT]])
  File "M:\git\osgar\osgar\node.py", line 20, in publish
    return self.bus.publish(channel, data)
  File "M:\git\osgar\osgar\bus.py", line 174, in publish
    assert almost_equal(data, ref_data), (data, ref_data, dt)
AssertionError: ([0, 0, 0, 0, 0, 0], [0, 0, 0, 0], datetime.timedelta(0, 0, 823908))
```