### PR TITLE
Feature/moon routerdealer step1

### DIFF
--- a/moon/controller.py
+++ b/moon/controller.py
@@ -138,7 +138,7 @@ class SpaceRoboticsChallenge(MoonNode):
             self.virtual_bumper.update_desired_speed(speed, angular_speed)
         self.bus.publish('desired_speed', [round(speed*1000), round(math.degrees(angular_speed)*100)])
 
-    def on_response(self, timestamp, data):
+    def on_response(self, data):
         token, response = data
         print(self.time, "controller:response received: token=%s, response=%s" % (token, response))
         callback = self.requests[token]
@@ -153,7 +153,7 @@ class SpaceRoboticsChallenge(MoonNode):
         print(self.time, "controller:send_request:token: %s, command: %s" % (token, cmd))
         self.publish('request', [token, cmd])
 
-        while blocking:  # this is kept here for backward compatibility and will be removed ASAP
+        while callback is None and blocking:  # this is kept here for backward compatibility and will be removed ASAP
             dt, channel, data = self.listen()
             if channel == 'response':
                 response_token, response = data

--- a/moon/controller.py
+++ b/moon/controller.py
@@ -123,6 +123,8 @@ class SpaceRoboticsChallenge(MoonNode):
         self.virtual_bumper = None
         self.rand = Random(0)
 
+        self.requests = {}
+
     def register(self, callback):
         self.monitors.append(callback)
         return callback
@@ -136,13 +138,27 @@ class SpaceRoboticsChallenge(MoonNode):
             self.virtual_bumper.update_desired_speed(speed, angular_speed)
         self.bus.publish('desired_speed', [round(speed*1000), round(math.degrees(angular_speed)*100)])
 
-    def send_request(self, cmd):
-        """Send ROS Service Request form a single place"""
-        self.publish('request', cmd)
-        while True:
+    def on_response(self, timestamp, data):
+        token, response = data
+        print(self.time, "controller:response received: token=%s, response=%s" % (token, response))
+        callback = self.requests[token]
+        self.requests.pop(token)
+        if callback is not None:
+            callback(response)
+
+    def send_request(self, cmd, callback=None, blocking=True):
+        """Send ROS Service Request from a single place"""
+        token = hex(self.rand.getrandbits(128))
+        self.requests[token] = callback
+        print(self.time, "controller:send_request:token: %s, command: %s" % (token, cmd))
+        self.publish('request', [token, cmd])
+
+        while blocking:  # this is kept here for backward compatibility and will be removed ASAP
             dt, channel, data = self.listen()
             if channel == 'response':
-                return data
+                response_token, response = data
+                assert token == response_token, (token, response_token)
+                return response
             print(dt, 'ignoring', channel)
 
     def set_cam_angle(self, angle):

--- a/moon/test_controller.py
+++ b/moon/test_controller.py
@@ -1,0 +1,48 @@
+import unittest
+from unittest.mock import MagicMock
+from datetime import timedelta
+
+from osgar.bus import Bus
+
+from moon.controller import SpaceRoboticsChallenge
+
+
+class EchoController(SpaceRoboticsChallenge):
+    pass
+
+
+echo_data = None
+
+class ControllerTest(unittest.TestCase):
+    def test_callback(self):
+        global echo_data
+
+        def echo_callback(data):
+            global echo_data
+            echo_data = data
+
+        config = {}
+        bus = Bus(MagicMock(write=MagicMock(return_value=timedelta())))
+
+        echo = EchoController(config, bus=bus.handle('echo'))
+
+        tester = bus.handle('tester')
+        tester.register("response")
+        bus.connect("tester.response", "echo.response")
+        bus.connect("echo.request", "tester.request")
+
+        echo.send_request('hello!', echo_callback)
+        echo.start()
+
+        _, channel, data = tester.listen()
+        self.assertEqual(data, ['0xe3e70682c2094cac629f6fbed82c07cd', 'hello!'])
+        tester.publish('response', data)
+
+        echo.bus.sleep(0.1)
+        self.assertEqual(echo_data, 'hello!')
+
+        echo.request_stop()
+        echo.join()
+
+# vim: expandtab sw=4 ts=4
+

--- a/osgar/drivers/logzeromq.py
+++ b/osgar/drivers/logzeromq.py
@@ -84,14 +84,15 @@ class LogZeroMQ:
         try:
             while True:
                 dt, __, data = self.bus.listen()
-                socket.send_string(data)
+                token, request = data
+                socket.send_string(request)
                 while self.bus.is_alive():
                     try:
                         resp = socket.recv()
-                        self.bus.publish('response', resp)
+                        self.bus.publish('response', [token, resp])
                         break
                     except zmq.error.Again:
-                        self.bus.publish('timeout', True)
+                        self.bus.publish('timeout', [token, True])
         except BusShutdownException:
             pass
         socket.close()

--- a/osgar/drivers/test_logzeromq.py
+++ b/osgar/drivers/test_logzeromq.py
@@ -54,7 +54,7 @@ class LogZeroMQTest(unittest.TestCase):
         socket.bind('tcp://127.0.0.1:5557')
 
         bus = MagicMock()
-        bus.listen = MagicMock(return_value=(1, 2, 'set_brakes on\n'))
+        bus.listen = MagicMock(return_value=(1, 2, ['abcd', 'set_brakes on\n']))
         bus.is_alive = MagicMock(return_value=True)
         node = LogZeroMQ(config, bus)
         node.start()
@@ -66,6 +66,6 @@ class LogZeroMQTest(unittest.TestCase):
         msg = socket.recv()
         node.join()
         self.assertEqual(msg, b'set_brakes on\n')
-        bus.publish.assert_called_with('timeout', True)
+        bus.publish.assert_called_with('timeout', ['abcd', True])
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
This is the first step of #527 replacement - it provides the new callback functionality in `controller.py` but allows backward compatibility with `blocking=true` (which will be removed at the end). Also the communication between request/response modules is now using extra token.