### PR TITLE
osgar.lib.quaternion: add from_rotation_matrix

### DIFF
--- a/osgar/lib/quaternion.py
+++ b/osgar/lib/quaternion.py
@@ -36,14 +36,18 @@ def rotate_vector(vector, quaternion):
     part1 = multiply(quaternion, qvector)
     return multiply(part1, con)[:-1]
 
-def euler_zyx(quaternion):
-    # assumption that quaternion is normalized
+
+def normalize(quaternion):
     x0, y0, z0, w0 = quaternion
     sqr_size = x0*x0 + y0*y0 + z0*z0 + w0*w0
     if abs(sqr_size - 1.0) > 0.00001:
-        # the assumption is broken, so normalize it
         k = math.sqrt(sqr_size)
         x0, y0, z0, w0 = x0/k, y0/k, z0/k, w0/k
+    return [x0, y0, z0, w0]
+
+
+def euler_zyx(quaternion):
+    x0, y0, z0, w0 = normalize(quaternion)
     ax =  math.atan2(2*(w0*x0+y0*z0), 1-2*(x0*x0+y0*y0))
     ay =  math.asin(2*(w0*y0-z0*x0))
     az =  math.atan2(2*(w0*z0+x0*y0), 1-2*(y0*y0+z0*z0))
@@ -69,5 +73,22 @@ def rotation_matrix(quaternion):
     r2 = [2*qx*qy + 2*qz*qw,      1 - 2*qx**2 - 2*qz**2,  2*qy*qz - 2*qx*qw]
     r3 = [2*qx*qz - 2*qy*qw,      2*qy*qz + 2*qx*qw,      1 - 2*qx**2 - 2*qy**2]
     return [r1, r2, r3]
+
+
+def from_rotation_matrix(rotation_matrix):
+    # http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm
+    # https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion
+    sqrt, copysign = math.sqrt, math.copysign
+    m00, m01, m02 = rotation_matrix[0]
+    m10, m11, m12 = rotation_matrix[1]
+    m20, m21, m22 = rotation_matrix[2]
+    qw = sqrt(max(0, 1 + m00 + m11 + m22)) / 2
+    qx = sqrt(max(0, 1 + m00 - m11 - m22)) / 2
+    qy = sqrt(max(0, 1 - m00 + m11 - m22)) / 2
+    qz = sqrt(max(0, 1 - m00 - m11 + m22)) / 2
+    qx = copysign(qx, m21 - m12)
+    qy = copysign(qy, m02 - m20)
+    qz = copysign(qz, m10 - m01)
+    return [qx, qy, qz, qw]
 
 # vim: expandtab sw=4 ts=4

--- a/osgar/lib/quaternion.py
+++ b/osgar/lib/quaternion.py
@@ -78,17 +78,16 @@ def rotation_matrix(quaternion):
 def from_rotation_matrix(rotation_matrix):
     # http://www.euclideanspace.com/maths/geometry/rotations/conversions/matrixToQuaternion/index.htm
     # https://en.wikipedia.org/wiki/Rotation_matrix#Quaternion
-    sqrt, copysign = math.sqrt, math.copysign
     m00, m01, m02 = rotation_matrix[0]
     m10, m11, m12 = rotation_matrix[1]
     m20, m21, m22 = rotation_matrix[2]
-    qw = sqrt(max(0, 1 + m00 + m11 + m22)) / 2
-    qx = sqrt(max(0, 1 + m00 - m11 - m22)) / 2
-    qy = sqrt(max(0, 1 - m00 + m11 - m22)) / 2
-    qz = sqrt(max(0, 1 - m00 - m11 + m22)) / 2
-    qx = copysign(qx, m21 - m12)
-    qy = copysign(qy, m02 - m20)
-    qz = copysign(qz, m10 - m01)
+    qw = math.sqrt(max(0, 1 + m00 + m11 + m22)) / 2
+    qx = math.sqrt(max(0, 1 + m00 - m11 - m22)) / 2
+    qy = math.sqrt(max(0, 1 - m00 + m11 - m22)) / 2
+    qz = math.sqrt(max(0, 1 - m00 - m11 + m22)) / 2
+    qx = math.copysign(qx, m21 - m12)
+    qy = math.copysign(qy, m02 - m20)
+    qz = math.copysign(qz, m10 - m01)
     return [qx, qy, qz, qw]
 
 # vim: expandtab sw=4 ts=4

--- a/osgar/lib/test_quaternion.py
+++ b/osgar/lib/test_quaternion.py
@@ -48,13 +48,30 @@ class QuaternionTest(TestCase):
             T([ 0, 0, 0.7071068, 0.7071068 ], [[0.0, -1.0, 0.0], [1.0, 0.0, 0.0], [0.0, 0.0, 1.0]]),
             T([ 0, 0.7071068, 0, 0.7071068 ], [[0.0, 0.0, 1.0], [0.0,  1.0,  0.0], [-1.0, 0.0, 0.0]]),
             T([ 0.7071068, 0, 0, 0.7071068 ], [[1.0,  0.0,  0.0], [0.0,  0.0, -1.0], [0.0, 1.0, 0.0 ]]),
-            T([ 0.5, 0.5, 0, 0.7071068 ], [[0.5, 0.5, 0.7071068], [0.5, 0.5, -0.7071068], [-0.7071068, 0.7071068, 0.0]])
+            T([ 0.5, 0.5, 0, 0.7071068 ], [[0.5, 0.5, 0.7071068], [0.5, 0.5, -0.7071068], [-0.7071068, 0.7071068, 0.0]]),
+            T([ 0, 0, 1, 0 ], [[-1.0, -0.0,  0.0], [0.0000000, -1.0,  0.0], [0.0,  0.0,  1.0]]),
         ]
         for i, t in enumerate(tests):
-            with self.subTest(test=i):
+            with self.subTest(test=i, kind="to matrix"):
                 actual = quaternion.rotation_matrix(t.q)
                 for row in range(len(actual)):
                     for col in range(len(actual[0])):
                         self.assertAlmostEqual(t.matrix[row][col], actual[row][col], places=6, msg=(row, col))
+
+        for i, t in enumerate(tests):
+            with self.subTest(test=i, kind="from matrix"):
+                q = quaternion.from_rotation_matrix(t.matrix)
+                self.assertListAlmostEqual(q, t.q)
+
+
+    def test_rotation_matrix_random(self):
+        from random import Random
+        r = Random(0).random
+        for i in range(1000):
+            with self.subTest(test=i):
+                q = quaternion.normalize([r(), r(), r(), r()])
+                rotmat = quaternion.rotation_matrix(q)
+                qq = quaternion.from_rotation_matrix(rotmat)
+                self.assertListAlmostEqual(q, qq)
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Since #565 uses matrices for rotations we need to be able to go back and forth between matrices and quaternions.