### PR TITLE
ros_proxy_node: increase log size to 3GB

### DIFF
--- a/subt/docker/robotika/ros_proxy_node.cc
+++ b/subt/docker/robotika/ros_proxy_node.cc
@@ -52,7 +52,7 @@
 #include <assert.h>
 
 
-#define ROSBAG_SIZE_LIMIT 2000000000L  // 2GB
+#define ROSBAG_SIZE_LIMIT 3000000000L  // 3GB
 
 
 int g_countClock = 0;


### PR DESCRIPTION
Tested on cloudsim. Creates 3 files in downloadable tar. The last one ends with `.active`.