### PR TITLE
gitattributes: mark pth extension as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 subt/ign_pb2.py linguist-generated -diff -merge
 subt/model/** filter=lfs diff=lfs merge=lfs -text
+*.pth binary


### PR DESCRIPTION
It is used for PyTorch saved models.