### PR TITLE
subt: Allow setting log filename from cmdline.

### DIFF
--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -81,12 +81,15 @@ class LogWriter:
             self.filename = prefix + self.start_time.strftime("%y%m%d_%H%M%S.log")
         else:
             self.filename = filename
-        if ENV_OSGAR_LOGS in os.environ:
-            os.makedirs(os.environ[ENV_OSGAR_LOGS], exist_ok=True)
-            self.filename = os.path.join(os.environ[ENV_OSGAR_LOGS], self.filename)
-        else:
-            logging.warning('Environment variable %s is not set - using working directory' % ENV_OSGAR_LOGS)
-        self.filename = str(pathlib.Path(self.filename).absolute())
+
+        if not pathlib.Path(self.filename).is_absolute():
+            if ENV_OSGAR_LOGS in os.environ:
+                os.makedirs(os.environ[ENV_OSGAR_LOGS], exist_ok=True)
+                self.filename = os.path.join(os.environ[ENV_OSGAR_LOGS], self.filename)
+            else:
+                logging.warning('Environment variable %s is not set - using working directory' % ENV_OSGAR_LOGS)
+            self.filename = str(pathlib.Path(self.filename).absolute())
+
         self.f = open(self.filename, 'wb')
 
         self.f.write(b"".join(format_header(self.start_time)))

--- a/osgar/record.py
+++ b/osgar/record.py
@@ -62,8 +62,8 @@ class Recorder:
         self.stop_requested.set()
 
 
-def record(config, log_prefix, duration_sec=None):
-    with LogWriter(prefix=log_prefix, note=str(sys.argv)) as log:
+def record(config, log_prefix, log_filename=None, duration_sec=None):
+    with LogWriter(prefix=log_prefix, filename=log_filename, note=str(sys.argv)) as log:
         log.write(0, bytes(str(config), 'ascii'))
         g_logger.info(log.filename)
         with Recorder(config=config['robot'], logger=log) as recorder:

--- a/subt/main.py
+++ b/subt/main.py
@@ -964,6 +964,7 @@ def main():
     parser_run.add_argument('--speed', help='maximum speed (default: from config)', type=float)
     parser_run.add_argument('--timeout', help='seconds of exploring before going home (default: %(default)s)',
                             type=int, default=10*60)
+    parser_run.add_argument('--log', nargs='?', help='record log filename')
     parser_run.add_argument('--init-offset', help='inital 3D offset accepted as a string of comma separated values (meters)')
     parser_run.add_argument('--init-path', help='inital path to be followed from (0, 0). 2D coordinates are separated by ;')
     parser_run.add_argument('--start-paused', dest='start_paused', action='store_true',
@@ -987,8 +988,6 @@ def main():
         # Disabled garbage collection needs to be paired with gc.collect() at place(s) that are not time sensitive.
         gc.disable()
 
-        # support simultaneously multiple platforms
-        prefix = os.path.basename(args.config[0]).split('.')[0] + '-'
         cfg = config_load(*args.config, application=SubTChallenge)
 
         # apply overrides from command line
@@ -1009,7 +1008,8 @@ def main():
 
         cfg['robot']['modules']['app']['init']['start_paused'] = args.start_paused
 
-        record(cfg, prefix)
+        prefix = os.path.basename(args.config[0]).split('.')[0] + '-'
+        record(cfg, prefix, args.log)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When the log filename is set from outside, it is known to the startup script. This script can then also start a separate "log uploader" node to upload the log to `robot_data`. Then this part no longer needs to be inside `ros_proxy_node.cc` and can be independent (it can even be in python2 using rospy if we wish). `LogWriter` already had this capability so it was just a matter of exposing it.