### PR TITLE
Feature/lidarview two lidars

### DIFF
--- a/osgar/tools/lidarview.py
+++ b/osgar/tools/lidarview.py
@@ -159,6 +159,13 @@ def draw_robot(foreground, pose, joint):
         dx, dy = dist*math.cos(angle), dist*math.sin(angle)
         pygame.draw.line(foreground, color, scr(x, y), scr(x + dx, y + dy), 3)
 
+        if len(joint) > 1:
+            # K3 specific
+            pygame.draw.circle(foreground, color, scr(x + dx, y + dy), 3)
+            angle -= math.radians(joint[1]/100.0)
+            dx2, dy2 = dist*math.cos(angle), dist*math.sin(angle)
+            pygame.draw.line(foreground, color, scr(x + dx, y + dy), scr(x + dx + dx2, y + dy + dy2), 3)
+
 
 g_depth = None
 g_danger_binary_image = False

--- a/osgar/tools/lidarview.py
+++ b/osgar/tools/lidarview.py
@@ -76,10 +76,11 @@ def draw_scan(foreground, pose, scan, color, joint=None):
         dx, dy = dist * math.cos(heading), dist * math.sin(heading)
         X += dx
         Y += dy
-        heading -= math.radians(joint[0] / 100.0)
-        dx, dy = dist * math.cos(heading), dist * math.sin(heading)
-        X += dx
-        Y += dy
+        for j in joint:
+            heading -= math.radians(j / 100.0)
+            dx, dy = dist * math.cos(heading), dist * math.sin(heading)
+            X += dx
+            Y += dy
 
     for i, i_dist in enumerate(scan):
         if i_dist == 0 or i_dist >= 10000:

--- a/subt/script/kloubak-view.bat
+++ b/subt/script/kloubak-view.bat
@@ -1,1 +1,1 @@
-python -m osgar.tools.lidarview --lidar lidar.scan --camera camera.raw --camera2 camera_back.raw --pose2d app.pose2d --keyframes detector.artf --joint kloubak.joint_angle %*
+python -m osgar.tools.lidarview --lidar lidar.scan --lidar2 lidar_back.scan --camera camera.raw --camera2 camera_back.raw --pose2d app.pose2d --keyframes detector.artf --joint kloubak.joint_angle %*


### PR DESCRIPTION
Add new parameter `--lidar2` which handles 2nd lidar for Kloubak robots (currently tested only with K2 data).

Note, that `CENTER_AXLE_DISTANCE = 0.348` probably does not reflect distance from front lidar to joint and then from joint to the 2nd (back) lidar.