### PR TITLE
subt.tools.ignstate: extract also breadcrumbs

### DIFF
--- a/subt/tools/ignstate.py
+++ b/subt/tools/ignstate.py
@@ -146,6 +146,10 @@ def draw(poses, artifacts):
         max_x = max_x if p[0] < max_x else p[0]
         max_y = max_y if p[1] < max_y else p[1]
 
+    # keep some space around so that markers fit
+    max_x += 1
+    max_y += 1
+
     print(f"min x: {min_x:.2f} y: {min_y:.2f}")
     print(f"max x: {max_x:.2f} y: {max_y:.2f}")
 

--- a/subt/tools/ignstate.py
+++ b/subt/tools/ignstate.py
@@ -39,7 +39,7 @@ MARKERS = {
 }
 
 class Vector3d(namedtuple('Vector3dBase', ('x', 'y', 'z'))):
-
+    __slots__ = () # https://docs.python.org/3/library/collections.html#collections.namedtuple
     def __sub__(self, other):
         return Vector3d(*(s - o for s, o in zip(self, other)))
 

--- a/subt/tools/validator.py
+++ b/subt/tools/validator.py
@@ -135,7 +135,7 @@ def main():
         if len(args.logfiles) == 0:
             sys.exit("no logfiles found in current directory")
 
-    ground_truth = ign.read_poses(args.ign, seconds=args.sec)
+    ground_truth, breadcrumbs = ign.read_poses(args.ign, seconds=args.sec)
     artifacts = ign.read_artifacts(args.ign)
     img = ign.draw(ground_truth, artifacts)
     cv2.imwrite(args.ign+'.png', img)

--- a/subt/tools/validator.py
+++ b/subt/tools/validator.py
@@ -137,7 +137,7 @@ def main():
 
     ground_truth, breadcrumbs = ign.read_poses(args.ign, seconds=args.sec)
     artifacts = ign.read_artifacts(args.ign)
-    img = ign.draw(ground_truth, artifacts)
+    img = ign.draw(ground_truth, artifacts, breadcrumbs)
     cv2.imwrite(args.ign+'.png', img)
     if args.draw:
         cv2.namedWindow("ground truth", cv2.WINDOW_NORMAL)


### PR DESCRIPTION
`read_poses` now returns robot positions and breadcrumbs positions (since it returns xyz and not pose, it is probably misnamed... oh well).

The positions are now `namedtuple` supporting both xyz attr and [0], [1], [2] indexing. The protobuf types are not leaked outside anymore.