### PR TITLE
Feature/moon routerdealer step2

### DIFF
--- a/moon/config/moon-round3.json
+++ b/moon/config/moon-round3.json
@@ -27,11 +27,11 @@
         }
       },
       "rpc": {
-        "driver": "zeromq",
+        "driver": "moon.zmqpool:ZMQPool",
         "in": ["request"],
         "out": ["response"],
         "init": {
-          "mode": "REQ",
+          "pool_size": 5,
           "endpoint": "tcp://localhost:5557",
           "save_data": true
         }

--- a/moon/test_zmqpool.py
+++ b/moon/test_zmqpool.py
@@ -16,10 +16,10 @@ class ZMQPoolTest(unittest.TestCase):
             super().__init__()
             self.msg = b''
             self.stop_requested = False
-            
+
         def stop(self):
             self.stop_requested = True
-            
+
         def run(self):
             context = zmq.Context()
             socket = context.socket(zmq.REP)
@@ -31,15 +31,15 @@ class ZMQPoolTest(unittest.TestCase):
                     socket.send_string("OK")
                 except zmq.Again:
                     pass
-                
+
         def get_message(self):
             return self.msg
-        
+
     def test_req(self):
         config = {
-            'mode': 'REQ',
             'endpoint': 'tcp://localhost:5557',
-            'timeout': 0.1
+            'timeout': 0.1,
+            'pool_size': 2
         }
         bus = MagicMock()
         bus.listen = MagicMock(return_value=(1, 2, ['abcdef', 'set_brakes on']))

--- a/moon/test_zmqpool.py
+++ b/moon/test_zmqpool.py
@@ -1,0 +1,64 @@
+import unittest
+from unittest.mock import MagicMock
+import time
+from threading import Thread
+
+import zmq
+
+from moon.zmqpool import ZMQPool
+from osgar.bus import BusShutdownException
+
+
+class ZMQPoolTest(unittest.TestCase):
+
+    class DummyROSServer(Thread):
+        def __init__(self):
+            super().__init__()
+            self.msg = b''
+            self.stop_requested = False
+            
+        def stop(self):
+            self.stop_requested = True
+            
+        def run(self):
+            context = zmq.Context()
+            socket = context.socket(zmq.REP)
+            socket.RCVTIMEO = 1000
+            socket.bind('tcp://127.0.0.1:5557')
+            while not self.stop_requested:
+                try:
+                    self.msg = socket.recv()
+                    socket.send_string("OK")
+                except zmq.Again:
+                    pass
+                
+        def get_message(self):
+            return self.msg
+        
+    def test_req(self):
+        config = {
+            'mode': 'REQ',
+            'endpoint': 'tcp://localhost:5557',
+            'timeout': 0.1
+        }
+        bus = MagicMock()
+        bus.listen = MagicMock(return_value=(1, 2, ['abcdef', 'set_brakes on']))
+        bus.is_alive = MagicMock(return_value=True)
+        node = ZMQPool(config, bus)
+
+        t = self.DummyROSServer()
+        t.start()
+        node.start()
+        time.sleep(0.1)  # give it a chance to start
+        node.request_stop()
+        bus.listen = MagicMock(side_effect=BusShutdownException())
+        bus.is_alive = MagicMock(return_value=False)  # supplement mock request_stop()
+        node.join()
+        t.stop()
+        msg = t.get_message()
+        t.join()
+
+        self.assertEqual(msg, b'set_brakes on')
+        bus.publish.assert_called_with('response', ['abcdef', 'OK'])
+
+# vim: expandtab sw=4 ts=4

--- a/moon/zmqpool.py
+++ b/moon/zmqpool.py
@@ -1,0 +1,104 @@
+"""
+  ZeroMQ Thread Pool for handling multiple ROS services
+"""
+
+from threading import Thread
+
+import zmq
+
+from osgar.bus import BusShutdownException
+
+
+class ZMQPool:
+    def __init__(self, config, bus):
+        bus.register('raw:gz' if config.get('save_data', False) else 'raw:null', 'response', 'timeout')
+        mode = config['mode']
+        self.endpoint = config['endpoint']
+        self.timeout = config.get('timeout', 1)  # default recv timeout 1s
+
+        # support only mode='REQ'
+        self.thread = Thread(target=self.run_reqrep)
+
+        self.thread.name = bus.name
+        self.bus = bus
+
+    def start(self):
+        self.thread.start()
+
+    def join(self, timeout=None):
+        self.thread.join(timeout=timeout)
+    
+    class ReqRepWorker(Thread):
+        def __init__(self, context, bus, endpoint):
+            Thread.__init__ (self)
+            self.context = context
+            self.bus = bus
+
+            self.rossocket = context.socket(zmq.REQ)
+            self.rossocket.RCVTIMEO = int(2000)
+            self.rossocket.connect(endpoint)
+            self.stop_requested = False
+            
+        def stop(self):
+            self.stop_requested = True
+            
+        def run(self):
+            worker = self.context.socket(zmq.REQ)
+            worker.setsockopt(zmq.LINGER, 0)
+            worker.RCVTIMEO = 1000 
+            worker.connect('inproc://reqrepbackend')
+
+            def run_loop():
+                while not self.stop_requested:
+                    try:
+                        worker.send(b"ready")
+                        while True:
+                            try:
+                                data = worker.recv()
+                                break
+                            except zmq.Again:
+                                if self.stop_requested:
+                                    return
+
+                        ident, msg = data.decode('ascii').split('|')
+                        self.rossocket.send_string(msg)
+                        rsp = self.rossocket.recv().decode('ascii')
+                        self.bus.publish('response', [ident, rsp])
+                    except Exception as e:
+                        print("logzeromq thread: %s" % str(e))
+
+            run_loop()
+            worker.close()
+            self.rossocket.close()
+            
+    def run_reqrep(self):
+        context = zmq.Context()
+        backend = context.socket(zmq.ROUTER)
+        backend.bind('inproc://reqrepbackend')
+
+        workers = []
+        for i in range(5):
+            worker = self.ReqRepWorker(context, self.bus, self.endpoint)
+            worker.start()
+            workers.append(worker)
+
+        try:
+            while True:
+                dt, __, data = self.bus.listen()
+                # data is [<ident>, <ROS request payload>]
+                ident, payload = data
+                address, empty, ready = backend.recv_multipart()                
+                backend.send_multipart([address, b'', (ident + '|' + payload).encode('ascii')])
+
+        except BusShutdownException:
+            for w in workers:
+                w.stop()
+                w.join()
+
+        backend.close()
+        context.term()
+
+    def request_stop(self):
+        self.bus.shutdown()
+
+# vim: expandtab sw=4 ts=4

--- a/moon/zmqpool.py
+++ b/moon/zmqpool.py
@@ -94,6 +94,7 @@ class ZMQPool:
         except BusShutdownException:
             for w in workers:
                 w.stop()
+            for w in workers:
                 w.join()
 
         backend.close()


### PR DESCRIPTION
This is the second part of replacement of #527. I checked the `rospy` part in Python2 with rather complex inheritance hierarchy, and decided to keep original Frantisek's ZeroMQ pool ... but move it to Moon project. I would use probably different tools like already existing thread pools in python and processing queue, or events for requesting STOP of execution, but ... if it works, let's move on as I still consider this as rather minor thing.

In the test is a race condition (but we have similar in other tests too), that `sleep(0.1)` is sometimes not enough to create the thread pool and start it (on my slow computer). It would be nicer to check/wait for "ready" but that is when the Tread is already blocked in `listen()`. I added parameter `pool_size` with default 5 (as it used to be), but reduced this number in test ... so it starts faster.

The only modified configuration is for round 3, which used to be working for
```
./docker/scripts/launch/roslaunch_docker --run-round 3 -n  -L -s 42 -S
```
(scoring 10 points in master) ... at the moment with score=0.
