### PR TITLE
Feature/moon motor pid

### DIFF
--- a/moon/motorpid.py
+++ b/moon/motorpid.py
@@ -1,0 +1,16 @@
+"""
+  Motor PID controller
+"""
+
+class MotorPID:
+    def __init__(self, p=1, i=0, d=0):
+        self.desired_speed = 0.0
+        self.param_p = p
+
+    def set_desired_speed(self, speed):
+        self.desired_speed = speed
+
+    def update(self, current_speed):
+        return self.param_p * (self.desired_speed - current_speed)
+
+# vim: expandtab sw=4 ts=4

--- a/moon/motorpid.py
+++ b/moon/motorpid.py
@@ -5,12 +5,17 @@
 class MotorPID:
     def __init__(self, p=1, i=0, d=0):
         self.desired_speed = 0.0
+        self.current_speed = 0.0
         self.param_p = p
 
     def set_desired_speed(self, speed):
         self.desired_speed = speed
 
     def update(self, current_speed):
-        return self.param_p * (self.desired_speed - current_speed)
+        self.current_speed = current_speed
+
+    def get_effort(self):
+        err = self.desired_speed - self.current_speed
+        return self.param_p * err
 
 # vim: expandtab sw=4 ts=4

--- a/moon/test_motorpid.py
+++ b/moon/test_motorpid.py
@@ -8,7 +8,8 @@ class MotorPIDTest(unittest.TestCase):
     def test_pid(self):
         pid = MotorPID(p=1, i=0, d=0)
         pid.set_desired_speed(0.5)
-        effort = pid.update(current_speed=0)
+        pid.update(current_speed=0)
+        effort = pid.get_effort()
         self.assertEqual(effort, 0.5)
 
 

--- a/moon/test_motorpid.py
+++ b/moon/test_motorpid.py
@@ -1,0 +1,16 @@
+import unittest
+
+from moon.motorpid import MotorPID
+
+
+class MotorPIDTest(unittest.TestCase):
+
+    def test_pid(self):
+        pid = MotorPID(p=1, i=0, d=0)
+        pid.set_desired_speed(0.5)
+        effort = pid.update(current_speed=0)
+        self.assertEqual(effort, 0.5)
+
+
+# vim: expandtab sw=4 ts=4
+

--- a/moon/vehicles/rover.py
+++ b/moon/vehicles/rover.py
@@ -172,10 +172,11 @@ class Rover(MoonNode):
 
     def on_joint_effort(self, data):
         assert self.joint_name is not None
+        steering, effort = self.get_steering_and_effort()
+        cmd = b'cmd_rover %f %f %f %f %f %f %f %f' % tuple(steering + effort)
+        self.bus.publish('cmd', cmd)
 
-        # TODO cycle through fl, fr, bl, br
-        effort =  data[self.joint_name.index(b'fl_wheel_joint')]
-
+    def get_steering_and_effort(self):
         steering = [0.0,] * 4
 
         if self.drive_speed == 0:
@@ -274,9 +275,7 @@ class Rover(MoonNode):
                             abs(self.prev_position[self.joint_name.index(b'fr_steering_arm_joint')] - fr) > 0.2
                     ):
                         effort = [0.0,]*4
-
-        cmd = b'cmd_rover %f %f %f %f %f %f %f %f' % tuple(steering + effort)
-        self.bus.publish('cmd', cmd)
+        return steering, effort
 
     def draw(self):
         # for debugging

--- a/moon/vehicles/test_rover.py
+++ b/moon/vehicles/test_rover.py
@@ -1,0 +1,21 @@
+import unittest
+from unittest.mock import MagicMock
+
+from moon.vehicles.rover import Rover
+
+
+JOINT_NAME = [b'bl_arm_joint', b'bl_steering_arm_joint', b'bl_wheel_joint', 
+        b'br_arm_joint', b'br_steering_arm_joint', b'br_wheel_joint', b'fl_arm_joint',
+        b'fl_steering_arm_joint', b'fl_wheel_joint', b'fr_arm_joint', b'fr_steering_arm_joint',
+        b'fr_wheel_joint', b'sensor_joint']
+
+class RoverTest(unittest.TestCase):
+
+    def test_rover_pid(self):
+        rover = Rover(config={}, bus=MagicMock())
+
+        rover.joint_name = JOINT_NAME  # in reality received as the first joint status
+        rover.on_joint_effort([0]*len(JOINT_NAME))
+
+# vim: expandtab sw=4 ts=4
+

--- a/moon/vehicles/test_rover.py
+++ b/moon/vehicles/test_rover.py
@@ -9,6 +9,7 @@ JOINT_NAME = [b'bl_arm_joint', b'bl_steering_arm_joint', b'bl_wheel_joint',
         b'fl_steering_arm_joint', b'fl_wheel_joint', b'fr_arm_joint', b'fr_steering_arm_joint',
         b'fr_wheel_joint', b'sensor_joint']
 
+
 class RoverTest(unittest.TestCase):
 
     def test_rover_pid(self):
@@ -16,6 +17,16 @@ class RoverTest(unittest.TestCase):
 
         rover.joint_name = JOINT_NAME  # in reality received as the first joint status
         rover.on_joint_effort([0]*len(JOINT_NAME))
+
+    def test_get_steering_and_effort(self):
+        rover = Rover(config={}, bus=MagicMock())
+        self.assertEqual(rover.get_steering_and_effort(), ([0.0, 0.0, 0.0, 0.0], [0, 0, 0, 0]))
+
+        rover.drive_speed = 1.0
+        self.assertEqual(rover.get_steering_and_effort(), ([0.0, 0.0, 0.0, 0.0], [40, 40, 40, 40]))
+
+        rover.drive_speed = -1.0
+        self.assertEqual(rover.get_steering_and_effort(), ([0.0, 0.0, 0.0, 0.0], [-40, -40, -40, -40]))
 
 # vim: expandtab sw=4 ts=4
 


### PR DESCRIPTION
I originally expected to wait with this PR until PID will be well tuned, but it looks like the first guess is better then the former version:
```
rospy_round3: Aligned service response: result: True
0:07:43.201000 app: Alignment response: ok
0:07:43.700000 Loc: [-95.792439 -1.567392 0.795888] [-0.002269 -0.014661 0.591492]; Driver: basemarker; Score: 13
```
so I would merge it and do tuning/improvements in different branch, OK?

Note, that promised PID controller is only P-controller at the moment as we really do not need exact speed - we just need the rover to move reasonable.

There is potentially `rover.py` rework needed as desired speed is still ignored and request is guessed from old effort estimation.