### PR TITLE
osgar.lib.serialize: refactor compress out from serialize

### DIFF
--- a/osgar/bus.py
+++ b/osgar/bus.py
@@ -102,7 +102,7 @@ class _BusHandler:
             else:
                 to_write = serialize(data)
                 if stream_id in self.compressed_output:
-                    to_write = compress(data)
+                    to_write = compress(to_write)
             timestamp = self.logger.write(stream_id, to_write)
 
             if self._time is not None:

--- a/osgar/bus.py
+++ b/osgar/bus.py
@@ -8,7 +8,7 @@ from queue import Queue
 from datetime import timedelta
 from collections import deque
 
-from osgar.lib.serialize import serialize, deserialize
+from osgar.lib.serialize import serialize, deserialize, compress
 
 
 # restrict replay time from given input
@@ -100,7 +100,9 @@ class _BusHandler:
             if stream_id in self.no_output:
                 to_write = serialize(None)  # i.e. at least there will be timestamp record
             else:
-                to_write = serialize(data, compress=(stream_id in self.compressed_output))
+                to_write = serialize(data)
+                if stream_id in self.compressed_output:
+                    to_write = compress(data)
             timestamp = self.logger.write(stream_id, to_write)
 
             if self._time is not None:

--- a/osgar/drivers/realsense.py
+++ b/osgar/drivers/realsense.py
@@ -46,7 +46,7 @@ def t265_to_osgar_orientation(t265_orientation):
 class RealSense(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
-        bus.register('pose2d', 'pose3d', 'pose_raw', 'orientation', 'depth')
+        bus.register('pose2d', 'pose3d', 'pose_raw', 'orientation', 'depth:gz')
         self.verbose = config.get('verbose', False)
         self.depth_subsample = config.get("depth_subsample", 3)
         self.pose_subsample = config.get("pose_subsample", 20)

--- a/osgar/lib/serialize.py
+++ b/osgar/lib/serialize.py
@@ -12,7 +12,8 @@ except:
     numpy = False
 
 MSGPACK_ZLIB_CODE = 42
-MSGPACK_NUMPY_CODE = 43
+MSGPACK_NUMPY_ZLIB_CODE = 43
+MSGPACK_NUMPY_CODE = 44
 
 
 def serialize(data, compress=False):
@@ -20,8 +21,11 @@ def serialize(data, compress=False):
         with BytesIO() as b:
             numpy.save(b, data, allow_pickle=False)
             data = b.getvalue()
-        data = zlib.compress(data)
-        data = msgpack.ExtType(MSGPACK_NUMPY_CODE, data)
+        if compress:
+            data = zlib.compress(data)
+            data = msgpack.ExtType(MSGPACK_NUMPY_ZLIB_CODE, data)
+        else:
+            data = msgpack.ExtType(MSGPACK_NUMPY_CODE, data)
     elif compress:
         packed_data = zlib.compress(msgpack.packb(data, use_bin_type=True))
         data = msgpack.ExtType(MSGPACK_ZLIB_CODE, packed_data)
@@ -33,14 +37,17 @@ def deserialize(bytes_data):
     data = msgpack.unpackb(bytes_data, raw=False)
     if isinstance(data, msgpack.ExtType):
         if data.code == MSGPACK_ZLIB_CODE:
-            assert data.code == MSGPACK_ZLIB_CODE, data.code
             data = zlib.decompress(data.data)
             data = msgpack.unpackb(data, raw=False)
-        elif data.code == MSGPACK_NUMPY_CODE:
+        elif data.code == MSGPACK_NUMPY_ZLIB_CODE:
             if not numpy:
                 raise TypeError("TypeError: can not deserialize 'numpy.ndarray' object")
             data = zlib.decompress(data.data)
             data = numpy.load(BytesIO(data), allow_pickle=False)
+        elif data.code == MSGPACK_NUMPY_CODE:
+            if not numpy:
+                raise TypeError("TypeError: can not deserialize 'numpy.ndarray' object")
+            data = numpy.load(BytesIO(data.data), allow_pickle=False)
     return data
 
 # vim: expandtab sw=4 ts=4

--- a/osgar/lib/serialize.py
+++ b/osgar/lib/serialize.py
@@ -12,34 +12,33 @@ except:
     numpy = False
 
 MSGPACK_ZLIB_CODE = 42
-MSGPACK_NUMPY_ZLIB_CODE = 43
+MSGPACK_NUMPY_ZLIB_CODE = 43 # for old logs only, no longer used
 MSGPACK_NUMPY_CODE = 44
 
 
-def serialize(data, compress=False):
+def serialize(data):
     if numpy and isinstance(data, (numpy.ndarray, numpy.generic)):
         with BytesIO() as b:
             numpy.save(b, data, allow_pickle=False)
             data = b.getvalue()
-        if compress:
-            data = zlib.compress(data)
-            data = msgpack.ExtType(MSGPACK_NUMPY_ZLIB_CODE, data)
-        else:
-            data = msgpack.ExtType(MSGPACK_NUMPY_CODE, data)
-    elif compress:
-        packed_data = zlib.compress(msgpack.packb(data, use_bin_type=True))
-        data = msgpack.ExtType(MSGPACK_ZLIB_CODE, packed_data)
+        data = msgpack.ExtType(MSGPACK_NUMPY_CODE, data)
 
+    return msgpack.packb(data, use_bin_type=True)
+
+
+def compress(data):
+    zlib_data = zlib.compress(data)
+    data = msgpack.ExtType(MSGPACK_ZLIB_CODE, zlib_data)
     return msgpack.packb(data, use_bin_type=True)
 
 
 def deserialize(bytes_data):
     data = msgpack.unpackb(bytes_data, raw=False)
-    if isinstance(data, msgpack.ExtType):
+    while isinstance(data, msgpack.ExtType):
         if data.code == MSGPACK_ZLIB_CODE:
             data = zlib.decompress(data.data)
             data = msgpack.unpackb(data, raw=False)
-        elif data.code == MSGPACK_NUMPY_ZLIB_CODE:
+        elif data.code == MSGPACK_NUMPY_ZLIB_CODE: # for old logs only, no longer used
             if not numpy:
                 raise TypeError("TypeError: can not deserialize 'numpy.ndarray' object")
             data = zlib.decompress(data.data)

--- a/osgar/lib/test_serialize.py
+++ b/osgar/lib/test_serialize.py
@@ -26,10 +26,15 @@ class SerializeTest(unittest.TestCase):
     def test_numpy(self):
         data = numpy.asarray(range(1, 100, 2), dtype=numpy.uint16)
         packet = serialize(data)
-        self.assertEqual(len(packet), 163)
+        packet_zlib = serialize(data, compress=True)
+        self.assertEqual(len(packet), 231)
+        self.assertEqual(len(packet_zlib), 163)
         dedata = deserialize(packet)
+        dedata_zlib = deserialize(packet_zlib)
         self.assertTrue(numpy.array_equal(dedata, data))
         self.assertEqual(dedata.dtype, data.dtype)
+        self.assertTrue(numpy.array_equal(dedata_zlib, data))
+        self.assertEqual(dedata_zlib.dtype, data.dtype)
 
         with unittest.mock.patch('osgar.lib.serialize.numpy', new=False):
             with self.assertRaises(TypeError):

--- a/osgar/lib/test_serialize.py
+++ b/osgar/lib/test_serialize.py
@@ -2,7 +2,7 @@ import unittest
 import unittest.mock
 import numpy
 
-from osgar.lib.serialize import serialize, deserialize
+from osgar.lib.serialize import serialize, deserialize, compress
 
 
 class SerializeTest(unittest.TestCase):
@@ -19,20 +19,21 @@ class SerializeTest(unittest.TestCase):
         self.assertEqual(len(packet), 1003)
         self.assertEqual(deserialize(packet), data)
 
-        compressed_packet = serialize(data, compress=True)
+        compressed_packet = compress(packet)
         self.assertEqual(len(compressed_packet), 22)
         self.assertEqual(deserialize(compressed_packet), data)
 
     def test_numpy(self):
         data = numpy.asarray(range(1, 100, 2), dtype=numpy.uint16)
         packet = serialize(data)
-        packet_zlib = serialize(data, compress=True)
+        packet_zlib = compress(packet)
         self.assertEqual(len(packet), 231)
-        self.assertEqual(len(packet_zlib), 163)
+        self.assertEqual(len(packet_zlib), 168)
         dedata = deserialize(packet)
-        dedata_zlib = deserialize(packet_zlib)
         self.assertTrue(numpy.array_equal(dedata, data))
         self.assertEqual(dedata.dtype, data.dtype)
+
+        dedata_zlib = deserialize(packet_zlib)
         self.assertTrue(numpy.array_equal(dedata_zlib, data))
         self.assertEqual(dedata_zlib.dtype, data.dtype)
 


### PR DESCRIPTION
For the work using zeromq for communication I need to separate compression from the serialization (to be able to compress data going to log only). 

I also decouple compression from numpy arrays - numpy arrays used to be compressed unconditionally which has caused confusion (at least for me) several times already.

I've kept the deserialization code backward compatible so that it is able to read older logs where numpy arrays are compressed always.