### PR TITLE
Indroduction of breadcrumbs

### DIFF
--- a/subt/breadcrumbs.py
+++ b/subt/breadcrumbs.py
@@ -1,0 +1,34 @@
+"""
+  OSGAR breadcrumbs dispenser for Virtual
+"""
+from ast import literal_eval
+
+from osgar.node import Node
+
+
+class Breadcrumbs(Node):
+    def __init__(self, config, bus):
+        super().__init__(config, bus)
+        bus.register("deploy")
+
+        self.robot_name = config.get('robot_name')
+        self.start_time = None  # unknown
+        self.next_deploy_time = None
+        self.step_time = config.get('step_sec')
+
+    def on_sim_time_sec(self, data):
+        if self.start_time is None:
+            self.start_time = data
+            if self.step_time is not None:
+                self.next_deploy_time = self.start_time + self.step_time
+        if self.next_deploy_time is not None and data > self.next_deploy_time:
+            self.next_deploy_time += self.step_time
+            self.publish('deploy', [])  # ROS std_msg/Empty expects empty list as input
+
+    def update(self):
+        channel = super().update()
+        handler = getattr(self, "on_" + channel, None)
+        if handler is not None:
+            handler(getattr(self, channel))
+
+# vim: expandtab sw=4 ts=4

--- a/subt/main.py
+++ b/subt/main.py
@@ -890,7 +890,7 @@ class SubTChallenge:
         self.wait(timedelta(seconds=10), use_sim_time=True)
 
     def play_virtual_track(self):
-        self.stdout("SubT Challenge Ver74!")
+        self.stdout("SubT Challenge Ver75!")
         self.stdout("Waiting for robot_name ...")
         while self.robot_name is None:
             self.update()

--- a/subt/test_breadcrumbs.py
+++ b/subt/test_breadcrumbs.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import MagicMock
+
+from subt.breadcrumbs import Breadcrumbs
+
+
+class BreadcrumbsTest(unittest.TestCase):
+
+    def test_deploy(self):
+        bus = bus=MagicMock()
+        bread = Breadcrumbs(bus=bus, config={'step_sec':10})
+        bread.on_sim_time_sec(3)
+        bus.publish.assert_not_called()
+        bread.on_sim_time_sec(14)
+        bus.publish.assert_called()
+        bus.publish.reset_mock()
+        bread.on_sim_time_sec(15)
+        bus.publish.assert_not_called()
+
+# vim: expandtab sw=4 ts=4

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -86,6 +86,14 @@
           "init": {
             "device_id": 1
           }
+      },
+      "breadcrumbs": {
+          "driver": "subt.breadcrumbs:Breadcrumbs",
+          "in": ["sim_time_sec"],
+          "out": ["deploy"],
+          "init": {
+            "step_sec": 10
+          }
       }
     },
     "links": [["app.desired_speed", "rosmsg.desired_speed"],
@@ -126,6 +134,9 @@
               ["lora.artf_xyz", "reporter.artf_xyz"],
               ["lora.raw", "rosmsg.broadcast"],
               ["rosmsg.radio", "lora.radio"],
+
+              ["rosmsg.sim_time_sec", "breadcrumbs.sim_time_sec"],
+              ["breadcrumbs.deploy", "torospy.deploy"],
 
               ["detector.artf", "app.artf"],
               ["detector.stdout", "rosmsg.stdout"],

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -92,7 +92,7 @@
           "in": ["sim_time_sec"],
           "out": ["deploy"],
           "init": {
-            "step_sec": 10
+            "step_sec": 50
           }
       }
     },


### PR DESCRIPTION
This is the very first attempt to deploy [breadcrumbs](https://github.com/osrf/subt/wiki/api) from robot Freyja (config 2).

It was tested on "simple cave 1" (ver75rc1) but with error of deploying all breadcrumbs within first minute (fixed). Nevertheless the log from teambase showed already extended range reported every 10s by all robots:
![s1-without-breadcrumbs](https://user-images.githubusercontent.com/5664353/94364747-e9743400-00cb-11eb-8bac-cf288798721b.png)

![s1-with-breadcrumbs](https://user-images.githubusercontent.com/5664353/94364760-06a90280-00cc-11eb-92af-27e9b137da05.png)

The range was extended only by a little as the breadcrumbs were not correctly deployed (rerun of ver75rc2 should be available within 1hour).
