### PR TITLE
run_solution: OMP_NUM_THREADS=1

### DIFF
--- a/subt/docker/robotika/run_solution.bash
+++ b/subt/docker/robotika/run_solution.bash
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+# disable crazy threading behavior inside openblas
+# https://github.com/xianyi/OpenBLAS#setting-the-number-of-threads-using-environment-variables
+export OMP_NUM_THREADS=1
+
 echo "Start robot solution"
 export OSGAR_LOGS=`pwd`
 cd osgar


### PR DESCRIPTION
While short in lines, this change seems to have a really great impact. I am still running more tests on cloudsim but the initial testing suggests major improvement wrt performace and latency.

The problem (as discussed over emails) is openblas going crazy creating many threads trying to parallelize something, with the only result of taking all available CPUs and getting the results significantly slower. On my 4C8T machine the difference in effectiveness is about 20 times better (faster by factor of 2.6 and using only 1 instead of 8 CPUs).