### PR TITLE
subt.tools.validator: show more info about position quality

### DIFF
--- a/subt/tools/test_validator.py
+++ b/subt/tools/test_validator.py
@@ -16,10 +16,10 @@ class ValidatorTest(unittest.TestCase):
 
         gt = [(0, 0, 0, 0), (1, 1, 0, 0), (2, 3, 4, 5)]
         poses = [(1, 2, 0, 0)]
-        self.assertEqual(evaluate_poses(poses, gt), [(1, 1.0, 1, 0, 0)])
+        self.assertEqual(evaluate_poses(poses, gt), [(1, 1.0, 1, 0, 0, (1,0,0))])
 
         poses = [(1, 2, 0, 0), (1, 2.2, 0, 0)]  # duplicate sim_time
-        self.assertEqual(evaluate_poses(poses, gt), [(1, 1.0, 1, 0, 0)])
+        self.assertEqual(evaluate_poses(poses, gt), [(1, 1.0, 1, 0, 0, (1,0,0))])
 
     def test_ign2arr(self):
         vec = Vector3d()

--- a/subt/tools/validator.py
+++ b/subt/tools/validator.py
@@ -169,7 +169,6 @@ def main():
         else:
             limits = iter([1,2,3,4,5])
             current_limit = next(limits)
-            #dist3d = [a[1] for a in arr]
             dist3d = []
             last_xyz = arr[0][-1]
             path_dist = 0

--- a/subt/tools/validator.py
+++ b/subt/tools/validator.py
@@ -30,7 +30,7 @@ def evaluate_poses(poses, gt_poses, time_step_sec=1):
             j += 1
         dist = distance3D(poses[i][1:], gt_poses[j][1:])
         diff = [a - b for a, b in zip(poses[i][1:], gt_poses[j][1:])]
-        arr.append((time_limit, dist, *diff))
+        arr.append((time_limit, dist, *diff, gt_poses[j][1:]))
         time_limit += time_step_sec
     return arr
 
@@ -167,7 +167,24 @@ def main():
             if len(tmp_gt) > 0:
                 print('gt   :', tmp_gt[0][0], tmp_gt[-1][0])
         else:
-            dist3d = [a[1] for a in arr]
+            limits = iter([1,2,3,4,5])
+            current_limit = next(limits)
+            #dist3d = [a[1] for a in arr]
+            dist3d = []
+            last_xyz = arr[0][-1]
+            path_dist = 0
+            for dt, e, x, y, z, gt_xyz in arr:
+                dist3d.append(e)
+                path_dist += distance3D(gt_xyz, last_xyz)
+                last_xyz = gt_xyz
+                if current_limit is not None and e > current_limit:
+                    print(f"  sim_time_sec: {dt:5d}, error: {e:5.2f}m, distance: {distance3D(gt_xyz, [0,0,0]):7.2f}m from origin, path: {path_dist:7.2f}m")
+                    try:
+                        while e > current_limit:
+                            current_limit = next(limits)
+                    except StopIteration:
+                        current_limit = None
+
             print(f"  Maximum error: {max(dist3d):.2f}m -> {'OK' if max(dist3d) < 3 else 'FAIL'}")
             assert min(dist3d) < 0.1, min(dist3d)  # the minimum should be almost zero for correct evaluation
 


### PR DESCRIPTION
Example output:
```
Ground truth count: 153982
Processing logfile: aws-jl001cvrc1q-A1300L.log
  Autodetected name: A1300L
  Autodetect pose3d stream: offseter.pose3d
  Trace reduced count: 1253
  Ground truth seconds: 1524
  sim_time_sec:   800, error:  1.04m, distance:  100.42m from origin, path:  755.60m
  sim_time_sec:   893, error:  2.09m, distance:  125.43m from origin, path:  848.85m
  sim_time_sec:  1273, error: 11.46m, distance:  225.33m from origin, path: 1234.28m
  Maximum error: 31.04m -> FAIL
Processing logfile: aws-jl001cvrc1q-T1500.log
  Autodetected name: T1500
  skiping teambase
Processing logfile: aws-jl001cvrc1q-C20W1200L.log
  Autodetected name: C20W1200L
  Autodetect pose3d stream: localization.pose3d
  Trace reduced count: 1272
  Ground truth seconds: 1524
  sim_time_sec:   125, error:  1.00m, distance:   68.88m from origin, path:   91.73m
  sim_time_sec:   132, error:  2.23m, distance:   69.83m from origin, path:   93.22m
  sim_time_sec:   135, error:  3.09m, distance:   69.83m from origin, path:   93.22m
  sim_time_sec:   139, error:  4.27m, distance:   69.83m from origin, path:   93.23m
  sim_time_sec:   142, error:  5.16m, distance:   69.83m from origin, path:   93.23m
  Maximum error: 225.48m -> FAIL
Processing logfile: aws-jl001cvrc1q-D30W1200R.log
  Autodetected name: D30W1200R
  Autodetect pose3d stream: localization.pose3d
  Trace reduced count: 1503
  Ground truth seconds: 1524
  sim_time_sec:   123, error:  1.00m, distance:   46.32m from origin, path:   77.71m
  sim_time_sec:   285, error:  2.02m, distance:   43.28m from origin, path:  256.68m
  sim_time_sec:   435, error:  3.50m, distance:   18.61m from origin, path:  413.47m
  sim_time_sec:   437, error:  4.19m, distance:   18.61m from origin, path:  413.47m
  sim_time_sec:   440, error:  5.44m, distance:   18.61m from origin, path:  413.47m
  Maximum error: 471.73m -> FAIL
Processing logfile: aws-jl001cvrc1q-B10W1300R.log
  Autodetected name: B10W1300R
  Autodetect pose3d stream: offseter.pose3d
  Trace reduced count: 1251
  Ground truth seconds: 1524
  sim_time_sec:   453, error:  1.11m, distance:   97.59m from origin, path:  408.73m
  sim_time_sec:   592, error:  2.01m, distance:  102.52m from origin, path:  550.63m
  sim_time_sec:   595, error:  5.34m, distance:   99.52m from origin, path:  553.93m
  Maximum error: 1444.74m -> FAIL
```