### PR TITLE
driver gps: add "try" to "str2ms" function

### DIFF
--- a/osgar/drivers/gps.py
+++ b/osgar/drivers/gps.py
@@ -26,7 +26,8 @@ def str2ms(s):
     dm, frac = (b'0000' + s).split(b'.')
     try:
         return round((int(dm[:-2]) * 60 + float(dm[-2:] + b'.' + frac)) * 60000)
-    except:
+    except Exception as e:
+        print(e)
         return None
 
 

--- a/osgar/drivers/gps.py
+++ b/osgar/drivers/gps.py
@@ -24,7 +24,10 @@ def str2ms(s):
     if s == b'':  # unknown position
         return None
     dm, frac = (b'0000' + s).split(b'.')
-    return round((int(dm[:-2]) * 60 + float(dm[-2:] + b'.' + frac)) * 60000)
+    try:
+        return round((int(dm[:-2]) * 60 + float(dm[-2:] + b'.' + frac)) * 60000)
+    except:
+        return None
 
 
 def parse_line(line):

--- a/osgar/drivers/test_gps.py
+++ b/osgar/drivers/test_gps.py
@@ -11,6 +11,9 @@ class GPSTest(unittest.TestCase):
     def test_str2ms(self):
         self.assertEqual(gps.str2ms(b'5007.71882'), 180463129)
 
+    def test_str2ms_err_input(self):
+        self.assertEqual(gps.str2ms(b'01422.489915\x0052'), None) # the checksum is passing because a zero byte is added
+
     def test_parse_line(self):
         line = b'$GNGGA,182433.10,5007.71882,N,01422.50467,E,1,05,6.09,305.1,M,44.3,M,,*41'
         self.assertEqual(gps.parse_line(line), [51750280, 180463129])  # arc milliseconds (x, y) = (lon, lat)


### PR DESCRIPTION
Workaround for nonsensical data received from GPS (usually during gps start).