### PR TITLE
quaternion: fix rotate_vector

### DIFF
--- a/osgar/lib/quaternion.py
+++ b/osgar/lib/quaternion.py
@@ -8,6 +8,8 @@ ROS uses quaternions to track and apply rotations. A quaternion has 4
 components (x,y,z,w). That's right, 'w' is last (but beware: some libraries
 like Eigen put w as the first number!). The commonly-used unit quaternion that
 yields no rotation about the x/y/z axes is (0,0,0,1)
+
+https://www.andre-gaschler.com/rotationconverter/
 """
 import math
 
@@ -28,10 +30,10 @@ def identity():
     return [0, 0, 0, 1]
 
 def rotate_vector(vector, quaternion):
-    qvector = [0] + vector
+    qvector = vector + [0]
     con = conjugate(quaternion)
     part1 = multiply(quaternion, qvector)
-    return multiply(part1, con)[1:]
+    return multiply(part1, con)[:-1]
 
 def euler_zyx(quaternion):
     x0, y0, z0, w0 = quaternion

--- a/osgar/lib/test_quaternion.py
+++ b/osgar/lib/test_quaternion.py
@@ -17,4 +17,21 @@ class QuaternionTest(unittest.TestCase):
         qdd = quaternion.multiply(qd, qd)
         self.assertEqual(qdd, qa)  # identity
 
+    def test_rotate_z90(self):
+        # rotate around Z axis by 90 deg (change heading)
+        v = [1, 0, 0]
+        q = [ 0, 0, 0.7071068, 0.7071068 ]
+        actual = quaternion.rotate_vector(v, q)
+        expected = [0, 1, 0]
+        self.assertAlmostEqual(expected[0], actual[0], places=6)
+        self.assertAlmostEqual(expected[1], actual[1], places=6)
+        self.assertAlmostEqual(expected[2], actual[2], places=6)
+
+        actual = quaternion.rotate_vector(expected, q)
+        expected = [-1, 0, 0]
+        self.assertAlmostEqual(expected[0], actual[0], places=6)
+        self.assertAlmostEqual(expected[1], actual[1], places=6)
+        self.assertAlmostEqual(expected[2], actual[2], places=6)
+
+
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
`osgar.lib.quaternion.rotate_vector` still assumed the old convention where `w` was first, not last.