### PR TITLE
ros_proxy_node: wait for full simulation startup

### DIFF
--- a/subt/docker/robotika/ros_proxy_node.cc
+++ b/subt/docker/robotika/ros_proxy_node.cc
@@ -289,6 +289,10 @@ Controller::Controller(const std::string &_name)
   ROS_INFO_STREAM("Waiting for " << this->name << "/front/depth");
   ros::topic::waitForMessage<sensor_msgs::Image>(this->name + "/front/depth", this->n);
 
+  ROS_INFO_STREAM("Sleeping 1 simulated second to let simulation start up");
+  ros::Duration(1).sleep();
+  ROS_INFO_STREAM("Simulation hopefully up and running");
+
   this->updateTimer = this->n.createTimer(ros::Duration(0.05), &Controller::Update, this);
   this->m_receiveZmq = std::thread(Controller::receiveZmqThread, this);
 }


### PR DESCRIPTION
Waiting for one /clock message is not enough because gazebo has clock
hickups during startup. Sleeping 1 simulated second takes about 20 walltime
seconds on my computer. 

Without this change a false positive error is detected when checking
delays between publish|listen because log filename is sent right away
and then 20s wait time for first clock message.