### PR TITLE
sim.bash: use volume to save simulation logs.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -19,3 +19,4 @@ osgar.egg-info/
 # other
 _deprecated
 
+ign-logs

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ __pycache__/
 
 # created when using `pip install -e .`
 osgar.egg-info/
+
+# ignition simulation logs
+ign-logs/

--- a/subt/docker/run.bash
+++ b/subt/docker/run.bash
@@ -52,7 +52,6 @@ then
     chmod a+r $XAUTH
 fi
 
-DOCKER_OPTS=
 
 # Get the current version of docker.io (Debian) or docker-ce (otherwise).
 # Strip leading stuff before the version number so it can be compared

--- a/subt/script/sim.bash
+++ b/subt/script/sim.bash
@@ -2,10 +2,24 @@
 
 ROBOT="${ROBOT:-X0F200L}"
 WORLD="${WORLD:-urban_circuit_practice_01}"
+HEADLESS="${HEADLESS:-false}"
 
-cd $(git rev-parse --show-toplevel)
+cd "$(git rev-parse --show-toplevel)" || exit
 
-./subt/docker/run.bash osrf/subt-virtual-testbed:cloudsim_sim_latest cloudsim_sim.ign \
+LOG_DIR="$(pwd)/ign-logs/$(date +%Y-%m-%dT%H.%M.%S)"
+
+echo $LOG_DIR
+mkdir -p $LOG_DIR
+
+trap 'echo; echo $LOG_DIR; echo $ROBOT; echo $WORLD; echo;' EXIT
+
+DOCKER_OPTS="--volume ${LOG_DIR}:/tmp/ign/logs"
+export DOCKER_OPTS
+
+./subt/docker/run.bash osrf/subt-virtual-testbed:cloudsim_sim_latest \
+  cloudsim_sim.ign \
+  headless:=$HEADLESS \
+  seed:=1 \
   circuit:=urban \
   worldName:=$WORLD \
   robotName1:=$ROBOT \


### PR DESCRIPTION
When a simulation is run locally using the `subt/script/sim.bash` file, the ignition logs (particularly the `state.tlog` file) are saved to a directory inside the checkout. The `state.tlog` file is useful for getting the true positions of the robots that are to be used for localization validation.

If you use `sim.bash` and want to keep it without the addition of this feature, I can add a separate script file.