### PR TITLE
subt.tools.validator: process all logfiles in curdir

### DIFF
--- a/subt/tools/validator.py
+++ b/subt/tools/validator.py
@@ -89,10 +89,6 @@ def autodetect_name(logfile):
     assert False, "Robot name autodetection failed!"
 
 
-def process_logfile(logfile):
-    pass
-
-
 def main():
     import argparse
     import pathlib


### PR DESCRIPTION
This is the sequel announced at #645. The diff looks big but it is mostly indentation change due to the loop over all logfiles.

Example outputs:

<pre>Ground truth count: 41053
Processing logfile: aaa.log
  Autodetected name: X200L
  Trace reduced count: 465
  Ground truth seconds: 492
  Maximum error: 3761.30m -&gt; FAIL
Processing logfile: zmq-subt-x4-2020-09-30T10.43.12.log
  Autodetected name: X200L
  Trace reduced count: 465
  Ground truth seconds: 492
  Maximum error: 3761.30m -&gt; FAIL
</pre>

<pre>Ground truth count: 35297
Processing logfile: zmq-subt-x4-2020-09-30T10.23.30.log
  Autodetected name: X200L
  Trace reduced count: 438
  Ground truth seconds: 492
  Maximum error: 1.08m -&gt; OK
</pre>