### PR TITLE
subt-base: switch base image from devel to runtime

### DIFF
--- a/subt/docker/base/Dockerfile
+++ b/subt/docker/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu18.04 as stage1
+FROM nvidia/cuda:10.1-cudnn7-runtime-ubuntu18.04 as stage1
 
 RUN apt-get update \
  && apt-get install -y \

--- a/subt/docker/cudatest/Dockerfile
+++ b/subt/docker/cudatest/Dockerfile
@@ -1,4 +1,4 @@
-FROM robotika/subt-base:2020-05-04
+FROM robotika/subt-base:2020-05-06
 
 ADD subt/docker/cudatest/cudatest_entrypoint.bash src/
 ADD subt/docker/cudatest/cudatest3.py src/


### PR DESCRIPTION
Results in 2GB space savings (7GB instead of 9GB).