### PR TITLE
Handle correctly almost_equal() for inf values

### DIFF
--- a/osgar/bus.py
+++ b/osgar/bus.py
@@ -16,6 +16,8 @@ ASSERT_QUEUE_DELAY = timedelta(seconds=.1)
 
 def almost_equal(data, ref_data):
     if isinstance(data, float) and isinstance(ref_data, float):
+        if data == ref_data:
+            return True  # handling float('inf')
         return abs(data - ref_data) < 1e-6
     if isinstance(data, list) and isinstance(ref_data, list):
         if len(data) != len(ref_data):

--- a/osgar/test_bus.py
+++ b/osgar/test_bus.py
@@ -169,6 +169,14 @@ class BusHandlerTest(unittest.TestCase):
         self.assertFalse(almost_equal([1.23], []))
         self.assertFalse(almost_equal([-0.27], [0.42]))
 
+    def test_almost_equal_inf(self):
+        # bug detected in Moon project
+        inf = float('inf')
+        self.assertTrue(almost_equal(inf, inf))
+        self.assertTrue(almost_equal([inf, 0, 10], [inf, 0, 10]))
+        self.assertFalse(almost_equal(-inf, inf))
+        self.assertFalse(almost_equal(inf, 42))
+
     def test_sleep(self):
         bus = Bus(MagicMock())
         handle = bus.handle('test')


### PR DESCRIPTION
Fixed comparison of inf values (from Moon project, where radius=inf encodes straight line)