### PR TITLE
Feature/speedup lidarview

### DIFF
--- a/osgar/tools/lidarview.py
+++ b/osgar/tools/lidarview.py
@@ -357,7 +357,6 @@ def lidarview(gen, caption_filename, callback=False, out_video=None, jump=None):
     pygame.display.flip()
 
     pygame.key.set_repeat(200, 20)
-    sleep_time = 0
 
     paused = False
     camera_on = True
@@ -445,8 +444,6 @@ def lidarview(gen, caption_filename, callback=False, out_video=None, jump=None):
                 event = pygame.event.wait()
             else:
                 event = pygame.event.poll()
-            if event.type == pygame.NOEVENT:
-                pygame.time.wait(sleep_time)
             if event.type == QUIT:
                 return
             if event.type == KEYDOWN:
@@ -468,23 +465,16 @@ def lidarview(gen, caption_filename, callback=False, out_video=None, jump=None):
                     map_on = not map_on
                 if event.key == K_0:
                     frames_step = 0
-                    sleep_time = 100
                 if event.key == K_1:
                     frames_step = 10
-                    sleep_time = 10
                 if event.key == K_2:
                     frames_step = 20
-                    sleep_time = 10
                 if event.key == K_3:
                     frames_step = 30
-                    sleep_time = 10
                 if event.key == K_4:
                     frames_step = 40
-                    sleep_time = 10
                 if event.key == K_9:
                     frames_step = 90
-                    sleep_time = 10
-                sleep_time = 0
                 if event.key == K_s:
                     save_image = image2 if use_image2 else image
                     pygame.image.save(save_image, "saveX-{:04}.jpg".format(save_counter))

--- a/osgar/tools/lidarview.py
+++ b/osgar/tools/lidarview.py
@@ -94,6 +94,8 @@ def draw_scan(foreground, pose, scan, color, joint=None):
 
 
 def draw(foreground, pose, scan, poses=[], image=None, callback=None, acc_pts=None):
+    foreground.lock()
+
     color = (0, 255, 0)
     X, Y, heading = pose
     for i, i_dist in enumerate(scan):
@@ -123,6 +125,8 @@ def draw(foreground, pose, scan, poses=[], image=None, callback=None, acc_pts=No
     if acc_pts is not None:
         for x, y in acc_pts:
             pygame.draw.circle(foreground, (0, 127, 0), scr(x - X, y - Y), 2)
+
+    foreground.unlock()
 
     if image is not None:
         width, height = image.get_size()

--- a/osgar/tools/lidarview.py
+++ b/osgar/tools/lidarview.py
@@ -353,7 +353,7 @@ def lidarview(gen, caption_filename, callback=False, out_video=None, jump=None):
     pygame.display.flip()
 
     pygame.key.set_repeat(200, 20)
-    sleep_time = 100
+    sleep_time = 0
 
     paused = False
     camera_on = True
@@ -480,6 +480,7 @@ def lidarview(gen, caption_filename, callback=False, out_video=None, jump=None):
                 if event.key == K_9:
                     frames_step = 90
                     sleep_time = 10
+                sleep_time = 0
                 if event.key == K_s:
                     save_image = image2 if use_image2 else image
                     pygame.image.save(save_image, "saveX-{:04}.jpg".format(save_counter))


### PR DESCRIPTION
I'd like to discuss removing the time between rendering the frames. I realized I only want to replay as fast as possible until I get to the point that interests me and then I want to step through anyway.

I also tried to add some locks to speed up pygame rendering of large scenes. Rendering a 11m logfile with map shown and twice zoomed out takes about 5 minutes with the locks while it takes 5m15s minutes without them. So not a breath taking speedup but measurable (the bigger the logfile the bigger the improvement).