### PR TITLE
ros_proxy_node: limit robot_data size

### DIFF
--- a/subt/docker/robotika/ros_proxy_node.cc
+++ b/subt/docker/robotika/ros_proxy_node.cc
@@ -469,6 +469,10 @@ void Controller::logSendingThread(Controller * self, std::string logFilename) {
 
         // send log data
         std::string buffer(std::istreambuf_iterator<char>(log_file), {});
+        if (log_file.tellg() >= ROSBAG_SIZE_LIMIT) {
+            ROS_WARN_STREAM("ROSBAG_SIZE_LIMIT reached, exiting log sending thread");
+            return;
+        }
         msg.data = buffer;
         self->robotDataPub.publish(msg);
 


### PR DESCRIPTION
During the last refactoring a regression has been introduced - the maximum size limit of `robot_data` was not honored.

The code in the PR limits the data sent to `robot_data` topic, resulting in this last message in the stream `rosmsg.sim_time_sec` to be `1:01:02.515707 19 3813` and limiting the size to approx 2GB. BTW: the simulation still continues past the 3600s mark.