### PR TITLE
SubT Breadcrumbs deploy based on distance

### DIFF
--- a/subt/breadcrumbs.py
+++ b/subt/breadcrumbs.py
@@ -4,17 +4,29 @@
 from ast import literal_eval
 
 from osgar.node import Node
+from subt.trace import distance3D
 
 
 class Breadcrumbs(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
-        bus.register("deploy")
+        bus.register("deploy", "location")
 
         self.robot_name = config.get('robot_name')
         self.start_time = None  # unknown
         self.next_deploy_time = None
         self.step_time = config.get('step_sec')
+
+        self.radius = config.get('radius')
+        self.locations = [[0, 0, 0]]  # all locations + fake for the base
+
+    def should_deploy(self, xyz):
+        if self.radius is None:
+            return False
+        for loc in self.locations:
+            if distance3D(xyz, loc) < self.radius:
+                return False
+        return True
 
     def on_sim_time_sec(self, data):
         if self.start_time is None:
@@ -24,6 +36,13 @@ class Breadcrumbs(Node):
         if self.next_deploy_time is not None and data > self.next_deploy_time:
             self.next_deploy_time += self.step_time
             self.publish('deploy', [])  # ROS std_msg/Empty expects empty list as input
+
+    def on_pose3d(self, data):
+        xyz, quat = data
+        if self.should_deploy(xyz):
+            self.locations.append(xyz)
+            self.publish('deploy', [])
+            self.publish('location', xyz)
 
     def update(self):
         channel = super().update()

--- a/subt/test_breadcrumbs.py
+++ b/subt/test_breadcrumbs.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from subt.breadcrumbs import Breadcrumbs
-
+from osgar.lib import quaternion
 
 class BreadcrumbsTest(unittest.TestCase):
 
@@ -16,5 +16,19 @@ class BreadcrumbsTest(unittest.TestCase):
         bus.publish.reset_mock()
         bread.on_sim_time_sec(15)
         bus.publish.assert_not_called()
+
+    def test_breadcrumbs_dist(self):
+        bus = bus=MagicMock()
+        bread = Breadcrumbs(bus=bus, config={'radius':10})
+        self.assertEqual(bread.locations, [[0, 0, 0]])
+
+        bread.on_pose3d([[1, 0, 0], quaternion.identity()])
+        self.assertEqual(bread.locations, [[0, 0, 0]])
+        bus.publish.assert_not_called()
+
+        bread.on_pose3d([[11, 0, 0], quaternion.identity()])
+        self.assertEqual(bread.locations, [[0, 0, 0], [11, 0, 0]])
+        bus.publish.assert_called()
+
 
 # vim: expandtab sw=4 ts=4

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -92,7 +92,7 @@
           "in": ["sim_time_sec"],
           "out": ["deploy"],
           "init": {
-            "step_sec": 50
+            "radius": 30
           }
       }
     },
@@ -136,6 +136,7 @@
               ["rosmsg.radio", "lora.radio"],
 
               ["rosmsg.sim_time_sec", "breadcrumbs.sim_time_sec"],
+              ["localization.pose3d", "breadcrumbs.pose3d"],
               ["breadcrumbs.deploy", "torospy.deploy"],
 
               ["detector.artf", "app.artf"],


### PR DESCRIPTION
This is preliminary step to place breadcrumbs more reasonably, i.e. instead of time interval it takes into account 3D distance. The `self.locations` should be later exchanged among all robots, so they will not place breadcrumbs where not needed. The location info could be later used also by teambase for filtering false artifacts or robot relocalization ... one day.

Note, that 30m is just wild guess and need evaluation. It would require to run at least 2 robots (TEAMBASE and Freyja config2) to be able to see it - I am adding @frantisekbrabec if he wants to try to find more suitable value (based on different worlds).