### PR TITLE
subt.main: set Ver62

### DIFF
--- a/subt/main.py
+++ b/subt/main.py
@@ -955,7 +955,7 @@ class SubTChallenge:
         self.stdout("Dump END")
 
     def play_virtual_track(self):
-        self.stdout("SubT Challenge Ver58!")
+        self.stdout("SubT Challenge Ver62!")
         self.stdout("Waiting for robot_name ...")
         while self.robot_name is None:
             self.update()


### PR DESCRIPTION
There have been many changes merged that deserve further testing. Some
notable ones include:

- 3GB log files on cloudsim
- OMP_NUM_THREADS=1 to stop openblas from spinning up a crazy number of threads
- send data to receiver.raw instead of slot_raw which prevents some CPU
  starvation (sometimes receiver was the only thread running for 44 sec)
- maximum delay over 0.1s of listen-publish pairs is logged as error
- upgraded dependencies (most notably opencv 4.2.0)
- zmq receive in ros_proxy_node has its own thread (preventing dropping
  of set speed commands)
- ros_proxy_node is built with optimizations (release build)
- app.pose3d implemented for virtual track
- sending log to robot_data in ros_proxy_node has its own thread