### PR TITLE
run_solution.bash: use SIGINT instead of SIGTERM.

### DIFF
--- a/subt/docker/robotika/run_solution.bash
+++ b/subt/docker/robotika/run_solution.bash
@@ -34,7 +34,7 @@ roslaunch proxy sim.launch --wait robot_name:=$ROBOT_NAME &
 
 echo "Starting osgar"
 export OSGAR_LOGS=/osgar-ws/logs
-/osgar-ws/env/bin/python3 -m subt run /osgar-ws/src/osgar/subt/zmq-subt-x2.json --side auto --walldist 0.8 --timeout 100 --speed 1.0 --note "run_solution.bash" &
+/osgar-ws/env/bin/python3 -m subt run /osgar-ws/src/osgar/subt/zmq-subt-x2.json --side auto --walldist 0.8 --timeout 100 --speed 1.0 --note "run_solution.bash"
 
 echo "Sleep and finish"
 sleep 30


### PR DESCRIPTION
Osgar is handling SIGINT correctly now and roslaunch escalates to SIGTERM
after timeout if the nodes do not react on SIGINT. Using SIGINT has the
advantage of giving everyone the chance to do a propper shutdown (like
closing the log file).