### PR TITLE
Feature/moon monitors

### DIFF
--- a/moon/main.py
+++ b/moon/main.py
@@ -123,9 +123,10 @@ class SpaceRoboticsChallenge(Node):
         self.xyz = x, y, z
 
         # pose3d
-        dist3d = quaternion.rotate_vector([dist, 0, 0], self.orientation)
-        self.xyz_quat = [a + b for a, b in zip(self.xyz_quat, dist3d)]
-        self.bus.publish('pose3d', [self.xyz_quat, self.orientation])
+        if self.orientation is not None:
+            dist3d = quaternion.rotate_vector([dist, 0, 0], self.orientation)
+            self.xyz_quat = [a + b for a, b in zip(self.xyz_quat, dist3d)]
+            self.bus.publish('pose3d', [self.xyz_quat, self.orientation])
 
         if self.virtual_bumper is not None:
             self.virtual_bumper.update_pose(self.time, pose)

--- a/moon/main.py
+++ b/moon/main.py
@@ -12,6 +12,8 @@ from osgar.lib import quaternion
 from osgar.lib.mathex import normalizeAnglePIPI
 from osgar.lib.virtual_bumper import VirtualBumper
 
+from moon.monitors import LidarCollisionException, LidarCollisionMonitor
+
 
 PRINT_STATUS_PERIOD = timedelta(seconds=10)
 
@@ -22,38 +24,6 @@ class VirtualBumperException(Exception):
 
 def distance(pose1, pose2):
     return math.hypot(pose1[0] - pose2[0], pose1[1] - pose2[1])
-
-
-def min_dist(laser_data):
-    if len(laser_data) > 0:
-        # remove ultra near reflections and unlimited values == 0
-        laser_data = [x if x > 10 else 10000 for x in laser_data]
-        return min(laser_data)/1000.0
-    return 0
-
-
-class LidarCollisionException(Exception):
-    pass
-
-
-class LidarCollisionMonitor:
-    def __init__(self, robot):
-        self.robot = robot
-
-    def update(self, robot, channel):
-        if channel == 'scan':
-            size = len(robot.scan)
-            # measure distance in front of the rover = 180deg of 270deg
-            if min_dist(robot.scan[size//6:-size//6]) < 1.0:
-                raise LidarCollisionException()
-
-    # context manager functions
-    def __enter__(self):
-        self.callback = self.robot.register(self.update)
-        return self
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.robot.unregister(self.callback)
 
 
 class SpaceRoboticsChallenge(Node):

--- a/moon/monitors.py
+++ b/moon/monitors.py
@@ -1,0 +1,37 @@
+"""
+  Moon Monitors for easier strategy coding
+"""
+
+def min_dist(laser_data):
+    if len(laser_data) > 0:
+        # remove ultra near reflections and unlimited values == 0
+        laser_data = [x if x > 10 else 10000 for x in laser_data]
+        return min(laser_data)/1000.0
+    return 0
+
+
+class LidarCollisionException(Exception):
+    pass
+
+
+class LidarCollisionMonitor:
+    def __init__(self, robot):
+        self.robot = robot
+
+    def update(self, robot, channel):
+        if channel == 'scan':
+            size = len(robot.scan)
+            # measure distance in front of the rover = 180deg of 270deg
+            if min_dist(robot.scan[size//6:-size//6]) < 1.0:
+                raise LidarCollisionException()
+
+    # context manager functions
+    def __enter__(self):
+        self.callback = self.robot.register(self.update)
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.robot.unregister(self.callback)
+
+
+# vim: expandtab sw=4 ts=4

--- a/moon/test_main.py
+++ b/moon/test_main.py
@@ -1,15 +1,9 @@
 import unittest
 from unittest.mock import MagicMock
 
-from moon.main import min_dist
-
 
 class MoonMainTest(unittest.TestCase):
-
-    def test_min_dist(self):
-        self.assertAlmostEqual(min_dist([1000, 2000, 3000]), 1.0)
-        self.assertAlmostEqual(min_dist([]), 0.0)
-        self.assertAlmostEqual(min_dist([0]), 10.0)
+    pass
 
 # vim: expandtab sw=4 ts=4
 

--- a/moon/test_monitors.py
+++ b/moon/test_monitors.py
@@ -1,6 +1,9 @@
 import unittest
+from unittest.mock import MagicMock
 
-from moon.monitors import LidarCollisionException, LidarCollisionMonitor
+from moon.monitors import (LidarCollisionException, LidarCollisionMonitor,
+                           VirtualBumperMonitor)
+
 
 class MonitorTester:
     def __init__(self):
@@ -15,8 +18,13 @@ class MonitorTester:
         self.monitors.remove(callback)
 
     def update(self, channel):
+        data = getattr(self, channel)
         for m in self.monitors:
-            m(self, channel)
+            m(self, channel, data)
+
+    def publish(self, channel, data):
+        for m in self.monitors:
+            m(self, channel, data)
 
 
 class MoonMonitorsTest(unittest.TestCase):
@@ -26,6 +34,11 @@ class MoonMonitorsTest(unittest.TestCase):
         with LidarCollisionMonitor(robot):
             robot.scan = [3000]*270
             robot.update('scan')
+
+    def test_virtual_bumper_monitor(self):
+        robot = MonitorTester()
+        with VirtualBumperMonitor(robot, virtual_bumper=MagicMock()):
+            robot.publish('desired_speed', [0, 0])
 
 # vim: expandtab sw=4 ts=4
 

--- a/moon/test_monitors.py
+++ b/moon/test_monitors.py
@@ -3,7 +3,8 @@ from unittest.mock import MagicMock
 
 from moon.monitors import (LidarCollisionException, LidarCollisionMonitor,
                            VirtualBumperMonitor,
-                           PitchRollException, PitchRollMonitor)
+                           PitchRollException, PitchRollMonitor,
+                           min_dist)
 
 
 class MonitorTester:
@@ -29,6 +30,11 @@ class MonitorTester:
 
 
 class MoonMonitorsTest(unittest.TestCase):
+
+    def test_min_dist(self):
+        self.assertAlmostEqual(min_dist([1000, 2000, 3000]), 1.0)
+        self.assertAlmostEqual(min_dist([]), 0.0)
+        self.assertAlmostEqual(min_dist([0]), 10.0)
 
     def test_lidar_monitor(self):
         robot = MonitorTester()

--- a/moon/test_monitors.py
+++ b/moon/test_monitors.py
@@ -2,7 +2,8 @@ import unittest
 from unittest.mock import MagicMock
 
 from moon.monitors import (LidarCollisionException, LidarCollisionMonitor,
-                           VirtualBumperMonitor)
+                           VirtualBumperMonitor,
+                           PitchRollException, PitchRollMonitor)
 
 
 class MonitorTester:
@@ -39,6 +40,17 @@ class MoonMonitorsTest(unittest.TestCase):
         robot = MonitorTester()
         with VirtualBumperMonitor(robot, virtual_bumper=MagicMock()):
             robot.publish('desired_speed', [0, 0])
+
+    def test_roll_pitch_monitor(self):
+        robot = MonitorTester()
+        with PitchRollMonitor(robot):
+            robot.rot = [0, 0, 0]
+            robot.update('rot')
+
+        with self.assertRaises(PitchRollException) as err:
+            with PitchRollMonitor(robot):
+                robot.rot = [0, 5000, 0]
+                robot.update('rot')
 
 # vim: expandtab sw=4 ts=4
 

--- a/moon/test_monitors.py
+++ b/moon/test_monitors.py
@@ -1,0 +1,31 @@
+import unittest
+
+from moon.monitors import LidarCollisionException, LidarCollisionMonitor
+
+class MonitorTester:
+    def __init__(self):
+        self.monitors = []
+
+    def register(self, callback):
+        self.monitors.append(callback)
+        return callback
+
+    def unregister(self, callback):
+        assert callback in self.monitors
+        self.monitors.remove(callback)
+
+    def update(self, channel):
+        for m in self.monitors:
+            m(self, channel)
+
+
+class MoonMonitorsTest(unittest.TestCase):
+
+    def test_lidar_monitor(self):
+        robot = MonitorTester()
+        with LidarCollisionMonitor(robot):
+            robot.scan = [3000]*270
+            robot.update('scan')
+
+# vim: expandtab sw=4 ts=4
+


### PR DESCRIPTION
This is draft of `Moon Monitors`, which should simply coding of the search strategy. I decided to move them all into separate `moon/monitors.py` file. Note, that they monitor not only data coming from outside, but also data leaving (see `desired_speed` for `VirtualBumperMonitor`). Because of that the monitors `update()` function needs to get also `data`. BTW I am not sure if it is necessary to distinguish received/transmitted channels - comments are welcome.

The code functionality is almost 1:1 - exceptions are handling of missing first `self.orientation`, bugfix of `VirtualBumperException` while backing up 1 meter. Also the `PitchRollMonitor` is currently using hardcoded 0.5rad for pitch only as previous code (the next step here is to use params and switch to quaternions and drop`rot`).

Thanks in advance for any comments.