### PR TITLE
record: add timeout to join call

### DIFF
--- a/config/eduro-subt-estop-lora-wifi.json
+++ b/config/eduro-subt-estop-lora-wifi.json
@@ -58,7 +58,7 @@
           "driver": "tcp",
           "in": ["raw"],
           "out": ["raw"],
-          "init": {"host": "192.168.1.52", "port": 2111, "timeout": 3.0}
+          "init": {"host": "192.168.1.52", "port": 2111, "timeout": 0.5}
       },
       "slope_lidar": {
           "driver": "lidar",
@@ -70,7 +70,7 @@
           "driver": "tcp",
           "in": ["raw"],
           "out": ["raw"],
-          "init": {"host": "192.168.2.71", "port": 2111, "timeout": 3.0}
+          "init": {"host": "192.168.2.71", "port": 2111, "timeout": 0.5}
       },
       "camera": {
           "driver": "http",

--- a/config/eduro-subt-estop-lora.json
+++ b/config/eduro-subt-estop-lora.json
@@ -58,7 +58,7 @@
           "driver": "tcp",
           "in": ["raw"],
           "out": ["raw"],
-          "init": {"host": "192.168.1.52", "port": 2111, "timeout": 3.0}
+          "init": {"host": "192.168.1.52", "port": 2111, "timeout": 0.5}
       },
       "slope_lidar": {
           "driver": "lidar",
@@ -70,7 +70,7 @@
           "driver": "tcp",
           "in": ["raw"],
           "out": ["raw"],
-          "init": {"host": "192.168.2.71", "port": 2111, "timeout": 3.0}
+          "init": {"host": "192.168.2.71", "port": 2111, "timeout": 0.5}
       },
       "camera": {
           "driver": "http",

--- a/config/kloubak2-subt-estop-lora.json
+++ b/config/kloubak2-subt-estop-lora.json
@@ -70,7 +70,7 @@
           "driver": "tcp",
           "in": ["raw"],
           "out": ["raw"],
-          "init": {"host": "192.168.0.1", "port": 2111, "timeout": 3.0}
+          "init": {"host": "192.168.0.1", "port": 2111, "timeout": 0.5}
       },
       "lidar_back": {
           "driver": "lidar",
@@ -82,7 +82,7 @@
           "driver": "tcp",
           "in": ["raw"],
           "out": ["raw"],
-          "init": {"host": "192.168.1.82", "port": 2111, "timeout": 3.0}
+          "init": {"host": "192.168.1.82", "port": 2111, "timeout": 0.5}
       },
        "camera": {
           "driver": "http",

--- a/config/kloubak3-subt-estop-lora.json
+++ b/config/kloubak3-subt-estop-lora.json
@@ -72,7 +72,7 @@
           "driver": "tcp",
           "in": ["raw"],
           "out": ["raw"],
-          "init": {"host": "192.168.0.1", "port": 2111, "timeout": 3.0}
+          "init": {"host": "192.168.0.1", "port": 2111, "timeout": 0.5}
       },
       "lidar_back": {
           "driver": "lidar",
@@ -84,7 +84,7 @@
           "driver": "tcp",
           "in": ["raw"],
           "out": ["raw"],
-          "init": {"host": "192.168.1.71", "port": 2111, "timeout": 3.0}
+          "init": {"host": "192.168.1.71", "port": 2111, "timeout": 0.5}
       },
        "camera": {
           "driver": "http",

--- a/examples/sick2018/sick2018.py
+++ b/examples/sick2018/sick2018.py
@@ -269,8 +269,8 @@ class SICKRobot2018:
     def request_stop(self):
         self.bus.shutdown()
 
-    def join(self):
-        self.thread.join()
+    def join(self, timeout=None):
+        self.thread.join(timeout)
 
 
 if __name__ == "__main__":

--- a/osgar/drivers/logzeromq.py
+++ b/osgar/drivers/logzeromq.py
@@ -38,7 +38,7 @@ class LogZeroMQ:
             assert False, mode  # unknown/unsupported mode
 
         self.socket.connect(endpoint)
-
+        self.thread.name = bus.name
         self.bus = bus
 
     def start(self):

--- a/osgar/drivers/test_logzeromq.py
+++ b/osgar/drivers/test_logzeromq.py
@@ -15,6 +15,7 @@ class LogZeroMQTest(unittest.TestCase):
         }
         bus = MagicMock()
         bus.is_alive = MagicMock(return_value=True)
+        bus.name = "test_recv_timeout"
         node = LogZeroMQ(config, bus)
         node.start()
         time.sleep(0.01)  # give it a chance to start

--- a/osgar/record.py
+++ b/osgar/record.py
@@ -36,7 +36,12 @@ class Recorder:
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.request_stop()
         for module in self.modules.values():
-            module.join()
+            module.join(1)
+        for t in threading.enumerate():
+            if t != threading.current_thread():
+                print(f'ERROR: thread {repr(t.name)} still running!')
+                print(f'ERROR:     class: {t.__class__.__module__}.{t.__class__.__name__}')
+                print(f'ERROR:     target: {t._target}')
 
     def request_stop(self, signum=None, frame=None): # pylint: disable=unused-argument
         if self.stop_requested.is_set():

--- a/osgar/ro2018.py
+++ b/osgar/ro2018.py
@@ -111,8 +111,8 @@ class RoboOrienteering2018:
     def request_stop(self):
         self.bus.shutdown()
 
-    def join(self):
-        self.thread.join()
+    def join(self, timeout=None):
+        self.thread.join(timeout)
 
     def register(self, callback):
         self.monitors.append(callback)

--- a/subt/control_center_qt.py
+++ b/subt/control_center_qt.py
@@ -72,8 +72,8 @@ class DummyRobot:
     def request_stop(self):
         self.bus.shutdown()
 
-    def join(self):
-        self.thread.join()
+    def join(self, timeout=None):
+        self.thread.join(timeout)
 
     def run(self):
         x, y = self.x, self.y
@@ -192,8 +192,8 @@ class OsgarControlCenter:
     def request_stop(self):
         self.bus.shutdown()
 
-    def join(self):
-        self.thread.join()
+    def join(self, timeout=None):
+        self.thread.join(timeout)
 
     def run(self):
         while True:

--- a/subt/main.py
+++ b/subt/main.py
@@ -879,8 +879,8 @@ class SubTChallenge:
     def request_stop(self):
         self.bus.shutdown()
 
-    def join(self):
-        self.thread.join()
+    def join(self, timeout=None):
+        self.thread.join(timeout)
 
 
 def main():


### PR DESCRIPTION
After all modules are joined, all running threads are listed
and reported to console as an error.

It should help in the cases when SIGINT is ignored due to the main thread being stuck in `thread.join` call.