### PR TITLE
moon/scout1.json - remove lidar downsampling

### DIFF
--- a/moon/scout1.json
+++ b/moon/scout1.json
@@ -29,7 +29,7 @@
       },
       "rosmsg": {
           "driver": "rosmsg",
-          "in": ["slot_raw", "desired_speed", "tick", "stdout", "request_origin"],
+          "in": ["raw", "desired_speed", "tick", "stdout", "request_origin"],
           "out": ["rot", "acc", "scan", "image", "pose2d", "sim_time_sec", "cmd", "origin", "gas_detected"],
           "init": {
             "topics": [
@@ -49,7 +49,7 @@
           }
       }
     },
-    "links": [["receiver.raw", "rosmsg.slot_raw"],
+    "links": [["receiver.raw", "rosmsg.raw"],
               ["rosmsg.cmd", "transmitter.raw"],
               ["rosmsg.rot", "app.rot"],
               ["rosmsg.orientation", "app.orientation"],

--- a/moon/scout1.json
+++ b/moon/scout1.json
@@ -32,8 +32,7 @@
           "in": ["slot_raw", "desired_speed", "tick", "stdout", "request_origin"],
           "out": ["rot", "acc", "scan", "image", "pose2d", "sim_time_sec", "cmd", "origin", "gas_detected"],
           "init": {
-            "downsample": 2,
-          "topics": [
+            "topics": [
               ["/scout_1/joint_states", "sensor_msgs/JointState"],
               ["/qual_1_score", "srcp2_msgs/Qual1ScoringMsg"],
               ["/scout_1/volatile_sensor", "srcp2_msgs/VolSensorMsg"],


### PR DESCRIPTION
This was copy and paste of SubT but in Moon the images are at 10Hz and lidar scans are also at 10Hz. Due to interference it looked like that several images are dropped in lidarview.
p.s. I am not sure if we still want to have downsampling in SubT, potentially degradating capability (before it was reduced for performance)