### PR TITLE
Bugfix/integrate downdrops

### DIFF
--- a/config/kloubak3-subt-estop-lora.json
+++ b/config/kloubak3-subt-estop-lora.json
@@ -47,7 +47,7 @@
             "ad_range": 7862,
             "ad_center2": 22533,
             "ad_range2": -5840,
-            "max_join_angle_deg": 45
+            "max_join_angle_deg": 42
           }
       },          
       "can": {

--- a/osgar/drivers/kloubak.py
+++ b/osgar/drivers/kloubak.py
@@ -285,6 +285,8 @@ class RobotKloubak(Node):
         self.debug_odo = []
         self.debug_downdrops_front = []
         self.debug_downdrops_rear = []
+        self.bumpers_front = None  # unknown, report difference
+        self.bumpers_rear = None
         print('Kloubak mode:', self.drive_mode, 'num_axis:', self.num_axis)
 
     def send_pose(self):
@@ -470,7 +472,10 @@ class RobotKloubak(Node):
             if len(payload) == 4:
                 self.downdrops_front = struct.unpack_from('>HH', payload)
                 self.publish('downdrops_front', list(self.downdrops_front))
-                self.publish('bumpers_front', get_downdrop_bumpers(self.downdrops_front))
+                prev = self.bumpers_front
+                self.bumpers_front = get_downdrop_bumpers(self.downdrops_front)
+                if prev != self.bumpers_front:
+                    self.publish('bumpers_front', self.bumpers_front)
 #                print(self.time, self.downdrops_front)
                 if self.verbose:
                     self.debug_downdrops_front.append(
@@ -482,7 +487,10 @@ class RobotKloubak(Node):
             if len(payload) == 4:
                 self.downdrops_rear = struct.unpack_from('>HH', payload)
                 self.publish('downdrops_rear', list(self.downdrops_rear))
-                self.publish('bumpers_rear', get_downdrop_bumpers(self.downdrops_rear))
+                prev = self.bumpers_rear
+                self.bumpers_rear = get_downdrop_bumpers(self.downdrops_rear)
+                if prev != self.bumpers_rear:
+                    self.publish('bumpers_rear', self.bumpers_rear)
 #                print(self.time, self.downdrops_rear)
                 if self.verbose:
                     self.debug_downdrops_rear.append(

--- a/osgar/drivers/kloubak.py
+++ b/osgar/drivers/kloubak.py
@@ -27,8 +27,8 @@ MAX_JOIN_ANGLE = math.radians(MAX_JOIN_ANGLE_DEG) # K2, can be modified by confi
 AD_CENTER2 = None
 AD_RANGE2 = None
 
-DOWNDROP_TOO_LONG_RAW = 700  # in millimeters, trigger for downdrop/hole
-DOWNDROP_TOO_SHORT_RAW = 350  # in millimeters, trigger for low obstacle, probably not visible by 2D lidar
+DOWNDROP_TOO_LONG_RAW = 800  # in millimeters, trigger for downdrop/hole
+DOWNDROP_TOO_SHORT_RAW = 250  # in millimeters, trigger for low obstacle, probably not visible by 2D lidar
 DOWNDROP_STABLE_COUNT = 2  # if within the limits for given number of cycles report as bumper True/False
 
 CAN_ID_BUTTONS = 0x1

--- a/osgar/drivers/kloubak.py
+++ b/osgar/drivers/kloubak.py
@@ -29,6 +29,7 @@ AD_RANGE2 = None
 
 DOWNDROP_TOO_LONG_RAW = 700  # in millimeters, trigger for downdrop/hole
 DOWNDROP_TOO_SHORT_RAW = 350  # in millimeters, trigger for low obstacle, probably not visible by 2D lidar
+DOWNDROP_STABLE_COUNT = 2  # if within the limits for given number of cycles report as bumper True/False
 
 CAN_ID_BUTTONS = 0x1
 CAN_ID_VESC_FRONT_R = 0x91
@@ -286,7 +287,9 @@ class RobotKloubak(Node):
         self.debug_downdrops_front = []
         self.debug_downdrops_rear = []
         self.bumpers_front = None  # unknown, report difference
+        self.bumpers_front_counter = 0  # how many cycles is the True/False value stable
         self.bumpers_rear = None
+        self.bumpers_rear_counter = 0
         print('Kloubak mode:', self.drive_mode, 'num_axis:', self.num_axis)
 
     def send_pose(self):
@@ -475,6 +478,9 @@ class RobotKloubak(Node):
                 prev = self.bumpers_front
                 self.bumpers_front = get_downdrop_bumpers(self.downdrops_front)
                 if prev != self.bumpers_front:
+                    self.bumpers_front_counter = 0  # reset on change
+                self.bumpers_front_counter += 1
+                if self.bumpers_front_counter == DOWNDROP_STABLE_COUNT:  # report only "slightly stable" values
                     self.publish('bumpers_front', self.bumpers_front)
 #                print(self.time, self.downdrops_front)
                 if self.verbose:
@@ -490,6 +496,9 @@ class RobotKloubak(Node):
                 prev = self.bumpers_rear
                 self.bumpers_rear = get_downdrop_bumpers(self.downdrops_rear)
                 if prev != self.bumpers_rear:
+                    self.bumpers_rear_counter = 0  # reset on change
+                self.bumpers_rear_counter += 1
+                if self.bumpers_rear_counter == DOWNDROP_STABLE_COUNT:  # report only "slightly stable" values
                     self.publish('bumpers_rear', self.bumpers_rear)
 #                print(self.time, self.downdrops_rear)
                 if self.verbose:

--- a/osgar/drivers/kloubak.py
+++ b/osgar/drivers/kloubak.py
@@ -27,7 +27,7 @@ MAX_JOIN_ANGLE = math.radians(MAX_JOIN_ANGLE_DEG) # K2, can be modified by confi
 AD_CENTER2 = None
 AD_RANGE2 = None
 
-DOWNDROP_TOO_LONG_RAW = 800  # in millimeters, trigger for downdrop/hole
+DOWNDROP_TOO_LONG_RAW = 700  # in millimeters, trigger for downdrop/hole
 DOWNDROP_TOO_SHORT_RAW = 350  # in millimeters, trigger for low obstacle, probably not visible by 2D lidar
 
 CAN_ID_BUTTONS = 0x1

--- a/osgar/drivers/test_kloubak.py
+++ b/osgar/drivers/test_kloubak.py
@@ -106,7 +106,7 @@ class KloubakTest(unittest.TestCase):
 
     def test_downdrops(self):
         self.assertEqual(get_downdrop_bumpers([500, 500]), [False, False])
-        self.assertEqual(get_downdrop_bumpers([800, 300]), [True, True])
+        self.assertEqual(get_downdrop_bumpers([850, 250]), [True, True])
 
     def test_compute_desired_angle_division_by_zero(self):
         self.assertAlmostEqual(compute_desired_angle(desired_speed=0.0, desired_angular_speed=0.1),

--- a/subt/script/run_kloubak3.sh
+++ b/subt/script/run_kloubak3.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
 python -m subt run config/kloubak3-subt-estop-lora.json --side left --speed 0.7 --timeout 300
+#python -m osgar.go config/kloubak3-subt-estop-lora.json -d 4 --timeout 20
 python -m osgar.record config/test-lora.json


### PR DESCRIPTION
This should be evaluated after #361 (first two commits) and it is here just for testing.

Note, that there is no hysteresis triggering the collision - that part should be probably handled on Kloubak driver side. Also Kloubak should not report this on 20Hz but only changes, where failure to update bumper can be also considered `bumper=[True, True]`