### PR TITLE
Move logsending out from ros_proxy_node.cc into sendlog.py

### DIFF
--- a/osgar/drivers/rosmsg.py
+++ b/osgar/drivers/rosmsg.py
@@ -569,17 +569,8 @@ class ROSMsgParser(Thread):
         cmd = b'request_origin'
         self.bus.publish('cmd', cmd)
 
-    def send_filename(self):
-        try:
-            filename = self.bus.logger.filename  # deep hack
-        except AttributeError:
-            filename = "unknown"  # workaround for replay
-        cmd = b'file ' + bytes(filename, encoding='ascii')
-        self.bus.publish('cmd', cmd)
-
     def run(self):
         try:
-            self.send_filename()
             while True:
                 timestamp, channel, data = self.bus.listen()
                 if channel == 'raw':

--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -84,12 +84,12 @@ class LogWriter:
 
         if not pathlib.Path(self.filename).is_absolute():
             if ENV_OSGAR_LOGS in os.environ:
-                os.makedirs(os.environ[ENV_OSGAR_LOGS], exist_ok=True)
                 self.filename = os.path.join(os.environ[ENV_OSGAR_LOGS], self.filename)
             else:
                 logging.warning('Environment variable %s is not set - using working directory' % ENV_OSGAR_LOGS)
             self.filename = str(pathlib.Path(self.filename).absolute())
 
+        os.makedirs(pathlib.Path(self.filename).parent, exist_ok=True)
         self.f = open(self.filename, 'wb')
 
         self.f.write(b"".join(format_header(self.start_time)))

--- a/subt/docker/robotika/run_solution.bash
+++ b/subt/docker/robotika/run_solution.bash
@@ -46,8 +46,8 @@ roslaunch $LAUNCH_FILE --wait robot_name:=$ROBOT_NAME &
 
 /osgar-ws/src/osgar/subt/cloudsim2osgar.py $ROBOT_NAME &
 
+LOG_FILE=/osgar-ws/logs/$(basename $CONFIG_FILE .json)-$(date +%Y-%m-%dT%H.%M.%S).log
 CONFIG_FILE=/osgar-ws/src/osgar/subt/$CONFIG_FILE
-LOG_FILE=/osgar-ws/logs/zmq-subt-x2-$(date +%Y-%m-%dT%H.%M.%S).log
 PYTHON=/osgar-ws/env/bin/python3
 
 rosrun proxy sendlog.py $LOG_FILE &

--- a/subt/docker/robotika/run_solution.bash
+++ b/subt/docker/robotika/run_solution.bash
@@ -49,6 +49,9 @@ roslaunch $LAUNCH_FILE --wait robot_name:=$ROBOT_NAME &
 CONFIG_FILE=/osgar-ws/src/osgar/subt/$CONFIG_FILE
 LOG_FILE=/osgar-ws/logs/zmq-subt-x2-$(date +%Y-%m-%dT%H.%M.%S).log
 PYTHON=/osgar-ws/env/bin/python3
+
+rosrun proxy sendlog.py $LOG_FILE &
+
 echo "Starting osgar"
 $PYTHON -m subt run $CONFIG_FILE --log $LOG_FILE --side auto --walldist 0.8 --speed 1.0 --note "run_solution.bash"
 

--- a/subt/docker/robotika/run_solution.bash
+++ b/subt/docker/robotika/run_solution.bash
@@ -38,6 +38,7 @@ else
     LAUNCH_FILE="proxy sim.launch"
     CONFIG_FILE="zmq-subt-x2.json"
 fi
+
 echo "Starting ros<->osgar proxy"
 # Wait for ROS master, then start ros nodes
 # http://wiki.ros.org/roslaunch/Commandline%20Tools#line-45 
@@ -45,9 +46,11 @@ roslaunch $LAUNCH_FILE --wait robot_name:=$ROBOT_NAME &
 
 /osgar-ws/src/osgar/subt/cloudsim2osgar.py $ROBOT_NAME &
 
+CONFIG_FILE=/osgar-ws/src/osgar/subt/$CONFIG_FILE
+LOG_FILE=/osgar-ws/logs/zmq-subt-x2-$(date +%Y-%m-%dT%H.%M.%S).log
+PYTHON=/osgar-ws/env/bin/python3
 echo "Starting osgar"
-export OSGAR_LOGS=/osgar-ws/logs
-/osgar-ws/env/bin/python3 -m subt run /osgar-ws/src/osgar/subt/$CONFIG_FILE --side auto --walldist 0.8 --timeout 100 --speed 1.0 --note "run_solution.bash"
+$PYTHON -m subt run $CONFIG_FILE --log $LOG_FILE --side auto --walldist 0.8 --speed 1.0 --note "run_solution.bash"
 
 echo "Sleep and finish"
 sleep 30

--- a/subt/main.py
+++ b/subt/main.py
@@ -830,17 +830,6 @@ class SubTChallenge:
 
         self.wait(timedelta(seconds=10), use_sim_time=True)
 
-    def dumplog(self):
-        import os
-        filename = self.bus.logger.filename  # deep hack
-        self.stdout("Dump Log:", filename)
-        size = statinfo = os.stat(filename).st_size
-        self.stdout("Size:", size)
-        with open(filename, 'rb') as f:
-            for i in range(0, size, 100):
-                self.stdout(i, f.read(100))
-        self.stdout("Dump END")
-
     def play_virtual_track(self):
         self.stdout("SubT Challenge Ver65!")
         self.stdout("Waiting for robot_name ...")

--- a/subt/ros/proxy/sendlog.py
+++ b/subt/ros/proxy/sendlog.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python2
+
+import sys
+import os.path
+import time
+
+import rospy
+import std_msgs.msg
+
+ROSBAG_SIZE_LIMIT = 3000000000  #3GB
+
+
+def main(*args):
+    log_filename = args[1]
+    rospy.init_node('sendlog', log_level=rospy.DEBUG)
+    pub = rospy.Publisher("/robot_data", std_msgs.msg.String, queue_size=1)
+
+    rospy.loginfo("waiting for subscriber on /robot_data")
+    while pub.get_num_connections() == 0:
+        if rospy.is_shutdown():
+            return
+        time.sleep(0.1)
+
+    rospy.loginfo("waiting for {}".format(log_filename))
+    while not os.path.isfile(log_filename):
+        if rospy.is_shutdown():
+            return
+        time.sleep(0.1)
+
+    rospy.loginfo("opening {}".format(log_filename))
+    with open(log_filename, 'rb') as log_file:
+        count = 0
+        while not rospy.is_shutdown():
+            msg = std_msgs.msg.String()
+            msg.data = "{}: Hello robot".format(rospy.get_time())
+            pub.publish(msg)
+
+            msg.data = log_file.read()
+            if log_file.tell() >= ROSBAG_SIZE_LIMIT:
+                rospy.warn("ROSBAG_SIZE_LIMIT reached, exiting log sending node")
+                return
+            pub.publish(msg)
+            rospy.loginfo_throttle(10, str(count))
+            time.sleep(0.1)
+            count += 1
+
+    rospy.loginfo("done sending {}".format(log_filename))
+
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        print("need log filename as argument")
+        raise SystemExit(1)
+    main(*sys.argv)
+

--- a/subt/script/bridge.bash
+++ b/subt/script/bridge.bash
@@ -13,6 +13,9 @@ CONFIG="${CONFIG:-ROBOTIKA_X2_SENSOR_CONFIG_1}"
 
 cd $(git rev-parse --show-toplevel)
 
+DOCKER_OPTS="--name bridge"
+export DOCKER_OPTS
+
 ./subt/docker/run.bash osrf/subt-virtual-testbed:cloudsim_bridge_latest \
   circuit:=$CIRCUIT \
   worldName:=$WORLD \

--- a/subt/script/devel.bash
+++ b/subt/script/devel.bash
@@ -4,7 +4,7 @@ cd "$(git rev-parse --show-toplevel)" || exit
 
 DIR=$(pwd)
 
-DOCKER_OPTS="--volume ${DIR}:/osgar-ws/src/osgar"
+DOCKER_OPTS="--volume ${DIR}:/osgar-ws/src/osgar --name devel"
 export DOCKER_OPTS
 
 ./subt/docker/run.bash robotika:latest bash

--- a/subt/script/sim.bash
+++ b/subt/script/sim.bash
@@ -17,7 +17,7 @@ mkdir -p $LOG_DIR
 
 trap 'echo; echo $LOG_DIR; echo $ROBOT; echo $WORLD; echo;' EXIT
 
-DOCKER_OPTS="--volume ${LOG_DIR}:/tmp/ign/logs"
+DOCKER_OPTS="--volume ${LOG_DIR}:/tmp/ign/logs --name sim"
 export DOCKER_OPTS
 
 termtitle "sim $ROBOT $WORLD"


### PR DESCRIPTION
There are several not that related changes here but I felt they are so small they might not be worth their own PR (given that we already have several PR open).

The main goal was to move logsending out from ros_proxy_node.cc into a separate rospy-based node because the "deep hack" in rosmsg.py was not working for zmq-based communication (not surprisingly).