### PR TITLE
subt.tools.validator: add autodetection of filenames in curdir

### DIFF
--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -41,6 +41,8 @@ import pathlib
 
 g_logger = logging.getLogger(__name__)
 
+MAGIC = b'Pyr\x00'
+
 INFO_STREAM_ID = 0
 ENV_OSGAR_LOGS = 'OSGAR_LOGS'
 
@@ -51,7 +53,7 @@ TIMESTAMP_MASK = TIMESTAMP_OVERFLOW_STEP - 1
 def format_header(start_time):
     t = start_time
     ret = []
-    ret.append(b'Pyr\x00')
+    ret.append(MAGIC)
     ret.append(struct.pack('HBBBBBI', t.year, t.month, t.day, t.hour, t.minute, t.second, t.microsecond))
     return ret
 
@@ -161,7 +163,7 @@ class LogReader:
         self.follow = follow
         self.f = open(self.filename, 'rb')
         data = self._read(4)
-        assert data == b'Pyr\x00', data
+        assert data == MAGIC, data
 
         data = self._read(12)
         self.start_time = datetime.datetime(*struct.unpack('HBBBBBI', data), datetime.timezone.utc)


### PR DESCRIPTION
This simplifies calling of validator in cases when 
 - the `state.tlog` is in current directory
 - there is only one osgar logfile in current directory

The workflow to analyze cloudsim run is:
 - download all tar.gz log to a dedicated directory
 - run `python -m subt.rosbag2log <filename>.tar.gz` for each of them
 - run `python -m subt.tools.validator`

I plan to lift the restriction on a single osgar logfile and process all logfiles sequentialy in next PR.
