### PR TITLE
SubT - allow teambase to kill all robots

### DIFF
--- a/subt/docker/robotika/run_solution.bash
+++ b/subt/docker/robotika/run_solution.bash
@@ -94,7 +94,7 @@ rosrun proxy sendlog.py $LOG_FILE &
 echo "Starting osgar"
 if $IS_TEAMBASE
 then
-    $PYTHON -m osgar.record ${CONFIG_FILE_PATHS[@]} --log $LOG_FILE --note "run teambase"
+    $PYTHON -m subt.teambase ${CONFIG_FILE_PATHS[@]} --robot-name $ROBOT_NAME --log $LOG_FILE --note "run teambase"
 else
     $PYTHON -m subt run ${CONFIG_FILE_PATHS[@]} --log $LOG_FILE --side auto --walldist $WALLDIST --speed $SPEED --note "run_solution.bash"
 fi

--- a/subt/docker/robotika/run_solution.bash
+++ b/subt/docker/robotika/run_solution.bash
@@ -96,6 +96,12 @@ echo "Sleep and finish"
 sleep 30
 
 # DO NOT CALL /subt/finish for group of robots!
-# it terminates the run for everybody
-# https://bitbucket.org/osrf/subt/issues/336/handling-subt-finish-for-multiple-robots
-# rosservice call '/subt/finish' true
+#
+if $IS_TEAMBASE
+then
+    echo "TEAMBASE is terminating all robots"
+    rosservice call '/subt/finish' true
+    # it terminates the run for everybody
+    # https://bitbucket.org/osrf/subt/issues/336/handling-subt-finish-for-multiple-robots
+fi
+

--- a/subt/main.py
+++ b/subt/main.py
@@ -874,7 +874,7 @@ class SubTChallenge:
         self.wait(timedelta(seconds=10), use_sim_time=True)
 
     def play_virtual_track(self):
-        self.stdout("SubT Challenge Ver68!")
+        self.stdout("SubT Challenge Ver69!")
         self.stdout("Waiting for robot_name ...")
         while self.robot_name is None:
             self.update()

--- a/subt/teambase.py
+++ b/subt/teambase.py
@@ -9,9 +9,16 @@ class Teambase(Node):
         super().__init__(config, bus)
         bus.register("broadcast")
 
+        self.robot_name = config.get('robot_name')
+        self.finish_time = None  # infinite
+        if self.robot_name is not None:
+            self.finish_time = int(self.robot_name[1:].split('F')[0])  # T100 is accepted for example
+
     def on_sim_time_sec(self, data):
         # broadcast simulation time every second
         self.publish('broadcast', b'%d' % data)
+        if self.finish_time is not None and data > self.finish_time:
+            self.request_stop()
 
     def update(self):
         channel = super().update()

--- a/subt/teambase.py
+++ b/subt/teambase.py
@@ -10,6 +10,7 @@ class Teambase(Node):
         bus.register("broadcast")
 
         self.robot_name = config.get('robot_name')
+        self.start_time = None  # unknown
         self.finish_time = None  # infinite
         if self.robot_name is not None:
             self.finish_time = int(self.robot_name[1:].split('F')[0])  # T100 is accepted for example
@@ -17,7 +18,9 @@ class Teambase(Node):
     def on_sim_time_sec(self, data):
         # broadcast simulation time every second
         self.publish('broadcast', b'%d' % data)
-        if self.finish_time is not None and data > self.finish_time:
+        if self.start_time is None:
+            self.start_time = data
+        if self.finish_time is not None and data - self.start_time > self.finish_time:
             self.request_stop()
 
     def update(self):

--- a/subt/teambase.py
+++ b/subt/teambase.py
@@ -20,4 +20,27 @@ class Teambase(Node):
         if handler is not None:
             handler(getattr(self, channel))
 
+
+def main():
+    import argparse
+    import os
+    from osgar.lib.config import config_load
+    from osgar.record import record
+
+    parser = argparse.ArgumentParser(description='SubT Teambase')
+    parser.add_argument('config', nargs='+', help='configuration file')
+    parser.add_argument('--note', help='add description')
+    parser.add_argument('--log', nargs='?', help='record log filename')
+    parser.add_argument('--robot-name', required=True, help='T<simulated seconds>F* name')
+    args = parser.parse_args()
+
+    cfg = config_load(*args.config)
+    cfg['robot']['modules']['app']['init']['robot_name'] = args.robot_name
+    prefix = os.path.basename(args.config[0]).split('.')[0] + '-'
+    record(cfg, prefix, args.log)
+
+
+if __name__ == "__main__":
+    main()
+
 # vim: expandtab sw=4 ts=4

--- a/subt/teambase.py
+++ b/subt/teambase.py
@@ -13,7 +13,7 @@ class Teambase(Node):
         self.start_time = None  # unknown
         self.finish_time = None  # infinite
         if self.robot_name is not None:
-            self.finish_time = int(self.robot_name[1:].split('F')[0])  # T100 is accepted for example
+            self.finish_time = int(self.robot_name[1:])  # T100 is accepted for example
 
     def on_sim_time_sec(self, data):
         # broadcast simulation time every second

--- a/subt/test_teambase.py
+++ b/subt/test_teambase.py
@@ -23,4 +23,8 @@ class TeambaseTest(unittest.TestCase):
         c.join()
         self.assertEqual(tester.listen()[2], b'13')
 
+    def test_finish_time(self):
+        tb = Teambase(bus=MagicMock(), config={'robot_name':'T42'})
+        self.assertEqual(tb.finish_time, 42)
+
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Yet another SubT (dangerous) PR ... we could use TEAMBASE to terminate all robots, i.e. when teambase ends everything ends ... I am not sure if it is safe for the competition (the answer is NO), but for testing on AWS it can speedup cycle time (and make logs reasonable).

Note, "minor" detail, that `teambase.py` does not parse "robot_name", because it is not receiving "origin" ... ideas welcome ...