### PR TITLE
osgar/bus.py - fix missing shutdown() for replay

### DIFF
--- a/osgar/bus.py
+++ b/osgar/bus.py
@@ -205,6 +205,9 @@ class LogBusHandler:
     def sleep(self, secs):
         pass
 
+    def shutdown(self):
+        pass
+
     def report_error(self, err):
         print(self.time, err)
 
@@ -231,6 +234,9 @@ class LogBusHandlerInputsOnly:
         return self.time
 
     def sleep(self, secs):
+        pass
+
+    def shutdown(self):
         pass
 
     def report_error(self, err):


### PR DESCRIPTION
Fixes following error:
```
$ python -m osgar.replay --module app d:\logs\aws\ver74rc1s2b\T\aws-ver74rc1s2b-T300.log
original args: b"['/osgar-ws/src/osgar/subt/teambase.py', '/osgar-ws/src/osgar/subt/zmq-subt-teambase.json', '--robot-name', 'T300', '--log', '/osgar-ws/logs/zmq-subt-teambase-2020-09-25T18.41.16.log', '--note', 'run teambase']"
Exception in thread Thread-1:
Traceback (most recent call last):
  File "C:\SDK\WinPython-64bit-3.6.2.0Qt5\python-3.6.2.amd64\lib\threading.py", line 916, in _bootstrap_inner
    self.run()
  File "D:\osgar\osgar\node.py", line 40, in run
    self.update()
  File "D:\osgar\subt\teambase.py", line 31, in update
    handler(getattr(self, channel))
  File "D:\osgar\subt\teambase.py", line 24, in on_sim_time_sec
    self.request_stop()
  File "D:\osgar\osgar\node.py", line 45, in request_stop
    self.bus.shutdown()
AttributeError: 'LogBusHandler' object has no attribute 'shutdown'
```