### PR TITLE
subt.tools.validator: open ground truth pic with system viewer

### DIFF
--- a/subt/tools/ignstate.py
+++ b/subt/tools/ignstate.py
@@ -240,8 +240,8 @@ def main():
     cv2.imwrite(args.filename+'.png', img)
     print("created:", args.filename+'.png')
     if args.open:
-        import webbrowser
-        webbrowser.open(args.filename+'.png')
+        from . import startfile
+        startfile.main(args.filename+'.png')
 
 
 if __name__ == "__main__":

--- a/subt/tools/startfile.py
+++ b/subt/tools/startfile.py
@@ -1,0 +1,19 @@
+import os
+import os.path
+import subprocess
+import sys
+
+if sys.platform[:3] == "win":
+
+    def main(filepath):
+        normpath = os.path.normpath(filepath)
+        os.startfile(normpath)
+
+else:
+
+    def main(filepath):
+        subprocess.Popen(['xdg-open', filepath], close_fds=True, start_new_session=True)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1])

--- a/subt/tools/validator.py
+++ b/subt/tools/validator.py
@@ -140,13 +140,8 @@ def main():
     img = ign.draw(ground_truth, artifacts, breadcrumbs)
     cv2.imwrite(args.ign+'.png', img)
     if args.draw:
-        cv2.namedWindow("ground truth", cv2.WINDOW_NORMAL)
-        cv2.imshow("ground truth", img)
-        while True:
-            key = cv2.waitKey()
-            if key in (ord('q'), 27):
-                break
-        cv2.destroyWindow("ground truth")
+        import webbrowser
+        webbrowser.open(args.ign+'.png')
 
     print('Ground truth count:', len(ground_truth))
 

--- a/subt/tools/validator.py
+++ b/subt/tools/validator.py
@@ -140,8 +140,8 @@ def main():
     img = ign.draw(ground_truth, artifacts, breadcrumbs)
     cv2.imwrite(args.ign+'.png', img)
     if args.draw:
-        import webbrowser
-        webbrowser.open(args.ign+'.png')
+        from . import startfile
+        startfile.main(args.ign+'.png')
 
     print('Ground truth count:', len(ground_truth))
 


### PR DESCRIPTION
I always close the opencv viewer with Alt+F4 which leaves me with no choice but to cancel the whole run. This makes it consistent with what `ignstate -o` does.