### PR TITLE
subt.tools.validator: skip teambase, autodetect pose3d stream

### DIFF
--- a/subt/tools/validator.py
+++ b/subt/tools/validator.py
@@ -99,14 +99,14 @@ def autodetect_name(logfile):
 
 def autodetect_pose3d(logfile):
     streams = lookup_stream_names(logfile)
-    streams = set(s.split('.')[0] for s in streams if s.endswith('.pose3d'))
-    if 'offseter' in streams:
+    nodes = set(s.split('.')[0] for s in streams if s.endswith('.pose3d'))
+    if 'offseter' in nodes:
         return 'offseter.pose3d'
-    if 'localization' in streams:
+    if 'localization' in nodes:
         return 'localization.pose3d'
-    if len(streams) == 1:
-        return streams[0]+'.pose3d'
-    assert False, f"pose3d stream autodetection failed: {streams}"
+    if len(nodes) == 1:
+        return nodes[0]+'.pose3d'
+    assert False, f"pose3d stream autodetection failed: {nodes}"
 
 
 def main():
@@ -185,8 +185,6 @@ def main():
             ax1.set_xlabel('sim time (s)')
             plt.legend()
             plt.show()
-
-    return
 
 
 if __name__ == "__main__":

--- a/subt/tools/validator.py
+++ b/subt/tools/validator.py
@@ -100,12 +100,12 @@ def autodetect_name(logfile):
 def autodetect_pose3d(logfile):
     streams = lookup_stream_names(logfile)
     nodes = set(s.split('.')[0] for s in streams if s.endswith('.pose3d'))
+    if len(nodes) == 1:
+        return nodes.pop()+'.pose3d'
     if 'offseter' in nodes:
         return 'offseter.pose3d'
     if 'localization' in nodes:
         return 'localization.pose3d'
-    if len(nodes) == 1:
-        return nodes[0]+'.pose3d'
     assert False, f"pose3d stream autodetection failed: {nodes}"
 
 


### PR DESCRIPTION
Example output:

<pre>$ python -m subt.tools.validator
Ground truth count: 153982
Processing logfile: aws-jl001cvrc1q-A1300L.log
  Autodetected name: A1300L
  Autodetect pose3d stream: offseter.pose3d
  Trace reduced count: 1253
  Ground truth seconds: 1524
  Maximum error: 31.04m -&gt; FAIL
Processing logfile: aws-jl001cvrc1q-T1500.log
  Autodetected name: T1500
  skiping teambase
Processing logfile: aws-jl001cvrc1q-C20W1200L.log
  Autodetected name: C20W1200L
  Autodetect pose3d stream: localization.pose3d
  Trace reduced count: 1272
  Ground truth seconds: 1524
  Maximum error: 225.48m -&gt; FAIL
Processing logfile: aws-jl001cvrc1q-D30W1200R.log
  Autodetected name: D30W1200R
  Autodetect pose3d stream: localization.pose3d
  Trace reduced count: 1503
  Ground truth seconds: 1524
  Maximum error: 471.73m -&gt; FAIL
Processing logfile: aws-jl001cvrc1q-B10W1300R.log
  Autodetected name: B10W1300R
  Autodetect pose3d stream: offseter.pose3d
  Trace reduced count: 1251
  Ground truth seconds: 1524
  Maximum error: 1444.74m -&gt; FAIL
</pre>
