### PR TITLE
Feature/zmqrouter eduro

### DIFF
--- a/config/eduro-subt-estop-lora.json
+++ b/config/eduro-subt-estop-lora.json
@@ -31,19 +31,19 @@
       },
       "eduro": {
           "driver": "eduro",
-          "in": ["slot_can", "slot_desired_speed"],
+          "in": ["can", "desired_speed"],
           "out": ["can", "encoders", "emergency_stop", "pose2d", "buttons", "voltage"],
           "init": {}
       },
       "can": {
           "driver": "can",
-          "in": ["slot_raw", "slot_can"],
+          "in": ["raw", "can"],
           "out": ["can", "raw"],
           "init": {"speed": "250k", "canopen":true}
       },
       "serial": {
           "driver": "serial",
-          "in": ["slot_raw"],
+          "in": ["raw"],
           "out": ["raw"],
           "init": {"port": "/dev/ttyS0", "speed": 115200,
                    "rtscts":true, "reset":true}
@@ -119,12 +119,12 @@
           "init": {"port": "/dev/lora", "speed": 115200}
       }
     },
-    "links": [["serial.raw", "can.slot_raw"], 
-              ["can.raw", "serial.slot_raw"],
-              ["eduro.can", "can.slot_can"],
-              ["can.can", "eduro.slot_can"],
+    "links": [["serial.raw", "can.raw"], 
+              ["can.raw", "serial.raw"],
+              ["eduro.can", "can.can"],
+              ["can.can", "eduro.can"],
               ["eduro.encoders", "app.encoders"],
-              ["app.desired_speed", "eduro.slot_desired_speed"],
+              ["app.desired_speed", "eduro.desired_speed"],
               ["lidar_tcp.raw", "lidar.raw"], 
               ["lidar.raw", "lidar_tcp.raw"],
               ["slope_lidar_tcp.raw", "slope_lidar.raw"], 

--- a/osgar/zmqrouter.py
+++ b/osgar/zmqrouter.py
@@ -57,7 +57,7 @@ def record(config, log_prefix=None, log_filename=None, duration_sec=None):
                 modules[module_name] = subprocess.Popen([sys.executable, "-c", program])
 
             try:
-                router.register_nodes(modules.keys(), timeout=datetime.timedelta(seconds=1))
+                router.register_nodes(modules.keys(), timeout=datetime.timedelta(seconds=10))
                 links =  config['robot']['links']
                 for link_from, link_to in links:
                     router.connect(link_from, link_to)


### PR DESCRIPTION
This is a short report of test of `zmqrouter` on Eduro robot. It works (almost) with two isses:
- start timeout 1s is insufficient (10s is OK)
- slots are no longer supported but Eduro depends on it (250ms watchdog on CAN motors).

It moves and resets motors all the time.

```
RUNNING 1
SWITCH TO OPERATION 2
2020-07-28 18:03:57,396 osgar.zmqrouter ERROR    failed to stop within timeout of 0:00:02, exiting anyway
2020-07-28 18:03:57,396 osgar.zmqrouter ERROR    b'can' queue: 263
2020-07-28 18:03:57,397 osgar.zmqrouter ERROR    b'serial' queue: 38
2020-07-28 18:03:57,398 osgar.zmqrouter ERROR    b'estop_serial' queue: 1
2020-07-28 18:03:57,398 osgar.zmqrouter ERROR    b'eduro' queue: 462
2020-07-28 18:03:57,399 osgar.zmqrouter ERROR    b'lidar' queue: 1
2020-07-28 18:03:57,399 osgar.zmqrouter ERROR    b'camera' queue: 1
2020-07-28 18:03:57,400 osgar.zmqrouter ERROR    b'lora' queue: 2
2020-07-28 18:03:57,400 osgar.zmqrouter ERROR    b'app' queue: 55
2020-07-28 18:03:57,401 osgar.zmqrouter ERROR    b'detector' queue: 1
2020-07-28 18:03:57,401 osgar.zmqrouter ERROR    still running: {b'can'}
2020-07-28 18:03:57,402 osgar.zmqrouter ERROR    can max delay: 0:00:00.286025
2020-07-28 18:03:57,402 osgar.zmqrouter ERROR    serial max delay: 0:00:00.472043
2020-07-28 18:03:57,403 osgar.zmqrouter ERROR    slope_lidar max delay: 0:00:00.145557
2020-07-28 18:03:57,403 osgar.zmqrouter INFO     imu_serial max delay: 0:00:00
2020-07-28 18:03:57,404 osgar.zmqrouter ERROR    imu max delay: 0:00:00.119980
2020-07-28 18:03:57,404 osgar.zmqrouter ERROR    estop max delay: 0:00:01.017559
2020-07-28 18:03:57,405 osgar.zmqrouter ERROR    lora_serial max delay: 0:00:01.365879
2020-07-28 18:03:57,405 osgar.zmqrouter INFO     estop_serial max delay: 0:00:00.093046
2020-07-28 18:03:57,406 osgar.zmqrouter ERROR    eduro max delay: 0:00:00.104448
2020-07-28 18:03:57,406 osgar.zmqrouter ERROR    lidar max delay: 0:00:00.148295
2020-07-28 18:03:57,407 osgar.zmqrouter INFO     camera max delay: 0:00:00
2020-07-28 18:03:57,407 osgar.zmqrouter INFO     lora max delay: 0:00:00.022605
2020-07-28 18:03:57,407 osgar.zmqrouter ERROR    lidar_tcp max delay: 0:00:00.174903
2020-07-28 18:03:57,408 osgar.zmqrouter ERROR    slope_lidar_tcp max delay: 0:00:00.233206
2020-07-28 18:03:57,408 osgar.zmqrouter INFO     reporter max delay: 0:00:00.007081
2020-07-28 18:03:57,409 osgar.zmqrouter INFO     app max delay: 0:00:00.064763
2020-07-28 18:03:57,409 osgar.zmqrouter ERROR    detector max delay: 0:00:02.035327
```
