### PR TITLE
subt.tools.submit: to ease submitting runs to cloudsim

### DIFF
--- a/subt/tools/submit.py
+++ b/subt/tools/submit.py
@@ -51,11 +51,9 @@ def validate_robots(robots, timeout):
 
 
 def validate_image(image):
-    image_bytes = bytes(image, 'ascii')
-    images = _cmd('aws', 'ecr', 'list-images', '--repository-name', 'subt/robotika')
-    for img in images.split(b'\n'):
-        parts = img.split(b'\t')
-        if parts[-1] == image_bytes:
+    images = _cmd('aws', 'ecr', 'list-images', '--repository-name', 'subt/robotika', '--output', 'json')
+    for img in json.loads(images)["imageIds"]:
+        if img.get('imageTag') == image:
             return f'200670743174.dkr.ecr.us-east-1.amazonaws.com/subt/robotika:{image}'
     sys.exit(f"image '{image}' not found in aws subt/robotika repository")
 

--- a/subt/tools/submit.py
+++ b/subt/tools/submit.py
@@ -24,7 +24,7 @@ WORLDS=dict(
 ROBOTS=dict(
     teambase = "TEAMBASE",
     drone = "SSCI_X4_SENSOR_CONFIG_2",
-    freya = "ROBOTIKA_FREYJA_SENSOR_CONFIG_2",
+    freyja = "ROBOTIKA_FREYJA_SENSOR_CONFIG_2",
 )
 
 

--- a/subt/tools/submit.py
+++ b/subt/tools/submit.py
@@ -1,0 +1,155 @@
+import argparse
+import json
+import re
+import requests
+import subprocess
+import os
+import pathlib
+
+import toml
+
+WORLDS=dict(
+    up1 = "Urban Practice 1",
+    up2 = "Urban Practice 2",
+    up3 = "Urban Practice 3",
+    cq  = "Cave Qualification",
+    cs1 = "Cave Simple 1",
+    cs2 = "Cave Simple 2",
+    cs3 = "Cave Simple 3",
+    cp1 = "Cave Practice 1",
+    cp2 = "Cave Practice 2",
+    cp3 = "Cave Practice 3",
+)
+
+ROBOTS=dict(
+    teambase = "TEAMBASE",
+    drone = "SSCI_X4_SENSOR_CONFIG_2",
+    freya = "ROBOTIKA_FREYJA_SENSOR_CONFIG_2",
+)
+
+
+def _cmd(*args):
+    return subprocess.run(args, stdout=subprocess.PIPE).stdout
+
+
+def validate_world(world):
+    try:
+        return WORLDS[world]
+    except KeyError:
+        sys.exit(f"'{world}' not valid world identification")
+
+
+def validate_robots(robots, timeout):
+    valid = {}
+    for name, kind in robots.items():
+        try:
+            valid[name] = ROBOTS[kind]
+        except KeyError:
+            sys.exit(f"'{kind}' not valid robot kind identification")
+    valid[f"T{timeout}"] = "TEAMBASE"
+    return valid
+
+
+def validate_image(image):
+    image_bytes = bytes(image, 'ascii')
+    images = _cmd('aws', 'ecr', 'list-images', '--repository-name', 'subt/robotika')
+    for img in images.split(b'\n'):
+        parts = img.split(b'\t')
+        if parts[-1] == image_bytes:
+            return f'200670743174.dkr.ecr.us-east-1.amazonaws.com/subt/robotika:{image}'
+    sys.exit(f"image '{image}' not found in aws subt/robotika repository")
+
+
+def generate_simname(logdir, image, world):
+    if not logdir.exists():
+        sys.exit(f"{logdir} does not exist")
+    image = image.replace('-', '').replace('_', '')
+    prefix = image+world
+    existing = [x for x in logdir.iterdir() if x.is_dir() and x.name.startswith(prefix)]
+    run = 0
+    for a in sorted(existing):
+        run = re.search('(?<=[vr])[0-9]+$', a.name).group()
+    run = int(run) + 1
+    simname = f"{prefix}r{run}"
+    return simname
+
+
+def _pretty_print_request(req):
+    print('{}\n{}\r\n{}\r\n\r\n{}'.format(
+        '-----------START-----------',
+        req.method + ' ' + req.url,
+        '\r\n'.join('{}: {}'.format(k, v) for k, v in req.headers.items()),
+        req.body.decode('utf-8'),
+    ))
+
+
+def submit(token, simname, image, world, robots, dont_submit):
+    data = [
+        ('name', (None, simname)),
+        ('owner', (None, "robotika")),
+        ('circuit', (None, world)),
+    ]
+    for name, kind in robots.items():
+        data.append(('robot_name', (None, name)))
+        data.append(('robot_type', (None, kind)))
+        data.append(('robot_image', (None, image)))
+
+    headers = {
+        'Private-Token': token
+    }
+
+    req = requests.Request('POST', url="https://cloudsim.ignitionrobotics.org/1.0/simulations", files=data,
+                           headers=headers).prepare()
+
+    if dont_submit:
+        print("======= not really submiting =======")
+        _pretty_print_request(req)
+        return False
+
+    s = requests.Session()
+    resp = s.send(req)
+
+    print(json.dumps(resp.json(), indent=4))
+
+    if resp.status_code == 200:
+        return True
+
+    return False
+
+
+def main(argv):
+    token = os.getenv("SUBT_ACCESS_TOKEN")
+    if token is None:
+        sys.exit("SUBT_ACCESS_TOKEN environment variable not set")
+
+    parser = argparse.ArgumentParser(description='Submit cloudsim run')
+    parser.add_argument("config", nargs="?", default=str(pathlib.Path('./run.toml')))
+    parser.add_argument("-n", action="store_true", help="don't really submit")
+    args = parser.parse_args(argv)
+
+    config_file = pathlib.Path(args.config).absolute()
+    if not config_file.is_file():
+        sys.exit(f"{config_file} not found")
+
+    with open(args.config, 'r') as f:
+        config = toml.load(f)
+
+    world = validate_world(config["world"])
+    robots = validate_robots(config["robots"], config["timeout"])
+    image_url = validate_image(config["image"])
+    simname = generate_simname(config_file.parent, config["image"], config["world"])
+
+    print(f"world:   {world}")
+    print(f"image:   {image_url}")
+    print(f"simname: {simname}")
+    print(f"robots:  ")
+    for name, kind in robots.items():
+        print(f"  {name:>10s}: {kind}")
+
+    if submit(token, simname, image_url, world, robots, args.n):
+        (config_file.parent / simname).mkdir()
+
+
+if __name__ == "__main__":
+    import sys
+    main(sys.argv[1:])

--- a/subt/tools/submit.py
+++ b/subt/tools/submit.py
@@ -118,7 +118,9 @@ def submit(token, simname, image, world, robots, dont_submit):
 def main(argv):
     token = os.getenv("SUBT_ACCESS_TOKEN")
     if token is None:
-        sys.exit("SUBT_ACCESS_TOKEN environment variable not set")
+        sys.exit("SUBT_ACCESS_TOKEN environment variable not set\n"
+                 "https://subtchallenge.world/settings -> Access Tokens -> Create Token\n"
+                 "assing the token to the SUBT_ACCESS_TOKEN variable")
 
     parser = argparse.ArgumentParser(description='Submit cloudsim run')
     parser.add_argument("config", nargs="?", default=str(pathlib.Path('./run.toml')))


### PR DESCRIPTION
I have cleaned up a tool I was using locally for some time already. It has not really been tested much after the refactoring since a valid test requires submitting a new run.

The usage is as follows:
1. create a `run.toml` file
2. run `python -m subt.tools.submit [-n]` from the directory with `run.toml`

Example toml file for the recent drone relay run:
```toml
world = "cs2"
timeout = 2300
image = "ver81rc1"

[robots]
A1050L = "drone"
B300W900L = "drone"
C900W600L = "drone"
```
Example output:
```
world:   Cave Simple 2
image:   200670743174.dkr.ecr.us-east-1.amazonaws.com/subt/robotika:ver81rc1
simname: ver81rc1cs2r1
robots:  
      A1050L: SSCI_X4_SENSOR_CONFIG_2
   B300W900L: SSCI_X4_SENSOR_CONFIG_2
   C900W600L: SSCI_X4_SENSOR_CONFIG_2
       T2300: TEAMBASE
======= not really submiting =======
...
```

A directory with the name of the simulation is created alongside the `run.toml` file. This directory is used as an evidence that such a simulation has already been submitted (allows for automatic simulation naming) and can be used as a storage for downloaded logfiles from the run.