### PR TITLE
osgar.record: print() is not reentrant

### DIFF
--- a/osgar/record.py
+++ b/osgar/record.py
@@ -55,7 +55,6 @@ class Recorder:
     def request_stop(self, signum=None, frame=None): # pylint: disable=unused-argument
         if signum == signal.SIGINT:
             self.sigint_received = True
-            g_logger.info("SIGINT received")
         if self.stop_requested.is_set():
             return
         for module in self.modules.values():

--- a/osgar/test_record.py
+++ b/osgar/test_record.py
@@ -122,7 +122,7 @@ class RecorderTest(unittest.TestCase):
                 log_filename = log_line[-1]
                 self.assertTrue(log_filename.endswith(b".log"), stderr)
                 self.assertEqual(len(stdout), 1, stdout)
-                self.assertEqual(len(stderr), 3, stderr)
+                self.assertEqual(len(stderr), 2, stderr)
                 self.assertTrue(b"committing suicide by SIGINT" in stderr[-1])
             os.unlink(log_filename)
 


### PR DESCRIPTION
Signal can be received while inside print()
https://bugs.python.org/issue24283