### PR TITLE
Add cuda-based subt-base image with cudatest image.

### DIFF
--- a/subt/docker/base/Dockerfile
+++ b/subt/docker/base/Dockerfile
@@ -1,8 +1,7 @@
-# Ubuntu 18.04 with nvidia-docker2 beta opengl support
-FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04 as stage1
+FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04 as stage1
 
-RUN apt-get update -qq \
- && apt-get install -y -qq \
+RUN apt-get update \
+ && apt-get install -y \
         apt-utils \
         bash-completion \
         build-essential \
@@ -21,21 +20,21 @@ RUN apt-get update -qq \
         sudo \
         vim \
         wget \
- && apt-get clean -qq
+ && apt-get clean
 
 # set default timezone
 RUN export DEBIAN_FRONTEND=noninteractive \
- && apt-get update -qq \
- && apt-get install -y -qq \
+ && apt-get update \
+ && apt-get install -y \
     tzdata \
  && ln -fs /usr/share/zoneinfo/Europe/Prague /etc/localtime \
  && dpkg-reconfigure --frontend noninteractive tzdata \
- && apt-get clean -qq
+ && apt-get clean
 
 # install ROS and required packages
 RUN /bin/sh -c 'echo "deb [trusted=yes] http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list' \
- && apt-get update -qq \
- && apt-get install -y -qq \
+ && apt-get update \
+ && apt-get install -y \
     python-catkin-tools \
     python-rosdep \
     python-rosinstall \
@@ -49,7 +48,7 @@ RUN /bin/sh -c 'echo "deb [trusted=yes] http://packages.ros.org/ros/ubuntu $(lsb
     ros-melodic-tf2-sensor-msgs \
     ros-melodic-twist-mux \
  && rosdep init \
- && apt-get clean -qq
+ && apt-get clean
 
 # sdformat8-sdf conflicts with sdformat-sdf installed from gazebo
 # so we need to workaround this using a force overwrite
@@ -59,11 +58,11 @@ RUN /bin/sh -c 'echo "deb [trusted=yes] http://packages.osrfoundation.org/gazebo
  && /bin/sh -c 'apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654'
 
 # install ign-blueprint
-RUN apt-get update -qq \
-&&  apt-get install -y -qq \
+RUN apt-get update \
+&&  apt-get install -y \
     ignition-blueprint \
     ros-melodic-ros-ign \
- && apt-get clean -qq
+ && apt-get clean
 
 SHELL ["/bin/bash", "-c"]
 
@@ -82,11 +81,16 @@ COPY --from=build /tmp/subt-ws/src/.git/refs/heads/master /opt/subt/HEAD
 
 WORKDIR /osgar-ws
 
-RUN /usr/bin/python3 -m venv env && \
-  /osgar-ws/env/bin/pip install --no-cache-dir \
-  "http://osgar.robotika.cz/subt/pip/tensorflow/tensorflow-2.2.0rc3-cp36-cp36m-linux_x86_64.whl" \
+RUN /usr/bin/python3 -m venv env
+
+RUN ./env/bin/pip install --no-cache-dir \
   "msgpack==1.0.0" \
   "numpy==1.18.2" \
   "opencv-python==4.2.0.32" \
-  "pyzmq==19.0.0" \
-  "torch==1.4.0" \
+  "pyzmq==19.0.0"
+
+RUN ./env/bin/pip install --no-cache-dir \
+  "http://osgar.robotika.cz/subt/pip/tensorflow/tensorflow-2.2.0rc3-cp36-cp36m-linux_x86_64.whl"
+
+RUN ./env/bin/pip install --no-cache-dir \
+  "torch==1.5.0+cu101" -f https://download.pytorch.org/whl/torch_stable.html

--- a/subt/docker/base/Dockerfile
+++ b/subt/docker/base/Dockerfile
@@ -1,5 +1,5 @@
 # Ubuntu 18.04 with nvidia-docker2 beta opengl support
-FROM nvidia/opengl:1.0-glvnd-devel-ubuntu18.04 as stage1
+FROM nvidia/cuda:10.2-cudnn7-devel-ubuntu18.04 as stage1
 
 RUN apt-get update -qq \
  && apt-get install -y -qq \
@@ -84,7 +84,9 @@ WORKDIR /osgar-ws
 
 RUN /usr/bin/python3 -m venv env && \
   /osgar-ws/env/bin/pip install --no-cache-dir \
+  "http://osgar.robotika.cz/subt/pip/tensorflow/tensorflow-2.2.0rc3-cp36-cp36m-linux_x86_64.whl" \
   "msgpack==1.0.0" \
   "numpy==1.18.2" \
   "opencv-python==4.2.0.32" \
-  "pyzmq==19.0.0"
+  "pyzmq==19.0.0" \
+  "torch==1.4.0" \

--- a/subt/docker/cudatest/Dockerfile
+++ b/subt/docker/cudatest/Dockerfile
@@ -2,8 +2,8 @@ FROM robotika/subt-base:2020-05-04
 
 ADD subt/docker/cudatest/cudatest_entrypoint.bash src/
 ADD subt/docker/cudatest/cudatest3.py src/
-ADD subt/docker/cudatest/rospywrapper.py src/
+ADD subt/docker/cudatest/cloudsim_run.py src/
 
 ENTRYPOINT [ "./src/cudatest_entrypoint.bash" ]
 
-CMD [ "./src/rospywrapper.py" ]
+CMD [ "./src/cloudsim_run.py", "/osgar-ws/env/bin/python", "src/cudatest3.py" ]

--- a/subt/docker/cudatest/Dockerfile
+++ b/subt/docker/cudatest/Dockerfile
@@ -1,4 +1,4 @@
-FROM robotika/subt-base:2020-05-02
+FROM robotika/subt-base:2020-05-04
 
 ADD subt/docker/cudatest/cudatest_entrypoint.bash src/
 ADD subt/docker/cudatest/cudatest3.py src/

--- a/subt/docker/cudatest/Dockerfile
+++ b/subt/docker/cudatest/Dockerfile
@@ -1,0 +1,9 @@
+FROM robotika/subt-base:2020-05-02
+
+ADD subt/docker/cudatest/cudatest_entrypoint.bash src/
+ADD subt/docker/cudatest/cudatest3.py src/
+ADD subt/docker/cudatest/rospywrapper.py src/
+
+ENTRYPOINT [ "./src/cudatest_entrypoint.bash" ]
+
+CMD [ "./src/rospywrapper.py" ]

--- a/subt/docker/cudatest/cloudsim_run.py
+++ b/subt/docker/cudatest/cloudsim_run.py
@@ -1,10 +1,17 @@
 #!/usr/bin/python2
 
+"""
+In order to run on cloudsim, the solution must call `/subt/start` and `/subt/finish` service. If the solution
+does not call these, cloudsim sees it as an error and restarts the whole simulation. The function `main` here
+provides such a wrapper.
+"""
+
 from __future__ import print_function
 
 import errno
 import socket
 import subprocess
+import sys
 import time
 
 import rospy
@@ -12,6 +19,8 @@ from rospy.impl import rosout
 from std_srvs.srv import SetBool
 
 def wait_for_master():
+    """Return when /use_sim_time is set in rosparams. If rospy.init_node is called before /use_sim_time
+    is set, it uses real time."""
     print("Waiting for rosmaster")
     start = time.time()
     last_params = []
@@ -20,7 +29,7 @@ def wait_for_master():
             params = rospy.get_param_names()
             if params != last_params:
                 print(time.time()-start, params)
-                if '/robot_names' in params:
+                if '/use_sim_time' in params:
                     return True
                 last_params = params
             time.sleep(0.01)
@@ -30,31 +39,37 @@ def wait_for_master():
             time.sleep(0.5)
 
 def main():
+    "Call /subt/start, call sys.argv[1:], call /subt/finish."
     wait_for_master()
     rospy.init_node('cudatest', log_level=rospy.DEBUG)
     rospy.loginfo("waiting for rosout logger")
+    # if rosout is not logged, we will loose anything written to it
     while rosout._rosout_pub.get_num_connections() == 0:
         time.sleep(0.2)
     rospy.loginfo("got rosout logger")
 
+    # we need these services
+    rospy.loginfo("waiting for /subt/start and /subt/finish")
+    rospy.wait_for_service('/subt/start')
+    rospy.wait_for_service('/subt/finish')
+
+    # if clock is not ticking, service /subt/start will return with error
     rospy.loginfo("waiting for clock")
     rospy.sleep(2)
     rospy.loginfo(repr(rospy.get_rostime()))
-    rospy.wait_for_service('/subt/start')
-    rospy.wait_for_service('/subt/finish')
 
     try:
         subt_start = rospy.ServiceProxy('/subt/start', SetBool)
         ret = subt_start(True)
         rospy.loginfo("/subt/start: {0}".format(ret.success))
+        rospy.loginfo("executing {0}".format(sys.argv[1:]))
 
         with open('/dev/null') as devnul:
-            a = subprocess.check_output(["/osgar-ws/env/bin/python", "src/cudatest3.py"], stderr=devnul)
+            a = subprocess.check_output(sys.argv[1:], stderr=devnul)
             for line in a.splitlines():
                 rospy.loginfo(line)
 
     finally:
-        rospy.sleep(2)
         subt_finish = rospy.ServiceProxy('/subt/finish', SetBool)
         ret = subt_finish(True)
         rospy.loginfo("/subt/finish: {0}".format(ret.success))

--- a/subt/docker/cudatest/cudatest3.py
+++ b/subt/docker/cudatest/cudatest3.py
@@ -1,0 +1,14 @@
+
+import torch
+
+if torch.cuda.is_available():
+    print("torch ok")
+else:
+    print("torch failed")
+
+import tensorflow as tf
+
+if len(tf.config.list_physical_devices('GPU')) >= 1:
+    print("tf ok")
+else:
+    print("tf failed")

--- a/subt/docker/cudatest/cudatest_entrypoint.bash
+++ b/subt/docker/cudatest/cudatest_entrypoint.bash
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+echo "source /opt/ros/melodic/setup.sh" >> ~/.bashrc
+
+source /opt/ros/melodic/setup.bash
+
+exec "$@"

--- a/subt/docker/cudatest/rospywrapper.py
+++ b/subt/docker/cudatest/rospywrapper.py
@@ -1,0 +1,63 @@
+#!/usr/bin/python2
+
+from __future__ import print_function
+
+import errno
+import socket
+import subprocess
+import time
+
+import rospy
+from rospy.impl import rosout
+from std_srvs.srv import SetBool
+
+def wait_for_master():
+    print("Waiting for rosmaster")
+    start = time.time()
+    last_params = []
+    while not rospy.is_shutdown():
+        try:
+            params = rospy.get_param_names()
+            if params != last_params:
+                print(time.time()-start, params)
+                if '/robot_names' in params:
+                    return True
+                last_params = params
+            time.sleep(0.01)
+        except socket.error as serr:
+            if serr.errno != errno.ECONNREFUSED:
+                raise serr  # re-raise error if its not the one we want
+            time.sleep(0.5)
+
+def main():
+    wait_for_master()
+    rospy.init_node('cudatest', log_level=rospy.DEBUG)
+    rospy.loginfo("waiting for rosout logger")
+    while rosout._rosout_pub.get_num_connections() == 0:
+        time.sleep(0.2)
+    rospy.loginfo("got rosout logger")
+
+    rospy.loginfo("waiting for clock")
+    rospy.sleep(2)
+    rospy.loginfo(repr(rospy.get_rostime()))
+    rospy.wait_for_service('/subt/start')
+    rospy.wait_for_service('/subt/finish')
+
+    try:
+        subt_start = rospy.ServiceProxy('/subt/start', SetBool)
+        ret = subt_start(True)
+        rospy.loginfo("/subt/start: {0}".format(ret.success))
+
+        with open('/dev/null') as devnul:
+            a = subprocess.check_output(["/osgar-ws/env/bin/python", "src/cudatest3.py"], stderr=devnul)
+            for line in a.splitlines():
+                rospy.loginfo(line)
+
+    finally:
+        rospy.sleep(2)
+        subt_finish = rospy.ServiceProxy('/subt/finish', SetBool)
+        ret = subt_finish(True)
+        rospy.loginfo("/subt/finish: {0}".format(ret.success))
+
+if __name__ == "__main__":
+    main()

--- a/subt/docker/robotika/entrypoint.bash
+++ b/subt/docker/robotika/entrypoint.bash
@@ -2,4 +2,9 @@
 
 source /osgar-ws/devel/setup.sh
 
+# We need to look for NVidia libraries, but they are not around yet when
+# building the image, so `ldconfig` in Dockerfile is not a working solution.
+# https://gitlab.com/nvidia/container-images/cuda/-/issues/34
+sudo ldconfig
+
 exec "$@"


### PR DESCRIPTION
Output when running locally:

<pre>$ (feature/cuda+torch+tensorflow) ./subt/docker/run.bash cudatest 
Waiting for rosmaster
4.0509250164 [&apos;/roslaunch/uris/host_larsa__33405&apos;, &apos;/run_id&apos;]
4.49758291245 [&apos;/roslaunch/uris/host_larsa__38057&apos;, &apos;/roslaunch/uris/host_larsa__33405&apos;, &apos;/rosdistro&apos;, &apos;/rosversion&apos;, &apos;/run_id&apos;]
4.55253100395 [&apos;/roslaunch/uris/host_larsa__38057&apos;, &apos;/roslaunch/uris/host_larsa__33405&apos;, &apos;/rosversion&apos;, &apos;/run_id&apos;, &apos;/enable_statistics&apos;, &apos;/robot_names&apos;, &apos;/use_sim_time&apos;, &apos;/world_name&apos;, &apos;/rosdistro&apos;]
<font color="#4E9A06">[DEBUG] [1588579513.300989, 0.000000]: init_node, name[/cudatest], pid[1]</font>
<font color="#4E9A06">[DEBUG] [1588579513.302621, 0.000000]: binding to 0.0.0.0 0</font>
<font color="#4E9A06">[DEBUG] [1588579513.303514, 0.000000]: bound to 0.0.0.0 44351</font>
<font color="#4E9A06">[DEBUG] [1588579513.304889, 0.000000]: ... service URL is rosrpc://larsa:44351</font>
<font color="#4E9A06">[DEBUG] [1588579513.305582, 0.000000]: [/cudatest/get_loggers]: new Service instance</font>
<font color="#4E9A06">[DEBUG] [1588579513.307366, 0.000000]: ... service URL is rosrpc://larsa:44351</font>
<font color="#4E9A06">[DEBUG] [1588579513.308042, 0.000000]: [/cudatest/set_logger_level]: new Service instance</font>
[INFO] [1588579513.309672, 0.000000]: waiting for rosout logger
[INFO] [1588579513.711184, 0.000000]: got rosout logger
[INFO] [1588579513.712267, 0.000000]: waiting for clock
<font color="#4E9A06">[DEBUG] [1588579513.852284, 0.000000]: connecting to larsa 47335</font>
[INFO] [1588579546.733638, 2.052000]: rospy.Time[2052000000]
<font color="#4E9A06">[DEBUG] [1588579546.735238, 2.052000]: connecting to (&apos;larsa&apos;, 48873)</font>
<font color="#4E9A06">[DEBUG] [1588579546.736673, 2.052000]: connecting to (&apos;larsa&apos;, 48873)</font>
<font color="#4E9A06">[DEBUG] [1588579546.738622, 2.056000]: connecting to larsa 48873</font>
[INFO] [1588579546.843411, 2.064000]: /subt/start: True
[INFO] [1588579548.575977, 2.132000]: torch ok
[INFO] [1588579548.577356, 2.132000]: tf ok
<font color="#4E9A06">[DEBUG] [1588579567.402482, 4.132000]: connecting to larsa 48873</font>
[INFO] [1588579567.404501, 4.132000]: /subt/finish: True
</pre>

Output when running on cloudsim:

```
0.000000000  Node Startup
83.796000000 INFO /rosbag_robot_data [/tmp/binarydeb/ros-melodic-rosbag-1.14.5/src/recorder.cpp:394(Recorder::startWriting)] [topics: /rosout] Recording to '/home/developer/.ros/robot_data_0.bag'.
0.000000000 INFO /tf_world_static [/tmp/binarydeb/ros-melodic-tf2-ros-0.6.5/src/static_transform_broadcaster_program.cpp:142(main)] [topics: /rosout, /tf_static] Spinning until killed publishing world to urban_circuit_practice_01
0.000000000 DEBUG /cudatest [tcpros_base.py:559(TCPROSTransport.connect)] [topics: /clock, /rosout] connecting to 10.38.0.2 40635
375.800000000 INFO /cudatest [entrypoint.py:37(main)] [topics: /clock, /rosout] got rosout logger
375.804000000 INFO /cudatest [entrypoint.py:39(main)] [topics: /clock, /rosout] waiting for clock
377.808000000 INFO /cudatest [entrypoint.py:41(main)] [topics: /clock, /rosout] rospy.Time[377808000000]
377.812000000 DEBUG /cudatest [tcpros_service.py:112(contact_service)] [topics: /clock, /rosout] connecting to ('10.38.0.2', 54493)
377.812000000 DEBUG /cudatest [tcpros_service.py:112(contact_service)] [topics: /clock, /rosout] connecting to ('10.38.0.2', 54493)
377.816000000 DEBUG /cudatest [tcpros_base.py:559(TCPROSTransport.connect)] [topics: /clock, /rosout] connecting to 10.38.0.2 54493
377.824000000 INFO /cudatest [entrypoint.py:48(main)] [topics: /clock, /rosout] /subt/start: True
380.456000000 INFO /cudatest [entrypoint.py:53(main)] [topics: /clock, /rosout] torch ok
380.460000000 INFO /cudatest [entrypoint.py:53(main)] [topics: /clock, /rosout] tf ok
382.460000000 DEBUG /cudatest [tcpros_base.py:559(TCPROSTransport.connect)] [topics: /clock, /rosout] connecting to 10.38.0.2 54493
382.464000000 INFO /cudatest [entrypoint.py:59(main)] [topics: /clock, /rosout] /subt/finish: True
```
