### PR TITLE
osgar/test_bus.py - increase robustness of the test_alive

### DIFF
--- a/osgar/test_bus.py
+++ b/osgar/test_bus.py
@@ -180,8 +180,11 @@ class BusHandlerTest(unittest.TestCase):
         t.start()
         t.join(10)
         end = time.monotonic()
+        # add extra epsilon time to avoid rounding error:
+        # AssertionError: 255.85899999999998 not greater than or equal to 255.859
+        eps = 0.000001  # 1us
         self.assertFalse(t.is_alive())
-        self.assertGreaterEqual(end-interval, start)
+        self.assertGreaterEqual(end-interval+eps, start)
 
     def test_interruptible_sleep(self):
         bus = Bus(MagicMock())


### PR DESCRIPTION
The error `AssertionError: 255.85899999999998 not greater than or equal to 255.859`
https://github.com/robotika/osgar/pull/427/checks?check_run_id=591742038
was probably caused due to rounding or different representation of time