### PR TITLE
subt/zmq-subt-x2.json: send data to receiver.raw instead of slot

### DIFF
--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -67,7 +67,7 @@
               ["app.request_origin", "rosmsg.request_origin"],
               ["rosmsg.origin", "app.origin"],
 
-              ["receiver.raw", "rosmsg.slot_raw"],
+              ["receiver.raw", "rosmsg.raw"],
               ["rosmsg.cmd", "transmitter.raw"],
 
               ["rosmsg.rot", "app.rot"],


### PR DESCRIPTION
When zmq sends data fast enough the `slot_raw` function is called over and over never giving chance other threads. This happens intermittently but can have fatal consequences - I've found one logfile where this kept going for 44s. With this change I was able to once get 1 point on cloudsim with X0F100L robot for the first time.