### PR TITLE
Allow templated variables in config files.

### DIFF
--- a/osgar/lib/config.py
+++ b/osgar/lib/config.py
@@ -64,4 +64,20 @@ def merge_dict(dict1, dict2):
             ret[key] = dict2[key]
     return ret
 
+
+def expand(cfg, data):
+    if isinstance(cfg, dict):
+        ret = {}
+        for k,v in cfg.items():
+            ret[eval(f"f'{k}'", data)] = expand(v, data)
+        return ret
+    if isinstance(cfg, list):
+        ret = []
+        for v in cfg:
+            ret.append(expand(v, data))
+        return ret
+    if isinstance(cfg, str):
+        return eval(f"f'{cfg}'", data)
+    return cfg
+
 # vim: expandtab sw=4 ts=4

--- a/osgar/lib/test_config.py
+++ b/osgar/lib/test_config.py
@@ -1,6 +1,6 @@
 import os
 import unittest
-from osgar.lib.config import config_load, merge_dict, MergeConflictError, get_class_by_name
+from osgar.lib.config import config_load, merge_dict, MergeConflictError, get_class_by_name, expand
 from osgar.drivers.logsocket import LogTCPStaticIP as LogTCP
 
 def test_data(filename, test_dir='test_data'):
@@ -61,6 +61,23 @@ class ConfigTest(unittest.TestCase):
         self.assertTrue(conf['robot']['modules']['app']['driver'].endswith('lib.test_config:MyTestRobot'))
         conf = config_load(filename, application='osgar.lib.test_config:MyTestRobot')
         self.assertTrue(conf['robot']['modules']['app']['driver'].endswith('lib.test_config:MyTestRobot'))
+
+    def test_expand(self):
+        a = expand('{application}', dict(application="subt"))
+        self.assertEqual(a, 'subt')
+        a = expand('before{application}after', dict(application="subt"))
+        self.assertEqual(a, 'beforesubtafter')
+        a = expand(['{application}'], dict(application="subt"))
+        self.assertEqual(a, ['subt'])
+        a = expand({'{application}': []}, dict(application="subt"))
+        self.assertEqual(a, {'subt': []})
+        a = expand({'{application}': ['{item}']}, dict(application="subt", item='first'))
+        self.assertEqual(a, {'subt': ['first']})
+
+        a = expand('{speed if speed is not None else 0.5}', dict(speed=1))
+        self.assertEqual(a, '1')
+        a = expand('{speed if speed is not None else 0.5}', dict(speed=None))
+        self.assertEqual(a, '0.5')
 
 # vim: expandtab sw=4 ts=4
 

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -8,6 +8,10 @@
                  "sim_time_sec", "acc", "origin"],
           "out": ["desired_speed", "pose2d", "artf_xyz", "pose3d", "stdout", "request_origin"],
           "init": {
+            "walldist": "{walldist}",
+            "side": "{side}",
+            "speed": "{speed}",
+            "timeout": "{timeout}",
             "max_speed": 0.5,
             "symmetric": false,
             "virtual_bumper_sec": 60,


### PR DESCRIPTION
The main advantage is that a cmdline argument can be used multiple times
in the config file and it does not have to be in app.init section. The
disadvantage is that the values are strings so they need to be explicitly
converted on the application side.

This might break some config files used for system track, however I have no good way to find which are relevant and which are obsolete. If if I tried to fix them, I'd have no way to verify the fix :worried:. I hope that the test_subt.py passing is helping in that regard. 

I've converted only those values actually used in virtual track for now since I remember there was
a bug in the implementation of the start_paused, init_path and init_offset and I am not sure what the plan with them is.