### PR TITLE
SubT refactoring LoRA into subt/radio

### DIFF
--- a/subt/radio.py
+++ b/subt/radio.py
@@ -9,7 +9,7 @@ from osgar.node import Node
 from osgar.bus import BusShutdownException
 
 
-def Xdraw_lora_positions(arr):
+def draw_positions(arr):
     """
     Draw positions of tripples:
         (time, ID, (x. y, heading))
@@ -22,7 +22,7 @@ def Xdraw_lora_positions(arr):
     for robot_id in robot_ids:
         x = [a[2][0]/1000.0 for a in arr if a[1] == robot_id]
         y = [a[2][1]/1000.0 for a in arr if a[1] == robot_id]
-        line = plt.plot(x, y, '-o', linewidth=2, label='Robot #%d' % robot_id)
+        line = plt.plot(x, y, '-o', linewidth=2, label=f'Robot {robot_id}')
 
 #    plt.xlabel('time (s)')
     plt.axes().set_aspect('equal', 'datalim')
@@ -51,7 +51,8 @@ class Radio(Node):
             arr = literal_eval(packet.decode('ascii'))
             if len(arr) == 3:
                 # position
-                pass
+                if self.verbose:
+                    self.debug_robot_poses.append((self.time, name, arr))  # TODO sim_time_sec
             elif len(arr) == 4:
                 # artifact
                 self.publish('artf_xyz', [arr])  # publish also standard "list" of detected artifacts
@@ -77,7 +78,7 @@ class Radio(Node):
         """
         Debug Draw
         """
-        draw_lora_positions(self.debug_robot_poses)
+        draw_positions(self.debug_robot_poses)
 
 
 # vim: expandtab sw=4 ts=4

--- a/subt/radio.py
+++ b/subt/radio.py
@@ -1,0 +1,86 @@
+"""
+  Radio for Virtual SubT
+
+"""
+from datetime import timedelta
+from ast import literal_eval
+
+from osgar.node import Node
+from osgar.bus import BusShutdownException
+
+
+def Xdraw_lora_positions(arr):
+    """
+    Draw positions of tripples:
+        (time, ID, (x. y, heading))
+    """
+    import matplotlib.pyplot as plt
+    t = [a[0] for a in arr]
+    robot_ids = sorted(list(set([a[1] for a in arr])))
+    print('Robot IDs', robot_ids)
+
+    for robot_id in robot_ids:
+        x = [a[2][0]/1000.0 for a in arr if a[1] == robot_id]
+        y = [a[2][1]/1000.0 for a in arr if a[1] == robot_id]
+        line = plt.plot(x, y, '-o', linewidth=2, label='Robot #%d' % robot_id)
+
+#    plt.xlabel('time (s)')
+    plt.axes().set_aspect('equal', 'datalim')
+    plt.legend()
+    plt.show()
+
+
+class Radio(Node):
+    def __init__(self, config, bus):
+        super().__init__(config, bus)
+        bus.register('raw', 'cmd', 'robot_status', 'artf', 'artf_xyz')
+        self.min_transmit_dt = timedelta(seconds=10)  # TODO config?
+        self.last_transmit = None
+        self.recent_packets = []
+        self.verbose = config.get('verbose', False)
+        self.debug_robot_poses = []
+
+    def send_data(self, data):
+        self.last_transmit = self.publish('raw', data + b'\n')
+        return self.last_transmit
+
+    def on_radio(self, data):
+        src, packet = data
+        name = src.decode('ascii')
+        if packet.startswith(b'['):
+            arr = literal_eval(packet.decode('ascii'))
+            if len(arr) == 3:
+                # position
+                pass
+            elif len(arr) == 4:
+                # artifact
+                self.publish('artf_xyz', [arr])  # publish also standard "list" of detected artifacts
+            else:
+                assert False, arr  # unexpected size/type
+
+    def update(self):
+        channel = super().update()  # define self.time
+        if channel == 'radio':
+            self.on_radio(self.radio)
+        elif channel == 'pose2d':
+            if self.last_transmit is None or self.time > self.last_transmit + self.min_transmit_dt:
+                self.send_data(bytes(str(self.pose2d), encoding='ascii'))
+        elif channel == 'cmd':
+            assert len(self.cmd) == 2, self.cmd
+            self.send_data(b'%d:%s:%d' % (self.cmd[0], self.cmd[1], int(self.time.total_seconds())))
+        elif channel == 'artf':
+            # send data as they are, ignore transmit time, ignore transmit failure
+            for artf_item in self.artf:
+                self.send_data(bytes(str(artf_item), encoding='ascii'))
+        else:
+            assert False, channel  # not supported
+        return channel
+
+    def draw(self):
+        """
+        Debug Draw
+        """
+        draw_lora_positions(self.debug_robot_poses)
+
+
+# vim: expandtab sw=4 ts=4

--- a/subt/radio.py
+++ b/subt/radio.py
@@ -33,7 +33,7 @@ def Xdraw_lora_positions(arr):
 class Radio(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
-        bus.register('raw', 'cmd', 'robot_status', 'artf', 'artf_xyz')
+        bus.register('radio', 'artf_xyz')
         self.min_transmit_dt = timedelta(seconds=10)  # TODO config?
         self.last_transmit = None
         self.recent_packets = []
@@ -41,7 +41,7 @@ class Radio(Node):
         self.debug_robot_poses = []
 
     def send_data(self, data):
-        self.last_transmit = self.publish('raw', data + b'\n')
+        self.last_transmit = self.publish('radio', data + b'\n')
         return self.last_transmit
 
     def on_radio(self, data):
@@ -65,9 +65,6 @@ class Radio(Node):
         elif channel == 'pose2d':
             if self.last_transmit is None or self.time > self.last_transmit + self.min_transmit_dt:
                 self.send_data(bytes(str(self.pose2d), encoding='ascii'))
-        elif channel == 'cmd':
-            assert len(self.cmd) == 2, self.cmd
-            self.send_data(b'%d:%s:%d' % (self.cmd[0], self.cmd[1], int(self.time.total_seconds())))
         elif channel == 'artf':
             # send data as they are, ignore transmit time, ignore transmit failure
             for artf_item in self.artf:

--- a/subt/test_radio.py
+++ b/subt/test_radio.py
@@ -1,0 +1,25 @@
+import unittest
+import datetime
+from unittest.mock import MagicMock, patch, call
+
+from subt.radio import Radio
+from osgar.bus import Bus
+
+
+class RadioTest(unittest.TestCase):
+
+    def test_on_radio(self):
+        # virtual world
+        data = [b'A0F150L', b"['TYPE_RESCUE_RANDY', 15982, 104845, 3080]\n"]
+        bus = MagicMock()
+        dev = Radio(bus=bus, config={})
+        bus.reset_mock()
+        dev.on_radio(data)
+        bus.publish.assert_called()
+
+        data = [b'A0F150L', b'[11896, 7018, -11886]\n']
+        bus.reset_mock()
+        dev.on_radio(data)
+        bus.publish.assert_not_called()
+
+# vim: expandtab sw=4 ts=4

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -80,7 +80,7 @@
           "driver": "subt.push:Push"
       },
       "radio": {
-          "driver": "radio",
+          "driver": "subt.radio:Radio",
           "in": ["radio", "pose2d", "artf"],
           "out": ["radio", "artf_xyz"],
           "init": {}

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -79,13 +79,11 @@
       "torospy": {
           "driver": "subt.push:Push"
       },
-      "lora": {
-          "driver": "lora",
-          "in": ["raw", "pose2d"],
-          "out": ["raw", "cmd"],
-          "init": {
-            "device_id": 1
-          }
+      "radio": {
+          "driver": "radio",
+          "in": ["radio", "pose2d", "artf"],
+          "out": ["radio", "artf_xyz"],
+          "init": {}
       },
       "breadcrumbs": {
           "driver": "subt.breadcrumbs:Breadcrumbs",
@@ -128,12 +126,11 @@
 
               ["rosmsg.gas_detected", "detector.gas_detected"],
 
-              ["app.pose2d", "lora.pose2d"],
-              ["lora.cmd", "app.cmd"],
-              ["reporter.artf_all", "lora.artf"],
-              ["lora.artf_xyz", "reporter.artf_xyz"],
-              ["lora.raw", "rosmsg.broadcast"],
-              ["rosmsg.radio", "lora.radio"],
+              ["app.pose2d", "radio.pose2d"],
+              ["reporter.artf_all", "radio.artf"],
+              ["radio.artf_xyz", "reporter.artf_xyz"],
+              ["radio.radio", "rosmsg.broadcast"],
+              ["rosmsg.radio", "radio.radio"],
 
               ["rosmsg.sim_time_sec", "breadcrumbs.sim_time_sec"],
               ["breadcrumbs.deploy", "torospy.deploy"],

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -88,7 +88,7 @@
 	      }
       },
       "radio": {
-          "driver": "radio",
+          "driver": "subt.radio:Radio",
           "in": ["radio", "pose2d", "artf"],
           "out": ["radio", "artf_xyz"],
           "init": {}

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -87,13 +87,11 @@
 	        "outputs": ["rot", "acc", "orientation", "top_scan", "bottom_scan", "pose3d"]
 	      }
       },
-      "lora": {
-          "driver": "lora",
-          "in": ["raw", "pose2d"],
-          "out": ["raw", "cmd"],
-          "init": {
-            "device_id": 1
-          }
+      "radio": {
+          "driver": "radio",
+          "in": ["radio", "pose2d", "artf"],
+          "out": ["radio", "artf_xyz"],
+          "init": {}
       },
       "offseter": {
         "driver": "subt.offseter:Offseter"
@@ -129,12 +127,11 @@
 
               ["rosmsg.gas_detected", "detector.gas_detected"],
 
-              ["app.pose2d", "lora.pose2d"],
-              ["lora.cmd", "app.cmd"],
-              ["reporter.artf_all", "lora.artf"],
-              ["lora.artf_xyz", "reporter.artf_xyz"],
-              ["lora.raw", "rosmsg.broadcast"],
-              ["rosmsg.radio", "lora.radio"],
+              ["app.pose2d", "radio.pose2d"],
+              ["reporter.artf_all", "radio.artf"],
+              ["radio.artf_xyz", "reporter.artf_xyz"],
+              ["radio.radio", "rosmsg.broadcast"],
+              ["rosmsg.radio", "radio.radio"],
 
               ["detector.artf", "app.artf"],
               ["detector.stdout", "rosmsg.stdout"],


### PR DESCRIPTION
This is the first step of refactoring LoRA - cut bits which should be SubT Virtual specific.

The LoRA should be universal driver for sending small packets over long range radio. In SubT Virtual the packets are much bigger and can be send much more frequently. Also we need "virtual specific" functionality.

This PR creates `subt/radio.py`, which implements the same functionality, which currently also is in `subt/drivers/lora.py`:
* broadcast robot position every 10s
* broadcast internally received artifacts one by one
* publish externally received artifacts as "newly detected" (`artf_xyz`)
