### PR TITLE
rosconsole: disable roscpp_internal messages.

### DIFF
--- a/subt/docker/robotika/rosconsole.config
+++ b/subt/docker/robotika/rosconsole.config
@@ -6,4 +6,9 @@
 #
 log4j.logger.ros=DEBUG
 log4j.logger.ros.roscpp.superdebug=WARN
+
+# hide messages about recursive call
 log4j.logger.ros.roscpp.cached_parameters=INFO
+
+# hide messages about connections
+log4j.logger.ros.roscpp.roscpp_internal=INFO


### PR DESCRIPTION
We primarily need info about dropped messages so disabling this lowers the
cognitive load.