### PR TITLE
subt/main.py - fix crash for self.xyz as received list instead of tuple

### DIFF
--- a/subt/main.py
+++ b/subt/main.py
@@ -481,7 +481,7 @@ class SubTChallenge:
     def on_pose3d(self, timestamp, data):
         if self.xyz is None:
             # to avoid deadlock when we are waiting for offset but it is defined after self.xyz is not None
-            self.xyz = data[0]
+            self.xyz = tuple(data[0])
         if self.offset is None:
             # we cannot align global coordinates if offset is not known
             return


### PR DESCRIPTION
  File "D:\osgar\subt\main.py", line 581, in update
    self.stdout(timestamp, '(%.1f %.1f %.1f)' % self.xyz if self.xyz is not None else '(xyz=None)', sorted(self.stat.items()))
TypeError: must be real number, not list

This bug showed in test of `ver74rc1` when the drone `B30F100L` did not take off.