### PR TITLE
test: allow for relative imports in tests

### DIFF
--- a/test.py
+++ b/test.py
@@ -2,4 +2,9 @@
 
 if __name__ == "__main__":
     import unittest
-    unittest.main(module=None)
+    import unittest.loader
+    testLoader = unittest.loader.TestLoader()
+    from pathlib import Path
+    top_level_dir = Path(__file__).parent
+    testLoader._top_level_dir = top_level_dir
+    unittest.main(module=None, testLoader=testLoader)


### PR DESCRIPTION
With these changes we can run `./test.py subt` (to execute all tests inside `subt` package) while inside `subt` we have `test_something.py` where inside is 
```python
from . import something
```
It is the equivalent of running 
```
python -m unittest discover --top-level-directory . --start-directory subt
```
