### PR TITLE
Feature/spider refactor can

### DIFF
--- a/config/spider.json
+++ b/config/spider.json
@@ -1,0 +1,40 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "app": {
+          "driver": "application",
+          "in": [],
+          "out": ["desired_speed"],
+          "init": {
+            "max_speed": 0.5
+          }
+      },
+      "spider": {
+          "driver": "spider",
+          "in": ["can", "move"],
+          "out": ["can"],
+          "init": {}
+      },
+      "can": {
+          "driver": "can",
+          "in": ["raw", "can"],
+          "out": ["can", "raw"],
+          "init": {}
+      },
+      "serial": {
+          "driver": "serial",
+          "in": ["raw"],
+          "out": ["raw"],
+          "init": {"port": "/dev/ttyS0", "speed": 115200,
+                   "rtscts":true, "reset":true}
+      }
+    },
+    "links": [["app.desired_speed", "spider.move"],
+              ["spider.status", "app.status"],
+              ["spider.can", "can.can"],
+              ["can.can", "spider.can"],
+              ["serial.raw", "can.raw"], 
+              ["can.raw", "serial.raw"]]
+  }
+}

--- a/config/test-spider.json
+++ b/config/test-spider.json
@@ -4,11 +4,17 @@
     "modules": {
       "spider": {
           "driver": "spider",
-          "in": ["raw"],
+          "in": ["can"],
           "out": ["can"],
           "init": {}
       },
-      "spider_serial": {
+      "can": {
+          "driver": "can",
+          "in": ["raw", "can"],
+          "out": ["can", "raw"],
+          "init": {}
+      },
+      "serial": {
           "driver": "serial",
           "in": ["raw"],
           "out": ["raw"],
@@ -16,7 +22,9 @@
                    "rtscts":true, "reset":true}
       }
     },
-    "links": [["spider_serial.raw", "spider.raw"], 
-              ["spider.can", "spider_serial.raw"]]
+    "links": [["spider.can", "can.can"],
+              ["can.can", "spider.can"],
+              ["serial.raw", "can.raw"], 
+              ["can.raw", "serial.raw"]]
   }
 }

--- a/osgar/drivers/spider.py
+++ b/osgar/drivers/spider.py
@@ -79,6 +79,12 @@ class Spider(Thread):
                 val = struct.unpack_from('HHBBH', packet, 2)
                 if verbose:
                     print("User:", val[2]&0x7F, val[3]&0x7F, val)
+            elif msg_id == 0x2A0:
+                # encoders
+                assert len(packet) == 2 + 4, packet
+                val = struct.unpack_from('hh', packet, 2)
+                if verbose:
+                    print("Enc:", val)
 
     def process_gen(self, data, verbose=False):
         self.buf, packet = self.split_buffer(self.buf + data)

--- a/osgar/drivers/test_spider.py
+++ b/osgar/drivers/test_spider.py
@@ -2,42 +2,23 @@ import unittest
 from unittest.mock import MagicMock
 from datetime import timedelta
 
-from osgar.drivers.spider import Spider, CAN_packet
+from osgar.drivers.spider import Spider, CAN_triplet
 from osgar.bus import Bus
 
+
 class SpiderTest(unittest.TestCase):
-
-    def test_split_buffer(self):
-        self.assertEqual(Spider.split_buffer(b''), (b'', b''))
-        self.assertEqual(Spider.split_buffer(b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfe\x10'), (b'', b'\xfe\x10'))
-        data = b'\xff\xff\xff\xff\xff\xff\xff\xff\xff\xff\xfeW\xfe0@h\x9e\x01i\x01\xf7\x01\x18\x00'
-        self.assertEqual(Spider.split_buffer(data), (b'\xfe0@h\x9e\x01i\x01\xf7\x01\x18\x00', b'\xfeW'))
-
-        data = b'0@h\x9e\x01i\x01\xf7\x01\x18\x00'
-        self.assertEqual(Spider.split_buffer(data), (b'h\x9e\x01i\x01\xf7\x01\x18\x00', b'0@'))
-
-    def test_can_packet(self):
-        self.assertEqual(CAN_packet(0x400, [0, 0]), b'\x80\x02\x00\x00')
-
-    def test_uninitialized_can_bridge(self):
-        bus = MagicMock()
-        spider = Spider(config={'stream_id_in':1, 'stream_id_out':2}, bus=bus)
-        spider.send((0, 0))
-#        bus.write.assert_called_once_with(0, 'ERROR: CAN bridge not initialized yet! [(0, 0)]')
 
     def test_publish_status(self):
         logger=MagicMock()
         logger.write = MagicMock(return_value=timedelta(seconds=135))
         bus = Bus(logger=logger)
         tester = bus.handle('tester')
-        tester.register('raw')
+        tester.register('can')
         spider = Spider(config={}, bus=bus.handle('spider'))
-        bus.connect('tester.raw', 'spider.raw')
+        bus.connect('tester.can', 'spider.can')
         bus.connect('spider.status', 'tester.status')
 
-        spider.can_bridge_initialized = True  # skip initialization
-        self.assertEqual(CAN_packet(0x200, [0, 0x80]), b'@\x02\x00\x80')
-        tester.publish('raw', b'@\x02\x00\x80')
+        tester.publish('can', CAN_triplet(0x200, [0, 0x80]))
         spider.start()
         dt, stream, data = tester.listen()
         spider.request_stop()


### PR DESCRIPTION
This is already more then week old code tested on Spider3. The original idea of this branch/PR was to change direct CAN parsing and use already existing CAN messages. It works OK.

In order to run real machine it is also necessary to hack `go.py`, which I definitely do not want to merge. There is a new branch `feature\spider-robotour` where further development for Robotour 2020 will continue.