### PR TITLE
drivers/rosmsg.py - support also uint16 RGBD depth data from ROS

### DIFF
--- a/subt/script/mobos-view.bat
+++ b/subt/script/mobos-view.bat
@@ -1,0 +1,1 @@
+python -m osgar.tools.lidarview --pose2d app.pose2d --lidar rosmsg.scan --camera rosmsg.image --camera2 rosmsg.depth  --title rosmsg.sim_time_sec %*


### PR DESCRIPTION
tested on sample data from MOBoS