### PR TITLE
subt.{cloudsim2osgar,push}: add osgar->cloudsim direction

### DIFF
--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -114,7 +114,7 @@ class main:
             setattr(self, handler.__name__+"_count", 0)
             rospy.Subscriber(name, type, handler)
 
-        while rospy.ok():
+        while not rospy.is_shutdown():
             channel, bytes_data = self.bus.listen()
             # TODO: switch on channel to feed different ROS publishers
 

--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -52,6 +52,7 @@ class Bus:
         self.push.bind('tcp://*:5565')
         self.pull = context.socket(zmq.PULL)
         self.pull.LINGER = 100
+        self.pull.bind('tcp://*:5566')
 
     def register(self, *outputs):
         pass
@@ -115,7 +116,9 @@ class main:
             rospy.Subscriber(name, type, handler)
 
         while not rospy.is_shutdown():
-            channel, bytes_data = self.bus.listen()
+            channel, data = self.bus.listen()
+            print("_"*50)
+            print("receiving:", data)
             # TODO: switch on channel to feed different ROS publishers
 
     def imu(self, msg):

--- a/subt/push.py
+++ b/subt/push.py
@@ -1,0 +1,51 @@
+import contextlib
+
+from threading import Thread
+
+import zmq
+import msgpack
+
+from osgar.bus import BusShutdownException
+
+
+class Push:
+
+    def __init__(self, config, bus):
+        bus.register()
+        self.endpoint = config.get('endpoint', 'tcp://127.0.0.1:5566')
+        self.timeout = config.get('timeout', 1) # default send timeout 1s, effective on full queue only
+        self.thread = Thread(target=self.run)
+        self.thread.name = bus.name
+        self.bus = bus
+
+    def start(self):
+        self.thread.start()
+
+    def join(self, timeout=None):
+        self.thread.join(timeout=timeout)
+
+    def run(self):
+        context = zmq.Context.instance()
+        socket = context.socket(zmq.PUSH)
+
+        # https://stackoverflow.com/questions/7538988/zeromq-how-to-prevent-infinite-wait
+        socket.SNDTIMEO = int(self.timeout * 1000)  # convert to milliseconds
+        socket.LINGER = 100 #milliseconds
+        socket.connect(self.endpoint)
+
+        try:
+            with contextlib.closing(socket):
+                while True:
+                    dt, channel, data = self.bus.listen()
+                    raw = msgpack.packb(data, use_bin_type=True)
+                    socket.send_multipart([channel, raw])
+        except zmq.ZMQError as e:
+            if e.errno == zmq.EAGAIN:
+                pass #TODO log timeout
+            else:
+                pass #TODO log other error
+        except BusShutdownException:
+            pass
+
+    def request_stop(self):
+        self.bus.shutdown()

--- a/subt/push.py
+++ b/subt/push.py
@@ -37,8 +37,10 @@ class Push:
             with contextlib.closing(socket):
                 while True:
                     dt, channel, data = self.bus.listen()
+                    print("*"*50)
+                    print("sending:", data)
                     raw = msgpack.packb(data, use_bin_type=True)
-                    socket.send_multipart([channel, raw])
+                    socket.send_multipart([bytes(channel, 'ascii'), raw])
         except zmq.ZMQError as e:
             if e.errno == zmq.EAGAIN:
                 pass #TODO log timeout

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -77,11 +77,14 @@
             }
           }
       },
-      "rospy": {
+      "fromrospy": {
           "driver": "subt.pull:Pull",
 	      "init": {
 	        "outputs": ["rot", "acc", "orientation"]
 	      }
+      },
+      "torospy": {
+          "driver": "subt.push:Push"
       },
       "lora": {
           "driver": "lora",
@@ -99,10 +102,10 @@
 
               ["rosmsg.origin",     "localization.origin"],
               ["rosmsg.pose2d",     "localization.odom"],
-              ["rospy.orientation", "localization.orientation"],
+              ["fromrospy.orientation", "localization.orientation"],
 
               ["rosmsg.origin",     "vo.origin"],
-              ["rospy.orientation", "vo.orientation"],
+              ["fromrospy.orientation", "vo.orientation"],
               ["rosmsg.depth",      "vo.depth"],
               ["rosmsg.image",      "vo.image"],
               ["localization.pose3d", "vo.baseline"],
@@ -110,9 +113,9 @@
               ["receiver.raw", "rosmsg.raw"],
               ["rosmsg.cmd", "transmitter.raw"],
 
-              ["rospy.rot", "app.rot"],
-              ["rospy.rot", "depth2scan.rot"],
-              ["rospy.acc", "app.acc"],
+              ["fromrospy.rot", "app.rot"],
+              ["fromrospy.rot", "depth2scan.rot"],
+              ["fromrospy.acc", "app.acc"],
 
               ["rosmsg.scan", "detector.scan"],
               ["rosmsg.scan", "depth2scan.scan"],
@@ -126,6 +129,7 @@
 
               ["localization.pose3d", "app.pose3d"],
               ["rosmsg.sim_time_sec", "app.sim_time_sec"],
+              ["rosmsg.sim_time_sec", "torospy.sim_time_sec"],
 
               ["rosmsg.gas_detected", "detector.gas_detected"],
 


### PR DESCRIPTION
Implements sending messages from `osgar` to `cloudsim`/`ROS`. Uses `PUSH`/`PULL` sockets from `zmq`. Serializes using msgpack. Supports arbitrary channel names.