### PR TITLE
Use devel space instead of install space.

### DIFF
--- a/subt/docker/robotika/Dockerfile
+++ b/subt/docker/robotika/Dockerfile
@@ -8,6 +8,8 @@ RUN /usr/bin/python3 -m pip install --user --no-cache-dir \
   "opencv-python==4.2.0.32" \
   "pyzmq==19.0.0"
 
+RUN cd /home/developer/ && head -n -2 .bashrc > .bashrc.new && mv .bashrc.new .bashrc
+
 COPY --chown=developer:developer . ./osgar/
 
 RUN source /opt/ros/melodic/setup.bash && ./osgar/subt/script/sync.sh

--- a/subt/docker/robotika/entrypoint.bash
+++ b/subt/docker/robotika/entrypoint.bash
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-source /opt/ros/melodic/setup.bash
-source ~/subt_solution/install/setup.sh
+source ~/subt_solution/devel/setup.sh
 
 exec "$@"

--- a/subt/script/sync.sh
+++ b/subt/script/sync.sh
@@ -9,5 +9,5 @@ if [ "$sum1" != "$sum2" ]; then
     cp osgar/subt/docker/robotika/CMakeLists.txt src/subt_seed/CMakeLists.txt
 fi
 
-catkin_make install -DCMAKE_BUILD_TYPE=Release
+catkin_make -DCMAKE_BUILD_TYPE=Release
 


### PR DESCRIPTION
Speeds up builds and makes the resulting docker image much smaller.