### PR TITLE
subt.rosbag2log: process all tar files in curdir 

### DIFF
--- a/subt/rosbag2log.py
+++ b/subt/rosbag2log.py
@@ -213,8 +213,8 @@ def main():
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('filenames', help='ROS bag file(s) or tar(.gz)', nargs='*')
-    parser.add_argument('-a', '--all', help='extract all robot_data* files', action='store_true')
-    parser.add_argument('-v', '--verbose', help='verbose mode', action='store_true')
+    #parser.add_argument('-a', '--all', help='extract all robot_data* files', action='store_true')
+    parser.add_argument('--debug', help='debug output', action='store_true')
     args = parser.parse_args()
 
     if args.filenames == []:
@@ -227,10 +227,10 @@ def main():
     for filename in args.filenames:
         print("processing:", filename)
         if filename.endswith('.tar') or filename.endswith('.tar.gz'):
-            process_tar(filename, args.all, args.verbose)
+            process_tar(filename, all=True, verbose=args.debug)
         else:
             out_name = os.path.join(os.path.dirname(filename), 'tmp.log')
-            extract_log(read_rosbag_gen(filename), out_name, verbose=args.verbose)
+            extract_log(read_rosbag_gen(filename), out_name, verbose=args.debug)
 
 
 if __name__ == "__main__":

--- a/subt/rosbag2log.py
+++ b/subt/rosbag2log.py
@@ -208,18 +208,29 @@ def process_tar(filepath, all, verbose):
 
 def main():
     import argparse
+    import pathlib
+    import sys
 
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('filename', help='ROS bag file or tar(.gz)')
+    parser.add_argument('filenames', help='ROS bag file(s) or tar(.gz)', nargs='*')
     parser.add_argument('-a', '--all', help='extract all robot_data* files', action='store_true')
     parser.add_argument('-v', '--verbose', help='verbose mode', action='store_true')
     args = parser.parse_args()
 
-    if args.filename.endswith('.tar') or args.filename.endswith('.tar.gz'):
-        process_tar(args.filename, args.all, args.verbose)
-    else:
-        out_name = os.path.join(os.path.dirname(args.filename), 'tmp.log')
-        extract_log(read_rosbag_gen(args.filename), out_name, verbose=args.verbose)
+    if args.filenames == []:
+        for p in pathlib.Path('.').iterdir():
+            if p.suffixes == ['.tar', '.gz'] or p.suffixes == ['.tar']:
+                args.filenames.append(str(p))
+        if len(args.filenames) == 0:
+            sys.exit("no logfiles found in current directory")
+
+    for filename in args.filenames:
+        print("processing:", filename)
+        if filename.endswith('.tar') or filename.endswith('.tar.gz'):
+            process_tar(filename, args.all, args.verbose)
+        else:
+            out_name = os.path.join(os.path.dirname(filename), 'tmp.log')
+            extract_log(read_rosbag_gen(filename), out_name, verbose=args.verbose)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There are 2 commits
 - the first one just moves code around without any changes
 - the second one is the actual implementation

The workflow with this code (and with #646) is the following:
 - open cloudsim site
 - open browser preferences, find the option to set default download directory and set it to a newly created directory
 - click on all logfiles from a single simulation run and wait until the files appear in the directory selected above
 - in terminal, change to that directory and run in sequence:
    * `python -m subt.rosbag2log`
    * `python -m subt.tools.validator`

Now you should see if any of the robots got lost :v: 

Couple of notes:
 - the `-a` option does not make sense - I have never ever wanted an incomplete log file - so my proposal is to remove the option in its entirety and just always process the whole file
 - the `-v` option should actually be called `--debug` since that is what it is and the `-v` option could be repurposed to possibly hide even the current output