### PR TITLE
Feature/moon convert to sim time fix

### DIFF
--- a/moon/controller.py
+++ b/moon/controller.py
@@ -157,9 +157,6 @@ class SpaceRoboticsChallenge(MoonNode):
         self.send_request('set_brakes %s\n' % ('on' if on else 'off'))
         print (self.sim_time, "app: Brakes set to: %s" % on)
 
-    def on_sim_clock(self, data):
-        self.sim_time = timedelta(seconds=data[0], microseconds=data[1] // 1000)
-
     def on_driving_recovery(self, data):
         self.in_driving_recovery = data
         print (self.sim_time, "Driving recovery changed to: %r" % data)

--- a/moon/controller.py
+++ b/moon/controller.py
@@ -6,13 +6,14 @@ from random import Random
 from datetime import timedelta
 from statistics import median
 
-from osgar.node import Node
 from osgar.bus import BusShutdownException
 from osgar.lib import quaternion
 from osgar.lib.mathex import normalizeAnglePIPI
 from osgar.lib.virtual_bumper import VirtualBumper
 
 from subt.local_planner import LocalPlanner
+
+from moon.moonnode import MoonNode
 
 
 class ChangeDriverException(Exception):
@@ -73,13 +74,11 @@ class LidarCollisionMonitor:
         self.robot.unregister(self.callback)
 
 
-class SpaceRoboticsChallenge(Node):
+class SpaceRoboticsChallenge(MoonNode):
     def __init__(self, config, bus):
         super().__init__(config, bus)
         bus.register("desired_speed", "artf_xyz", "artf_cmd", "pose2d", "pose3d", "driving_recovery", "request", "cmd")
 
-        self.sim_time = None
-        self.monitors = []
         self.last_position = None
         self.max_speed = 1.0  # oficial max speed is 1.5m/s
         self.max_angular_speed = math.radians(60)
@@ -236,13 +235,6 @@ class SpaceRoboticsChallenge(Node):
                 print (self.sim_time, "Loc: [%f %f %f] [%f %f %f]; Driver: %s; Score: %d" % (x, y, z, self.roll, self.pitch, self.yaw, self.current_driver, self.score))
 
         channel = super().update()
-        handler = getattr(self, "on_" + channel, None)
-        if handler is not None:
-            handler(getattr(self, channel))
-
-        for m in self.monitors:
-            m(self, channel)
-
         return channel
 
     def go_straight(self, how_far, timeout=None):

--- a/moon/moonnode.py
+++ b/moon/moonnode.py
@@ -13,7 +13,7 @@ class MoonNode(Node):
         self.monitors = []
 
     def on_sim_clock(self, data):
-        self.sim_time = timedelta(seconds=data[0], microseconds=data[1] // 1000)
+        self.sim_time = timedelta(seconds=data[0], microseconds=data[1])
 
     def update(self):
         channel = super().update()

--- a/moon/moonnode.py
+++ b/moon/moonnode.py
@@ -1,0 +1,28 @@
+"""
+  MoonNode - parent for Moon processing nodes
+"""
+from osgar.node import Node
+
+
+class MoonNode(Node):
+    def __init__(self, config, bus):
+        super().__init__(config, bus)
+        self.sim_time = None
+        self.monitors = []
+
+    def on_sim_clock(self, data):
+        self.sim_time = timedelta(seconds=data[0], microseconds=data[1] // 1000)
+
+    def update(self):
+        channel = super().update()
+
+        handler = getattr(self, "on_" + channel, None)
+        if handler is not None:
+            handler(getattr(self, channel))
+
+        for m in self.monitors:
+            m(self, channel)
+
+        return channel
+
+# vim: expandtab sw=4 ts=4

--- a/moon/moonnode.py
+++ b/moon/moonnode.py
@@ -1,6 +1,8 @@
 """
   MoonNode - parent for Moon processing nodes
 """
+from datetime import timedelta
+
 from osgar.node import Node
 
 

--- a/moon/rospy/rospy_base.py
+++ b/moon/rospy/rospy_base.py
@@ -87,7 +87,7 @@ class RospyBasePushPull(Thread):
 
     def callback_clock(self, data):
         if (self.prev_time is not None and 
-                prev_time.nsecs//100_000_000 != data.clock.nsecs//100_000_000):
+                prev_time.nsecs//100000000 != data.clock.nsecs//100000000):
             # run at 10Hz, i.e. every 100ms
             s1 = BytesIO()
             data.serialize(s1)

--- a/moon/rospy/rospy_base.py
+++ b/moon/rospy/rospy_base.py
@@ -87,7 +87,7 @@ class RospyBasePushPull(Thread):
 
     def callback_clock(self, data):
         if (self.prev_time is not None and 
-                prev_time.nsecs//100000000 != data.clock.nsecs//100000000):
+                self.prev_time.nsecs//100000000 != data.clock.nsecs//100000000):
             # run at 10Hz, i.e. every 100ms
             s1 = BytesIO()
             data.serialize(s1)

--- a/moon/vehicles/rover.py
+++ b/moon/vehicles/rover.py
@@ -60,7 +60,8 @@ import math
 from datetime import timedelta
 
 from osgar.lib.mathex import normalizeAnglePIPI
-from osgar.node import Node
+
+from moon.moonnode import MoonNode
 
 
 WHEEL_RADIUS = 0.275  # meters
@@ -71,12 +72,10 @@ WHEEL_NAMES = ['fl', 'fr', 'bl', 'br']
 
 CRAB_ROLL_ANGLE = 0.78
 
-class Rover(Node):
+class Rover(MoonNode):
     def __init__(self, config, bus):
         super().__init__(config, bus)
         bus.register('cmd', 'pose2d')
-
-        self.sim_time = None
 
         # general driving parameters
         # radius: radius of circle to drive around, "inf" if going straight; 0 if turning round in place
@@ -101,9 +100,6 @@ class Rover(Node):
         self.yaw = 0.0
         self.yaw_offset = None
         self.in_driving_recovery = False
-
-    def on_sim_clock(self, data):
-        self.sim_time = timedelta(seconds=data[0], microseconds=data[1] // 1000)
 
     def on_driving_recovery(self, data):
         self.in_driving_recovery = data
@@ -281,15 +277,6 @@ class Rover(Node):
 
         cmd = b'cmd_rover %f %f %f %f %f %f %f %f' % tuple(steering + effort)
         self.bus.publish('cmd', cmd)
-
-    def update(self):
-        channel = super().update()
-        handler = getattr(self, "on_" + channel, None)
-        if handler is not None:
-            handler(getattr(self, channel))
-
-        return channel
-
 
     def draw(self):
         # for debugging

--- a/osgar/drivers/rosmsg.py
+++ b/osgar/drivers/rosmsg.py
@@ -532,7 +532,7 @@ class ROSMsgParser(Thread):
         elif frame_id.endswith(b'/clock'):
             prev = self.timestamp_sec
             self.timestamp_sec, self.timestamp_nsec = parse_clock(packet)
-            self.bus.publish('sim_clock', [self.timestamp_sec, self.timestamp_nsec])
+            self.bus.publish('sim_clock', [self.timestamp_sec, self.timestamp_nsec//1000])  # publish us resolution (~Python.timedelta)
             if prev != self.timestamp_sec:
                 self.bus.publish('sim_time_sec', self.timestamp_sec)
 


### PR DESCRIPTION
These are proposed changes to `feature/moon-convert-to-sim-time` branch:
* introduction of MoonNode
* downsample Clock to 10Hz (simulated time)
* report time as pair of integers (secocnds, microseconds)

Note, that the 3rd change is different to original proposal. The motivation is that we are modifying common `rosmsg.py` which is part of `osgar` and there the time base resolution is defined by Python `datetime.timedelta`, which is in microseconds.