### PR TITLE
sync.sh: don't copy CMakeLists.txt if not changed.

### DIFF
--- a/subt/script/sync.sh
+++ b/subt/script/sync.sh
@@ -1,7 +1,13 @@
 #!/bin/bash
 
 cp osgar/subt/docker/robotika/ros_proxy_node.cc src/subt_seed/src/subt_seed_node.cc
-cp osgar/subt/docker/robotika/CMakeLists.txt src/subt_seed/CMakeLists.txt
+
+sum1=$(md5sum osgar/subt/docker/robotika/CMakeLists.txt | cut -d' ' -f1)
+sum2=$(md5sum src/subt_seed/CMakeLists.txt | cut -d' ' -f1)
+
+if [ "$sum1" != "$sum2" ]; then
+    cp osgar/subt/docker/robotika/CMakeLists.txt src/subt_seed/CMakeLists.txt
+fi
 
 catkin_make install -DCMAKE_BUILD_TYPE=Release
 


### PR DESCRIPTION
Significantly speeds up repeated rebuilds inside running docker
container.