### PR TITLE
github-ci: set utf-8 encoding on console output

### DIFF
--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -27,3 +27,5 @@ jobs:
     - name: Run tests
       run: |
         python -u test.py -v
+      env:
+        PYTHONIOENCODING: utf-8


### PR DESCRIPTION
Python fails to autodetect it runs in unicode environment when run in Github CI.