### PR TITLE
osgar.logger: add walltime to format string

### DIFF
--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -74,7 +74,7 @@ class LogWriter:
     def __init__(self, prefix='', note='', filename=None, start_time=None):
         self.lock = RLock()
         if start_time is None:
-            self.start_time = datetime.datetime.utcnow()
+            self.start_time = datetime.datetime.now(datetime.timezone.utc)
         else:
             self.start_time = start_time
         if filename is None:
@@ -106,7 +106,7 @@ class LogWriter:
         with self.lock:
             if dt is None:
                 # by defaut generate timestamps automatically
-                dt = datetime.datetime.utcnow() - self.start_time
+                dt = datetime.datetime.now(datetime.timezone.utc) - self.start_time
             packet = format_packet(stream_id, data, dt)
             self.f.write(b"".join(packet))
             self.f.flush()
@@ -134,7 +134,7 @@ class LogReader:
         assert data == b'Pyr\x00', data
 
         data = self._read(12)
-        self.start_time = datetime.datetime(*struct.unpack('HBBBBBI', data))
+        self.start_time = datetime.datetime(*struct.unpack('HBBBBBI', data), datetime.timezone.utc)
         self.us_offset = 0  # increase after overflow
         self.prev_microseconds = 0
 
@@ -382,6 +382,7 @@ def main():
             elif args.format:
                 kw = dict(sec=timestamp.total_seconds(),
                           timestamp=timestamp,
+                          walltime=log.start_time+timestamp,
                           stream_id=stream_id,
                           data=data,
                           )

--- a/osgar/test_logger.py
+++ b/osgar/test_logger.py
@@ -5,7 +5,7 @@ import time
 import logging
 
 from threading import Timer
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 from contextlib import ExitStack
 from pathlib import Path
@@ -20,9 +20,10 @@ class TimeStandsStill:
     # inspired by
     # https://marcusahnve.org/blog/2017/mocking-datetime-in-python/
     def __init__(self, datetime):
-        self.datetime = datetime
+        self.datetime = datetime.replace(tzinfo=timezone.utc)
 
-    def utcnow(self):
+    def now(self, tzinfo):
+        assert tzinfo == timezone.utc
         return self.datetime
 
 
@@ -184,7 +185,7 @@ class LoggerStreamingTest(unittest.TestCase):
 
     def test_time_overflow(self):
         with LogWriter(prefix='tmp8', note='test_time_overflow') as log:
-            log.start_time = datetime.utcnow() - timedelta(hours=1, minutes=30)
+            log.start_time = datetime.now(timezone.utc) - timedelta(hours=1, minutes=30)
             t1 = log.write(1, b'\x01\x02')
             self.assertGreater(t1, timedelta(hours=1))
             filename = log.filename


### PR DESCRIPTION
Use as `logger <file> --stream <steam> -- format "{walltime}" to get
readable representation of calendar time or
`logger <file> --stream <steam> -- format "{walltime.timestamp()}" to
get unix timestamp value.

Necessary feature for comparing real time from cloudsim ROS and osgar logs.