### PR TITLE
Increase of tilt/roll limits to max and integration of loop detector

### DIFF
--- a/osgar/lib/loop.py
+++ b/osgar/lib/loop.py
@@ -11,14 +11,14 @@ class LoopDetector:
                        pose_distance_threshold=0.5,
                        granularity=0.3,
                        max_loop_length=100.0,
-                       min_loop_length=5.0):
+                       min_loop_length=10.0):
         self.orientation_similarity_threshold = orientation_similarity_threshold
         self.pose_distance_threshold = pose_distance_threshold
         self.granularity = granularity
         self.max_loop_length = max_loop_length
         self.min_loop_length = min_loop_length
-
         self.trajectory = []
+        self.detected_loop = []
 
 
     def add(self, xyz, orientation):
@@ -33,16 +33,15 @@ class LoopDetector:
         self.trajectory[-1][2] = d
         self.trajectory.append([xyz, orientation, 0])
 
+        self.detected_loop = self.__detect_loop()
+
 
     def add_all(self, poses):
         for pose in poses:
             self.add(*pose)
 
 
-    def loop(self):
-        if not self.trajectory:
-            return None
-
+    def __detect_loop(self):
         loop_candidate = []
         loop_candidate_length = 0.0
         is_loop = False
@@ -71,7 +70,10 @@ class LoopDetector:
             break
 
 
-        return loop_candidate[::-1] if is_loop else None
+        return loop_candidate[::-1] if is_loop else []
+
+    def loop(self):
+        return self.detected_loop if self.detected_loop else None
 
 if __name__ == '__main__':
     import argparse

--- a/osgar/lib/test_loop.py
+++ b/osgar/lib/test_loop.py
@@ -12,7 +12,7 @@ class LoopDetectionTest(TestCase):
                       ((2, 2, 0), forward),
                       ((0, 2, 0), forward),
                       ((0, 0, 0), forward)]
-        detector = LoopDetector()
+        detector = LoopDetector(min_loop_length=5)
         detector.add_all(trajectory)
         loop = detector.loop()
         self.assertEqual(loop, trajectory)
@@ -26,7 +26,7 @@ class LoopDetectionTest(TestCase):
                       ((2, 2, 0), forward),
                       ((0, 2, 0), forward),
                       ((0, 0, 0), forward)]
-        detector = LoopDetector()
+        detector = LoopDetector(min_loop_length=5)
         detector.add_all(trajectory)
         loop = detector.loop()
         self.assertEqual(loop, trajectory[1:])
@@ -40,7 +40,7 @@ class LoopDetectionTest(TestCase):
                       ((2, 2, 0), forward),
                       ((0, 2, 0), forward),
                       ((0, 0, 0), almost_forward)]
-        detector = LoopDetector()
+        detector = LoopDetector(min_loop_length=5)
         detector.add_all(trajectory)
         loop = detector.loop()
         self.assertEqual(loop, trajectory)
@@ -53,7 +53,7 @@ class LoopDetectionTest(TestCase):
                       ((2, 2, 0), forward),
                       ((0, 2, 0), forward),
                       ((0.1, 0.1, 0.1), forward)]
-        detector = LoopDetector()
+        detector = LoopDetector(min_loop_length=5)
         detector.add_all(trajectory)
         loop = detector.loop()
         self.assertEqual(loop, trajectory)
@@ -70,7 +70,7 @@ class LoopDetectionTest(TestCase):
                       ((0, 2, 0), forward),
                       ((0, 1, 0), forward),
                       ((0, 0, 0), forward)]
-        detector = LoopDetector(granularity=2.0)
+        detector = LoopDetector(min_loop_length=5, granularity=2.0)
         detector.add_all(trajectory)
         loop = detector.loop()
         self.assertEqual(loop, trajectory[::2])
@@ -82,7 +82,7 @@ class LoopDetectionTest(TestCase):
                       ((2, 0, 0), forward),
                       ((2, 2, 0), forward),
                       ((0, 2, 0), forward)]
-        detector = LoopDetector()
+        detector = LoopDetector(min_loop_length=5)
         detector.add_all(trajectory)
         loop = detector.loop()
         self.assertIsNone(loop)
@@ -95,7 +95,7 @@ class LoopDetectionTest(TestCase):
                       ((2, 2, 0), forward),
                       ((0, 2, 0), forward),
                       ((0, 0, 1), forward)]
-        detector = LoopDetector()
+        detector = LoopDetector(min_loop_length=5)
         detector.add_all(trajectory)
         loop = detector.loop()
         self.assertIsNone(loop)
@@ -109,7 +109,7 @@ class LoopDetectionTest(TestCase):
                       ((2, 2, 0), forward),
                       ((0, 2, 0), forward),
                       ((0, 0, 0), left)]
-        detector = LoopDetector()
+        detector = LoopDetector(min_loop_length=5)
         detector.add_all(trajectory)
         loop = detector.loop()
         self.assertIsNone(loop)
@@ -122,7 +122,7 @@ class LoopDetectionTest(TestCase):
                       ((1, 1, 0), forward),
                       ((0, 1, 0), forward),
                       ((0, 0, 0), forward)]
-        detector = LoopDetector()
+        detector = LoopDetector(min_loop_length=5)
         detector.add_all(trajectory)
         loop = detector.loop()
         self.assertIsNone(loop)
@@ -135,7 +135,7 @@ class LoopDetectionTest(TestCase):
                       ((100, 100, 0), forward),
                       ((0, 100, 0), forward),
                       ((0, 0, 0), forward)]
-        detector = LoopDetector()
+        detector = LoopDetector(min_loop_length=5)
         detector.add_all(trajectory)
         loop = detector.loop()
         self.assertIsNone(loop)

--- a/subt/main.py
+++ b/subt/main.py
@@ -18,6 +18,7 @@ from osgar.lib.mathex import normalizeAnglePIPI
 from osgar.lib import quaternion
 from osgar.lib.virtual_bumper import VirtualBumper
 from osgar.lib.lidar_pts import equal_scans
+from osgar.lib.loop import LoopDetector
 
 from subt.local_planner import LocalPlanner
 from subt.trace import Trace, distance3D
@@ -133,6 +134,7 @@ class SubTChallenge:
         self.voltage = []
         self.artifacts = []
         self.trace = Trace()
+        self.loop_detector = LoopDetector()
         self.collision_detector_enabled = False
         self.sim_time_sec = 0
 
@@ -313,6 +315,10 @@ class SubTChallenge:
                     self.go_straight(-0.3, timeout=timedelta(seconds=10))
                     reason = REASON_VIRTUAL_BUMPER
                     break
+
+                loop = self.loop_detector.loop()
+                if loop:
+                    print(self.time, self.sim_time_sec, 'Loop detected')
 
                 if self.front_bumper and not flipped:
                     print(self.time, "FRONT BUMPER - collision")
@@ -512,6 +518,7 @@ class SubTChallenge:
                 self.virtual_bumper.update_pose(self.time, pose)
         self.xyz = tuple(xyz)
         self.trace.update_trace(self.xyz)
+        self.loop_detector.add(self.xyz, rot)
 
     def on_acc(self, timestamp, data):
         acc = [x / 1000.0 for x in data]

--- a/subt/main.py
+++ b/subt/main.py
@@ -902,7 +902,7 @@ class SubTChallenge:
         self.stdout('Final xyz (DARPA coord system):', (x + x0, y + y0, z + z0))
 
     def play_virtual_track(self):
-        self.stdout("SubT Challenge Ver78!")
+        self.stdout("SubT Challenge Ver79!")
         self.stdout("Waiting for robot_name ...")
         while self.robot_name is None:
             self.update()

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -81,7 +81,7 @@
               "min_z": -0.2,
               "max_z": 0.4,
               "max_slope": -3.14,
-              "disabled_vertical_diff_limit": 0.698, "vd_comment": "radians(40)"
+              "vertical_diff_limit": 1.4835, "vd_comment": "radians(85)"
             }
           }
       },

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -16,7 +16,11 @@
             "speed_policy": "conservative",
             "obstacle_influence": 1.2,
             "max_obstacle_distance": 3.0,
-            "height_above_ground": 2.0
+            "height_above_ground": 2.0,
+            "limit_roll": 90,
+            "limit_pitch": 90,
+            "return_limit_roll": 90,
+            "return_limit_pitch": 90
           }
       },
       "detector": {


### PR DESCRIPTION
Increase of tilt/roll limits to max and integration of loop detector (just print). Note, that the replay visibly slowed down so we may need to move loop detector to separate process? Also instead of print we may trigger action similar to virtual bumper? (for now)
Or we can at least publish "loop", which would oscillate True/False, i.e. report on change? If we extract loops after `pose3d` update, then it can be really separate node. Yes, there can be revision after "virtual obstacles" are implemented.