### PR TITLE
fix rosproxy test failure

### DIFF
--- a/osgar/drivers/rosproxy.py
+++ b/osgar/drivers/rosproxy.py
@@ -156,6 +156,7 @@ class ROSProxy(Thread):
             ready = False
             while True:
                 timestamp, channel, data = self.bus.listen()
+                print(timestamp, channel, data)
                 if channel != 'tick' and self.verbose:
                     print(timestamp, channel)
                 if channel == 'cmd_vel':

--- a/osgar/drivers/rosproxy.py
+++ b/osgar/drivers/rosproxy.py
@@ -156,7 +156,6 @@ class ROSProxy(Thread):
             ready = False
             while True:
                 timestamp, channel, data = self.bus.listen()
-                print(timestamp, channel, data)
                 if channel != 'tick' and self.verbose:
                     print(timestamp, channel)
                 if channel == 'cmd_vel':

--- a/osgar/drivers/test_rosproxy.py
+++ b/osgar/drivers/test_rosproxy.py
@@ -87,7 +87,9 @@ class DummyROSMaster(Thread):
         url = "http://{}:{}".format(*self.host_port_addr)
         s = ServerProxy(url)
         s.request_shutdown()
-        self.join()
+        self.join(timeout=1)
+        if self.is_alive():
+            raise RuntimeError("DummyROSMaster failed to shutdown.")
         self.server.server_close()
 
 
@@ -114,7 +116,6 @@ class ROSProxyTest(unittest.TestCase):
             proxy.request_stop()
             proxy.join(timeout=1)
             self.assertFalse(proxy.is_alive())
-            
         master.shutdown()
 
     def test_prefix4BytesLen(self):

--- a/osgar/drivers/test_rosproxy.py
+++ b/osgar/drivers/test_rosproxy.py
@@ -73,17 +73,20 @@ class DummyROSMaster(Thread):
 
         # fake calls for "real" ROS node
         self.server.register_function(requestTopic, 'requestTopic')
-        self.server.register_function(lambda: '', 'request_shutdown')
+        self.server.register_function(self.request_shutdown, 'request_shutdown')
         self.quit = False
         self.host_port_addr = host_port_addr
         self.start()
+
+    def request_shutdown(self):
+        self.quit = True
+        return True
 
     def run( self ):
         while not self.quit:
             self.server.handle_request()
 
     def shutdown(self):
-        self.quit = True
         url = "http://{}:{}".format(*self.host_port_addr)
         s = ServerProxy(url)
         s.request_shutdown()

--- a/osgar/drivers/test_rosproxy.py
+++ b/osgar/drivers/test_rosproxy.py
@@ -114,6 +114,7 @@ class ROSProxyTest(unittest.TestCase):
             proxy.request_stop()
             proxy.join(timeout=1)
             self.assertFalse(proxy.is_alive())
+            
         master.shutdown()
 
     def test_prefix4BytesLen(self):

--- a/osgar/drivers/test_rosproxy.py
+++ b/osgar/drivers/test_rosproxy.py
@@ -112,7 +112,8 @@ class ROSProxyTest(unittest.TestCase):
         with GlobalExceptionWatcher():
             proxy.start()
             proxy.request_stop()
-            proxy.join()
+            proxy.join(timeout=1)
+            self.assertFalse(proxy.is_alive())
         master.shutdown()
 
     def test_prefix4BytesLen(self):


### PR DESCRIPTION
At last, I've managed to reproduce the problem locally:

<pre>  File &quot;/home/zbynek/osgar-ws/devel/osgar/drivers/test_rosproxy.py&quot;, line 119, in test_usage
    master.shutdown()
  File &quot;/home/zbynek/osgar-ws/devel/osgar/drivers/test_rosproxy.py&quot;, line 89, in shutdown
    s.request_shutdown()
  File &quot;/usr/lib/python3.6/xmlrpc/client.py&quot;, line 1112, in __call__
    return self.__send(self.__name, args)
  File &quot;/usr/lib/python3.6/xmlrpc/client.py&quot;, line 1452, in __request
    verbose=self.__verbose
  File &quot;/usr/lib/python3.6/xmlrpc/client.py&quot;, line 1154, in request
    return self.single_request(host, handler, request_body, verbose)
  File &quot;/usr/lib/python3.6/xmlrpc/client.py&quot;, line 1167, in single_request
    resp = http_conn.getresponse()
  File &quot;/usr/lib/python3.6/http/client.py&quot;, line 1346, in getresponse
    response.begin()
  File &quot;/usr/lib/python3.6/http/client.py&quot;, line 307, in begin
    version, status, reason = self._read_status()
  File &quot;/usr/lib/python3.6/http/client.py&quot;, line 268, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), &quot;iso-8859-1&quot;)
  File &quot;/usr/lib/python3.6/socket.py&quot;, line 586, in readinto
    return self._sock.recv_into(b)
KeyboardInterrupt
</pre>

So it was stuck in a remote call `request_shutdown` which was there only to fix a situation when it is stuck. The problem was that there was a race - setting `self.quit = True` might happen while the previous request was still in `self.server.handle_request()` - when it returned, it saw that `self.quit` is True and quit the request handling loop. When the next request came, there was no loop to handle it, so it never returned.

With the change proposed in this PR, setting of `self.quit` happens in the same thread as the checking, so there should be no race condition any more (I know, famous last word).