### PR TITLE
.github/workflows: set timeout-minutes to 5

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -4,14 +4,14 @@ on:
   pull_request:
 
 jobs:
-  build:
-
+  test:
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-18.04, windows-2019]
         python-version: [3.6, 3.7, 3.8]
+    timeout-minutes: 5
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
When it gets stuck, we should be notified earlier than after 6 hours.