### PR TITLE
osgar.zmqrouter: run modules as processes

### DIFF
--- a/osgar/record.py
+++ b/osgar/record.py
@@ -74,7 +74,7 @@ def record(config, log_prefix, log_filename=None, duration_sec=None):
                 recorder.stop_requested.wait(duration_sec)
 
 
-def main():
+def main(record=record):
     import logging
     logging.basicConfig(
         level=logging.DEBUG,

--- a/osgar/record.py
+++ b/osgar/record.py
@@ -78,8 +78,7 @@ def main():
     import logging
     logging.basicConfig(
         level=logging.DEBUG,
-        format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-        datefmt='%Y-%m-%d %H:%M',
+        format='%(asctime)s %(name)-16s %(levelname)-8s %(message)s',
     )
     parser = argparse.ArgumentParser(description='Record run on real HW with given configuration')
     parser.add_argument('config', nargs='+', help='configuration file')

--- a/osgar/test_zmqrouter.py
+++ b/osgar/test_zmqrouter.py
@@ -1,35 +1,50 @@
+import unittest
+
 from threading import Thread
 
-from osgar.zmqrouter import Router, Bus
+from osgar.zmqrouter import Router, Bus, record
+
+
+class Test(unittest.TestCase):
+    def test_threads(self):
+        main()
+
+    def test_record(self):
+        with Router() as router:
+            pass
+
 
 def main():
-    router = Router()
     nodes = ["listener0", "listener1", "publisher"]
     links = [
         ["publisher.count", "listener0.count"],
         ["publisher.count", "listener1.count"],
     ]
 
-    Thread(target=node_listener, args=("listener0",)).start()
-    Thread(target=node_listener, args=("listener1",)).start()
-    Thread(target=node_publisher, args=("publisher", "count")).start()
+    with Router() as router:
+        Thread(target=node_listener, args=("listener0",)).start()
+        Thread(target=node_listener, args=("listener1",)).start()
+        Thread(target=node_publisher, args=("publisher", "count", 10)).start()
 
-    router.connect(len(nodes), links)
-    router.run()
+        router.connect(len(nodes), links)
+        router.run()
 
 
 def node_listener(name):
     bus = Bus(name)
     bus.register()
+    expected = 0
     while True:
         dt, channel, data = bus.listen()
-        print(f"  {name}", dt, channel, data)
+        assert data == expected
+        expected += 1
+        #print(f"  {name}", dt, channel, data)
 
 
-def node_publisher(name, channel):
+def node_publisher(name, channel, count):
     bus = Bus(name)
     bus.register(channel)
-    for i in range(10):
+    for i in range(count):
         dt = bus.publish(channel, i)
         print("  published", i, dt)
     bus.request_stop()

--- a/osgar/test_zmqrouter.py
+++ b/osgar/test_zmqrouter.py
@@ -34,5 +34,13 @@ def node_publisher(name, channel):
         print("  published", i, dt)
     bus.request_stop()
 
+
 if __name__ == "__main__":
+    import logging, sys
+    logging.basicConfig(
+        stream=sys.stderr,
+        level=logging.DEBUG,
+        format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+        datefmt='%Y-%m-%d %H:%M',
+    )
     main()

--- a/osgar/test_zmqrouter.py
+++ b/osgar/test_zmqrouter.py
@@ -114,6 +114,13 @@ class Test(unittest.TestCase):
         }
         record(config, log_filename='null-publisher.log')
 
+    def test_fail_to_register(self):
+        config = { 'version': 2, 'robot': { 'modules': {}, 'links': [] } }
+        config['robot']['modules']['publisher'] = {
+            "driver": "osgar.test_zmqrouter:Nonexisting",
+            "init": { "output": "count:null"}
+        }
+        record(config, log_filename='null-publisher.log')
 
 def main():
     nodes = ["listener0", "listener1", "publisher"]

--- a/osgar/test_zmqrouter.py
+++ b/osgar/test_zmqrouter.py
@@ -30,8 +30,8 @@ class Noop:
 class Publisher:
     def __init__(self, config, bus):
         self.bus = bus
-        self.output_name = config["output"]
-        self.bus.register(self.output_name)
+        self.output_name = config["output"].split(":")[0] # drop any possible suffix
+        self.bus.register(config["output"])
 
     def start(self):
         self.thread = Thread(target=self.run)
@@ -97,7 +97,22 @@ class Test(unittest.TestCase):
                 "init": { "output": f"count{i}" }
             }
         record(config, log_filename='publisher.log')
-        return
+
+    def test_compress(self):
+        config = { 'version': 2, 'robot': { 'modules': {}, 'links': [] } }
+        config['robot']['modules']['publisher'] = {
+            "driver": "osgar.test_zmqrouter:Publisher",
+            "init": { "output": "count:gz"}
+        }
+        record(config, log_filename='compressed-publisher.log')
+
+    def test_null(self):
+        config = { 'version': 2, 'robot': { 'modules': {}, 'links': [] } }
+        config['robot']['modules']['publisher'] = {
+            "driver": "osgar.test_zmqrouter:Publisher",
+            "init": { "output": "count:null"}
+        }
+        record(config, log_filename='null-publisher.log')
 
 
 def main():

--- a/osgar/test_zmqrouter.py
+++ b/osgar/test_zmqrouter.py
@@ -4,6 +4,7 @@ import unittest
 import os
 import shutil
 import pathlib
+import time
 
 from unittest.mock import MagicMock
 
@@ -41,6 +42,7 @@ class Publisher:
         count = 10
         for i in range(count):
             dt = self.bus.publish("count", i)
+            time.sleep(0.01)
             #print("  published", i, dt)
 
 

--- a/osgar/test_zmqrouter.py
+++ b/osgar/test_zmqrouter.py
@@ -61,6 +61,24 @@ class Sleeper:
     def join(self, timeout=None):
         pass
 
+
+class Listener:
+    def __init__(self, config, bus):
+        self.bus = bus
+        self.bus.register()
+
+    def start(self):
+        self.thread = Thread(target=self.run)
+        self.thread.start()
+
+    def run(self):
+        while True:
+            self.bus.listen()
+
+    def join(self, timeout=None):
+        self.thread.join(timeout)
+
+
 class PublisherListener:
     def __init__(self, config, bus):
         self.bus = bus
@@ -196,6 +214,13 @@ class Test(unittest.TestCase):
         }
         record(config, log_filename='sleeps.log')
 
+    def test_duration(self):
+        config = { 'version': 2, 'robot': { 'modules': {}, 'links': [] } }
+        config['robot']['modules']['listener'] = {
+            "driver": "osgar.test_zmqrouter:Listener",
+        }
+        record(config, log_filename='duration.log', duration_sec=0.3)
+
     def test_fail_to_register(self):
         config = { 'version': 2, 'robot': { 'modules': {}, 'links': [] } }
         config['robot']['modules']['publisher'] = {
@@ -214,6 +239,13 @@ class Test(unittest.TestCase):
             "driver": "osgar.test_zmqrouter:NoQuit",
         }
         record(config, log_filename='noquit.log')
+
+    def test_fail_to_quit_duration(self):
+        config = { 'version': 2, 'robot': { 'modules': {}, 'links': [] } }
+        config['robot']['modules']['noquit'] = {
+            "driver": "osgar.test_zmqrouter:NoQuit",
+        }
+        record(config, log_filename='duration-no-quit.log', duration_sec=0.3)
 
 
 def main():

--- a/osgar/test_zmqrouter.py
+++ b/osgar/test_zmqrouter.py
@@ -265,6 +265,6 @@ if __name__ == "__main__":
     logging.basicConfig(
         stream=sys.stdout,
         level=logging.DEBUG,
-        format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+        format='%(asctime)s %(name)-16s %(levelname)-8s %(message)s',
     )
     unittest.main()

--- a/osgar/test_zmqrouter.py
+++ b/osgar/test_zmqrouter.py
@@ -1,0 +1,38 @@
+from threading import Thread
+
+from osgar.zmqrouter import Router, Bus
+
+def main():
+    router = Router()
+    nodes = ["listener0", "listener1", "publisher"]
+    links = [
+        ["publisher.count", "listener0.count"],
+        ["publisher.count", "listener1.count"],
+    ]
+
+    Thread(target=node_listener, args=("listener0",)).start()
+    Thread(target=node_listener, args=("listener1",)).start()
+    Thread(target=node_publisher, args=("publisher", "count")).start()
+
+    router.connect(len(nodes), links)
+    router.run()
+
+
+def node_listener(name):
+    bus = Bus(name)
+    bus.register()
+    while True:
+        dt, channel, data = bus.listen()
+        print(f"  {name}", dt, channel, data)
+
+
+def node_publisher(name, channel):
+    bus = Bus(name)
+    bus.register(channel)
+    for i in range(10):
+        dt = bus.publish(channel, i)
+        print("  published", i, dt)
+    bus.request_stop()
+
+if __name__ == "__main__":
+    main()

--- a/osgar/test_zmqrouter.py
+++ b/osgar/test_zmqrouter.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import MagicMock
 
 from threading import Thread
 
@@ -10,7 +11,7 @@ class Test(unittest.TestCase):
         main()
 
     def test_record(self):
-        with Router() as router:
+        with Router(MagicMock()) as router:
             pass
 
 
@@ -21,13 +22,17 @@ def main():
         ["publisher.count", "listener1.count"],
     ]
 
-    with Router() as router:
+    logger = MagicMock()
+    with Router(logger) as router:
         Thread(target=node_listener, args=("listener0",)).start()
         Thread(target=node_listener, args=("listener1",)).start()
         Thread(target=node_publisher, args=("publisher", "count", 10)).start()
 
-        router.connect(len(nodes), links)
+        router.register_nodes(nodes)
+        for link_from, link_to in links:
+            router.connect(link_from, link_to)
         router.run()
+    print(logger.mock_calls)
 
 
 def node_listener(name):

--- a/osgar/test_zmqrouter.py
+++ b/osgar/test_zmqrouter.py
@@ -50,6 +50,17 @@ class Publisher:
             #print("  published", i, dt)
 
 
+class Sleeper:
+    def __init__(self, config, bus):
+        self.bus = bus
+        self.bus.register()
+
+    def start(self):
+        self.bus.sleep(0.001)
+
+    def join(self, timeout=None):
+        pass
+
 class PublisherListener:
     def __init__(self, config, bus):
         self.bus = bus
@@ -177,6 +188,13 @@ class Test(unittest.TestCase):
                     count += 1
                     self.assertGreater(data['delay'], 0.15)
             self.assertEqual(count, 10)
+
+    def test_sleep(self):
+        config = { 'version': 2, 'robot': { 'modules': {}, 'links': [] } }
+        config['robot']['modules']['sleeper'] = {
+            "driver": "osgar.test_zmqrouter:Sleeper",
+        }
+        record(config, log_filename='sleeps.log')
 
     def test_fail_to_register(self):
         config = { 'version': 2, 'robot': { 'modules': {}, 'links': [] } }

--- a/osgar/zmqrouter.py
+++ b/osgar/zmqrouter.py
@@ -92,13 +92,15 @@ class _Router:
         self.stopping = datetime.timedelta()
         self.no_output = set()
         self.compressed_output = set()
+        self._saved_sigint = None
 
     def __enter__(self):
         self.socket.bind(ENDPOINT)
-        signal.signal(signal.SIGINT, self.sigint)
+        self._saved_sigint = signal.signal(signal.SIGINT, self.sigint)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        signal.signal(signal.SIGINT, self._saved_sigint)
         self.socket.close()
         self._context.term()
 

--- a/osgar/zmqrouter.py
+++ b/osgar/zmqrouter.py
@@ -1,0 +1,174 @@
+import ast
+import collections
+import datetime
+import inspect
+import logging
+import struct
+import subprocess
+import sys
+
+
+from pprint import pprint
+from threading import Thread
+
+import zmq
+
+import osgar.lib.serialize
+import osgar.lib.config
+
+
+def main():
+    module_config = ast.literal_eval(sys.argv[1])
+    pprint(module_config)
+    klass = osgar.lib.config.get_class_by_name(module_config['driver'])
+    bus = Bus(module_config['name'])
+    instance = klass(config=module_config['init'], bus=bus)
+    instance.start()
+    print(module_config['name'], "running")
+    instance.join()
+
+
+def record(config, log_prefix, log_filename=None, duration_sec=None):
+    router = Router()
+    modules = {}
+    for module_name, module_config in config['robot']['modules'].items():
+        module_config['name'] = module_name
+        modules[module_name] = subprocess.Popen([sys.executable, __file__, str(module_config)])
+
+    router.connect(len(modules), config['robot']['links'])
+    pprint(router.subscriptions)
+    router.run()
+
+    for module in modules.values():
+        module.join()
+
+
+class Router:
+    def __init__(self):
+        self.start_time = datetime.datetime.now(datetime.timezone.utc)
+        context = zmq.Context.instance()
+        self.s = context.socket(zmq.ROUTER)
+        self.s.bind("tcp://127.0.0.1:8881")
+        self.nodes = dict()
+        self.subscriptions = dict()
+        self.listening = set()
+        self.stopping = False
+
+    def connect(self, num, links):
+        # wait for all nodes to "register" their outputs
+        for _ in range(num):
+            packet = self.s.recv_multipart() # TODO handle timeout
+            sender, _, action, *args = packet
+            assert action == b"register", (sender, action, args)
+            assert sender not in self.nodes
+            self.nodes[sender] = collections.deque()
+        
+        for sender, receiver in links:
+            sender = sender.encode("ascii")
+            receiver = receiver.encode("ascii")
+            receiver, input = receiver.split(b'.')
+            self.subscriptions.setdefault(sender, []).append((receiver, input))
+
+        # answer all connected nodes that it is ok to run now (connections are set up)
+        for node_name in self.nodes:
+            self.s.send_multipart([node_name, b"", b"register"])
+
+    def run(self):
+        for packet in self.receive():
+            sender, action, *args = packet
+            getattr(self, action.decode('ascii'))(sender, *args)
+        for node_name in self.nodes:
+            self.send(node_name, b"quit")
+
+    def receive(self, hz=10):
+        socket = self.s
+        poller = zmq.Poller()
+        poller.register(socket, zmq.POLLIN)
+        try:
+            while True:
+                obj = dict(poller.poll(1000//hz))
+                if socket in obj and obj[socket] == zmq.POLLIN:
+                    packet = socket.recv_multipart()
+                    yield (packet[0], *packet[2:]) # drop frame separator from REQ socket
+                elif self.stopping: # timeout && we are stopping
+                    return
+        except KeyboardInterrupt:
+            pass
+
+    def listen(self, sender):
+        queue = self.nodes[sender]
+        if len(queue) == 0:
+            self.listening.add(sender)
+        else:
+            packet = queue.popleft()
+            assert packet[0] == sender, (packet[0], sender)
+            self.s.send_multipart(packet)
+
+    def publish(self, sender, channel, data):
+        dt = datetime.datetime.now(datetime.timezone.utc) - self.start_time
+        assert dt <= datetime.timedelta(microseconds=(1<<32)-1)
+        dt_int = (dt.seconds * 1000000 + dt.microseconds)
+        dt_uint32 = struct.pack("I", dt_int)
+        self.s.send_multipart([sender, b"", b"publish", dt_uint32])
+        for node_name, input_channel in self.subscriptions.get(sender+b"."+channel, []):
+            self.send(node_name, b'listen', dt_uint32, input_channel, data)
+    
+    def request_stop(self, sender):
+        print(sender.decode('ascii'), "requested stop")
+        self.stopping = True
+
+    def send(self, node_name, *args):
+        packet = [node_name, b"", *args]
+        if node_name in self.listening:
+            self.listening.remove(node_name)
+            self.s.send_multipart(packet)
+        else:
+            self.nodes[node_name].append(packet)
+
+
+class Bus:
+    def __init__(self, name):
+        self.name = name
+        context = zmq.Context.instance()
+        self.sock = context.socket(zmq.REQ)
+        self.sock.setsockopt_string(zmq.IDENTITY, name)
+        self.sock.connect("tcp://127.0.0.1:8881")
+
+    def register(self, *outputs):
+        bytes_outputs = list(o.encode('ascii') for o in outputs)
+        self.sock.send_multipart([b"register", *bytes_outputs])
+        resp = self.sock.recv()
+        assert resp == b'register'
+
+    def listen(self):
+        self.sock.send(b"listen")
+        resp = self.sock.recv_multipart()
+        if resp[0] == b"quit":
+            print(f"{self.name} received quit")
+            raise SystemExit()
+        assert resp[0] == b"listen"
+        microseconds = struct.unpack('I', resp[1])[0]
+        dt = datetime.timedelta(microseconds=microseconds)
+        channel = resp[2].decode('ascii')
+        data = osgar.lib.serialize.deserialize(resp[3])
+        return dt, channel, data
+
+    def publish(self, channel, data):
+        raw = osgar.lib.serialize.serialize(data)
+        self.sock.send_multipart([b"publish", channel.encode('ascii'), raw])
+        resp = self.sock.recv_multipart()
+        assert resp[0] == b"publish"
+        microseconds = struct.unpack('I', resp[1])[0]
+        dt = datetime.timedelta(microseconds=microseconds)
+        return dt
+
+    def request_stop(self):
+        self.sock.send_multipart([b"request_stop"])
+
+    def is_alive(self):
+        return True
+
+
+if __name__ == "__main__":
+    main()
+

--- a/osgar/zmqrouter.py
+++ b/osgar/zmqrouter.py
@@ -18,7 +18,7 @@ ENDPOINT = "tcp://127.0.0.1:8882"
 ASSERT_QUEUE_DELAY = datetime.timedelta(seconds=.1)
 STOPPING_TIMEOUT = datetime.timedelta(seconds=2)
 
-g_logger = logging.getLogger(__name__)
+g_logger = logging.getLogger(sys.modules[__name__].__spec__.name)
 
 
 def child(name, module_config, log_level):
@@ -29,7 +29,7 @@ def child(name, module_config, log_level):
     logging.basicConfig(
         stream=sys.stdout,
         level=log_level,
-        format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+        format='%(asctime)s %(name)-16s %(levelname)-8s %(message)s',
     )
     # todo end
     signal.signal(signal.SIGINT,signal.SIG_IGN)

--- a/osgar/zmqrouter.py
+++ b/osgar/zmqrouter.py
@@ -68,6 +68,8 @@ def record(config, log_prefix=None, log_filename=None, duration_sec=None):
                 try:
                     # always stop within 1s
                     timeout = 1 - (router.now() - router.stopping).total_seconds()
+                    if timeout < 0:
+                        timeout = 0
                     module.wait(timeout)
                 except subprocess.TimeoutExpired:
                     module.kill()

--- a/osgar/zmqrouter.py
+++ b/osgar/zmqrouter.py
@@ -38,8 +38,10 @@ def record(config, log_prefix, log_filename=None, duration_sec=None):
             module_config['name'] = module_name
             modules[module_name] = subprocess.Popen([sys.executable, __file__, str(module_config)])
 
-        router.connect(len(modules), config['robot']['links'])
-        #pprint(router.subscriptions)
+        router.register_nodes(modules.keys())
+        links =  config['robot']['links']
+        for link_from, link_to in links:
+            router.connect(link_from, link_to)
         router.run()
 
         for module in modules.values():
@@ -50,19 +52,19 @@ class Router:
     def __init__(self):
         self.start_time = datetime.datetime.now(datetime.timezone.utc)
         self._context = zmq.Context()
-        self.s = self._context.socket(zmq.ROUTER)
+        self.socket = self._context.socket(zmq.ROUTER)
         self.nodes = dict()
         self.subscriptions = dict()
         self.listening = set()
         self.stopping = datetime.timedelta()
 
     def __enter__(self):
-        self.s.bind("tcp://127.0.0.1:8881")
+        self.socket.bind("tcp://127.0.0.1:8881")
         signal.signal(signal.SIGINT, self.sigint)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.s.close()
+        self.socket.close()
         self._context.term()
 
     def sigint(self, signum, frame):
@@ -70,34 +72,35 @@ class Router:
         # use Event? what is ok to do from a signal handler?
         self.request_stop(b'ctrl-c')
 
-    def connect(self, num, links):
+    def register_nodes(self, nodes):
         # wait for all nodes to "register" their outputs
-        for _ in range(num):
-            packet = self.s.recv_multipart() # TODO handle timeout
-            sender, _, action, *args = packet
-            assert action == b"register", (sender, action, args)
+        nodes = [bytes(node_name, "ascii") for node_name in nodes]
+        for _ in range(len(nodes)):
+            packet = self.socket.recv_multipart()  # TODO handle timeout
+            sender, _, action, *outputs = packet
+            assert action == b"register", (sender, action, outputs)
             assert sender not in self.nodes
+            assert sender in nodes, (sender, nodes)
+            # receiving queue
             self.nodes[sender] = collections.deque()
-        
-        for sender, receiver in links:
-            sender = sender.encode("ascii")
-            receiver = receiver.encode("ascii")
-            receiver, input = receiver.split(b'.')
-            self.subscriptions.setdefault(sender, []).append((receiver, input))
 
-        # answer all connected nodes that it is ok to run now (connections are set up)
-        for node_name in self.nodes:
-            self.s.send_multipart([node_name, b"", b"register"])
+    def connect(self, link_from, link_to):
+        link_from = bytes(link_from, "ascii")
+        assert link_from in self.stream_id, self.stream_id
+        receiver, channel = bytes(link_to, "ascii").split(b".")
+        self.subscriptions.setdefault(link_from, []).append((receiver, channel))
 
     def run(self):
+        # answer all connected nodes that it is ok to run now (connections are set up)
+        for node_name in self.nodes:
+            self.socket.send_multipart([node_name, b"", b"start"])
+
         for packet in self.receive():
             sender, action, *args = packet
             getattr(self, action.decode('ascii'))(sender, *args)
-        #for node_name in self.nodes:
-        #    self.send(node_name, b"quit")
 
     def receive(self, hz=10):
-        socket = self.s
+        socket = self.socket
         poller = zmq.Poller()
         poller.register(socket, zmq.POLLIN)
         while not self.stopping or self._now() - self.stopping < datetime.timedelta(seconds=1):
@@ -115,12 +118,13 @@ class Router:
         else:
             packet = queue.popleft()
             assert packet[0] == sender, (packet[0], sender)
-            self.s.send_multipart(packet)
+            self.socket.send_multipart(packet)
 
     def publish(self, sender, channel, data):
         dt_uint32 = self._pack_timestamp(self._now())
-        self.s.send_multipart([sender, b"", b"publish", dt_uint32])
-        for node_name, input_channel in self.subscriptions.get(sender+b"."+channel, []):
+        self.socket.send_multipart([sender, b"", b"publish", dt_uint32])
+        link_from = sender + b"." + channel
+        for node_name, input_channel in self.subscriptions.get(link_from, []):
             self.send(node_name, b'listen', dt_uint32, input_channel, data)
     
     def request_stop(self, sender):
@@ -133,13 +137,13 @@ class Router:
 
     def is_alive(self, sender):
         dt_uint32 = self._pack_timestamp(self._now())
-        self.s.send_multipart([sender, b"", b"quit" if self.stopping else b"is_alive", dt_uint32])
+        self.socket.send_multipart([sender, b"", b"quit" if self.stopping else b"is_alive", dt_uint32])
 
     def send(self, node_name, *args):
         packet = [node_name, b"", *args]
         if node_name in self.listening:
             self.listening.remove(node_name)
-            self.s.send_multipart(packet)
+            self.socket.send_multipart(packet)
         else:
             self.nodes[node_name].append(packet)
 
@@ -164,7 +168,7 @@ class Bus:
         bytes_outputs = list(o.encode('ascii') for o in outputs)
         self.sock.send_multipart([b"register", *bytes_outputs])
         resp = self.sock.recv()
-        assert resp == b'register'
+        assert resp == b'start'
 
     def listen(self):
         self.sock.send(b"listen")
@@ -200,7 +204,6 @@ class Bus:
         return True
 
     def _quit(self):
-        self.quit = True
         g_logger.info(f"{self.name} received quit")
         return SystemExit()
 

--- a/osgar/zmqrouter.py
+++ b/osgar/zmqrouter.py
@@ -5,6 +5,7 @@ import signal
 import subprocess
 import sys
 import threading
+import time
 
 
 import zmq
@@ -300,6 +301,9 @@ class _Bus:
             self._quit()
             return False
         return True
+
+    def sleep(self, duration):
+        time.sleep(duration)
 
     def _quit(self):
         g_logger.info(f"{self.name} received quit")

--- a/osgar/zmqrouter.py
+++ b/osgar/zmqrouter.py
@@ -36,7 +36,7 @@ def record(config, log_prefix=None, log_filename=None, duration_sec=None):
             modules = {}
             for module_name, module_config in config['robot']['modules'].items():
                 module_config['name'] = module_name
-                modules[module_name] = subprocess.Popen([sys.executable, __file__, str(module_config)])
+                modules[module_name] = subprocess.Popen([sys.executable, "-m", __name__, str(module_config)])
 
             router.register_nodes(modules.keys())
             links =  config['robot']['links']

--- a/osgar/zmqrouter.py
+++ b/osgar/zmqrouter.py
@@ -1,20 +1,17 @@
 import ast
 import collections
 import datetime
-import inspect
 import logging
 import signal
-import struct
 import subprocess
 import sys
 
-
-from pprint import pprint
 
 import zmq
 
 import osgar.lib.serialize
 import osgar.lib.config
+import osgar.logger
 
 g_logger = logging.getLogger(__name__)
 
@@ -31,28 +28,30 @@ def main():
     bus.request_stop()
 
 
-def record(config, log_prefix, log_filename=None, duration_sec=None):
-    logger = LogWriter()
-    with Router(logger) as router:
-        modules = {}
-        for module_name, module_config in config['robot']['modules'].items():
-            module_config['name'] = module_name
-            modules[module_name] = subprocess.Popen([sys.executable, __file__, str(module_config)])
+def record(config, log_prefix=None, log_filename=None, duration_sec=None):
+    with osgar.logger.LogWriter(prefix=log_prefix, filename=log_filename, note=str(sys.argv)) as log:
+        log.write(0, bytes(str(config), 'ascii'))
+        g_logger.info(log.filename)
+        with Router(log) as router:
+            modules = {}
+            for module_name, module_config in config['robot']['modules'].items():
+                module_config['name'] = module_name
+                modules[module_name] = subprocess.Popen([sys.executable, __file__, str(module_config)])
 
-        router.register_nodes(modules.keys())
-        links =  config['robot']['links']
-        for link_from, link_to in links:
-            router.connect(link_from, link_to)
-        router.run()
+            router.register_nodes(modules.keys())
+            links =  config['robot']['links']
+            for link_from, link_to in links:
+                router.connect(link_from, link_to)
+            router.run()
 
-        for module in modules.values():
-            module.wait() # TODO terminate rogue modules
+            for module in modules.values():
+                module.wait() # TODO terminate rogue modules
 
 
 class Router:
     def __init__(self, logger):
         self.logger = logger
-        self.start_time = datetime.datetime.now(datetime.timezone.utc)
+        self.start_time = self.logger.start_time
         self._context = zmq.Context()
         self.socket = self._context.socket(zmq.ROUTER)
         self.nodes = dict()
@@ -64,13 +63,11 @@ class Router:
     def __enter__(self):
         self.socket.bind("tcp://127.0.0.1:8881")
         signal.signal(signal.SIGINT, self.sigint)
-        self.logger.start(self.start_time)
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.socket.close()
         self._context.term()
-        self.logger.stop()
 
     def sigint(self, signum, frame):
         # TODO send message to myself telling me to stop?
@@ -86,7 +83,7 @@ class Router:
             assert action == b"register", (sender, action, outputs)
             assert sender not in self.nodes
             assert sender in nodes, (sender, nodes)
-            print(sender, outputs)
+            #print(sender, outputs)
             # receiving queue
             self.nodes[sender] = collections.deque()
             for o in outputs:
@@ -132,7 +129,7 @@ class Router:
 
     def publish(self, sender, channel, data):
         dt = self._now()
-        dt_uint32 = self._pack_timestamp(dt)
+        dt_uint32 = osgar.logger.format_timedelta(dt)
         self.socket.send_multipart([sender, b"", b"publish", dt_uint32])
         link_from = sender + b"." + channel
         for node_name, input_channel in self.subscriptions.get(link_from, []):
@@ -163,11 +160,6 @@ class Router:
     def _now(self):
         return datetime.datetime.now(datetime.timezone.utc) - self.start_time
 
-    def _pack_timestamp(self, dt):
-        assert dt <= datetime.timedelta(microseconds=(1<<32)-1)
-        dt_int = (dt.seconds * 1000000 + dt.microseconds)
-        dt_uint32 = struct.pack("I", dt_int)
-        return dt_uint32
 
 class Bus:
     def __init__(self, name):
@@ -176,6 +168,8 @@ class Bus:
         self.sock = context.socket(zmq.REQ)
         self.sock.setsockopt_string(zmq.IDENTITY, name)
         self.sock.connect("tcp://127.0.0.1:8881")
+        self.parse_listen_dt = osgar.logger.timedelta_parser()
+        self.parse_publish_dt = osgar.logger.timedelta_parser()
 
     def register(self, *outputs):
         bytes_outputs = list(bytes(o, 'ascii') for o in outputs)
@@ -189,8 +183,7 @@ class Bus:
         if resp[0] == b"quit":
             raise self._quit()
         assert resp[0] == b"listen"
-        microseconds = struct.unpack('I', resp[1])[0]
-        dt = datetime.timedelta(microseconds=microseconds)
+        dt = self.parse_listen_dt(resp[1])
         channel = str(resp[2], 'ascii')
         data = osgar.lib.serialize.deserialize(resp[3])
         return dt, channel, data
@@ -200,8 +193,7 @@ class Bus:
         self.sock.send_multipart([b"publish", bytes(channel, 'ascii'), raw])
         resp, timestamp = self.sock.recv_multipart()
         assert resp == b"publish"
-        microseconds = struct.unpack('I', timestamp)[0]
-        dt = datetime.timedelta(microseconds=microseconds)
+        dt = self.parse_publish_dt(timestamp)
         return dt
 
     def request_stop(self):
@@ -222,11 +214,12 @@ class Bus:
 
 
 if __name__ == "__main__":
-    logging.basicConfig(
-        stream=sys.stderr,
-        level=logging.DEBUG,
-        format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
-        datefmt='%Y-%m-%d %H:%M',
-    )
+    # todo how to inherit logging setup from parent process?
+    #logging.basicConfig(
+    #    stream=sys.stderr,
+    #    level=logging.DEBUG,
+    #    format='%(asctime)s %(name)-12s %(levelname)-8s %(message)s',
+    #    datefmt='%Y-%m-%d %H:%M',
+    #)
     main()
 

--- a/osgar/zmqrouter.py
+++ b/osgar/zmqrouter.py
@@ -88,7 +88,8 @@ class Router:
             # receiving queue
             self.nodes[sender] = collections.deque()
             self.delays[sender] = datetime.timedelta()
-            for o in outputs:
+            for name_and_type in outputs:
+                o = name_and_type.split(b':')[0]  # keep only prefixes
                 link_from = sender + b"." + o
                 idx = self.logger.register(str(link_from, 'ascii'))
                 self.stream_id[link_from] = idx

--- a/subt/main.py
+++ b/subt/main.py
@@ -899,7 +899,8 @@ class SubTChallenge:
 def main():
     import argparse
     from osgar.lib.config import config_load
-    from osgar.record import record
+    #from osgar.record import record
+    from osgar.zmqrouter import record
 
     parser = argparse.ArgumentParser(description='SubT Challenge')
     subparsers = parser.add_subparsers(help='sub-command help', dest='command')

--- a/test.py
+++ b/test.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 if __name__ == "__main__":
+    import logging
+    logging.root.level = logging.CRITICAL
     import unittest
     import unittest.loader
     testLoader = unittest.loader.TestLoader()


### PR DESCRIPTION
`zmqrouter.record` can start all modules as separate processes and route ZeroMQ messages among them - all without changing a single line inside the modules. In the future modules can be implemented in different languages (python2+rospy or rospp or anything else supporting ZeroMQ) and be native parts of osgar. We are also no longer bound by python GIL - osgar can now use all 16 cores in cloudsim.

The main process creates `zmq.ROUTER` socket and modules use `zmq.REQ` socket. All message
buffers are in the main process - each module is always handling only a single message. This is the basic control flow:
- router is created (socket is bound and ready to accept messages)
- modules are started one by one and each blocks within `bus.register` call where it advertises what outputs it has
- router waits for all modules to send in their outputs and then creates internal links among them according to the config file, then notifies modules that their `bus.register` call has succeeded and they can continue
- router receives published messages one by one and sends them to their respective destinations
- router can process `request_stop` which correctly stops all modules

TODOs before merging:
- [x] implement `is_alive()`
- [x] implement log recording
- [x] add tests
- [x] force-quit non-cooperating node
- [x] implement delay monitoring/logging
- [x] implement main as substitute for record.py
- [x] implement duration for record
- [ ] test extensively in virtual world
- [ ] test on real robots
