### PR TITLE
SubT X4 control height via OSGAR

### DIFF
--- a/osgar/drivers/rosmsg.py
+++ b/osgar/drivers/rosmsg.py
@@ -504,8 +504,8 @@ class ROSMsgParser(Thread):
         self.count = 0
         self.downsample = config.get('downsample', 1)
 
-        self.desired_speed = 0.0  # m/s
-        self.desired_angular_speed = 0.0
+        self.desired_speed = None  # m/s
+        self.desired_angular_speed = None
         # alternative 3D speed description used in ROS Twist message
         self.desired_speed_3d, self.desired_angular_speed_3d = None, None
         self.gas_detected = None  # this SubT Virtual specific :-(
@@ -515,8 +515,11 @@ class ROSMsgParser(Thread):
     def publish_desired_speed(self):
         if self.desired_speed is not None:
             cmd = b'cmd_vel %f %f' % (self.desired_speed, self.desired_angular_speed)
-        else:
+        elif self.desired_speed_3d is not None:
             cmd = b'cmd_vel_3d %f %f %f %f %f %f' % tuple(self.desired_speed_3d + self.desired_angular_speed_3d)
+        else:
+            # desired speed is not defined - valid state for waiting drone - do not send anything!
+            return
         self.bus.publish('cmd', cmd)
 
     def get_packet(self):

--- a/osgar/drivers/test_rosmsg.py
+++ b/osgar/drivers/test_rosmsg.py
@@ -147,6 +147,10 @@ class ROSMsgParserTest(unittest.TestCase):
 
         clock_data = b'\x08\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00'  # clock 3s
         r.slot_raw(timestamp=None, data=clock_data)
+        bus.publish.assert_called_with('sim_time_sec', 3)  # initially desired speed is None -> no cmd
+
+        r.slot_desired_speed(timestamp=None, data=[0, 0])
+        r.slot_raw(timestamp=None, data=clock_data)
         # ... asserting that the last call has been made in a particular way
         bus.publish.assert_called_with('cmd', b'cmd_vel 0.000000 0.000000')
 
@@ -154,5 +158,9 @@ class ROSMsgParserTest(unittest.TestCase):
         r.slot_desired_speed_3d(timestamp=None, data=[[1, 2, 3], [4, 5, 6]])
         r.slot_raw(timestamp=None, data=clock_data)
         bus.publish.assert_called_with('cmd', b'cmd_vel_3d 1.000000 2.000000 3.000000 4.000000 5.000000 6.000000')
+
+    def test_publish_undefined_desired_speed(self):
+        # for the drone it is important not to send any command until the very first desired speed is received
+        pass
 
 # vim: expandtab sw=4 ts=4

--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -208,6 +208,12 @@ class main:
         rospy.loginfo_throttle(10, "score callback: {}".format(self.score_count))
         self.bus.publish("score", msg.data)
 
+    def atmospheric_pressure(self, msg):
+        self.atmospheric_pressure_count += 1
+        rospy.loginfo_throttle(10, "atmospheric_pressure callback: {}".format(self.atmospheric_pressure_count))
+        self.bus.publish('atmospheric_pressure', msg.fluid_pressure)
+
+
 if __name__ == '__main__':
     if len(sys.argv) < 2:
         print("need robot name as argument", file=sys.stderr)

--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -19,7 +19,7 @@ import msgpack
 from sensor_msgs.msg import Imu, LaserScan
 from nav_msgs.msg import Odometry
 from std_msgs.msg import Empty, Int32
-from sensor_msgs.msg import BatteryState
+from sensor_msgs.msg import BatteryState, FluidPressure
 
 
 def py3round(f):
@@ -109,6 +109,7 @@ class main:
             topics.append(('/' + robot_name + '/top_scan', LaserScan, self.top_scan, ('top_scan',)))
             topics.append(('/' + robot_name + '/bottom_scan', LaserScan, self.bottom_scan, ('bottom_scan',)))
             topics.append(('/' + robot_name + '/odom_fused', Odometry, self.odom_fused, ('pose3d',)))
+            topics.append(('/' + robot_name + '/atmospheric_pressure', FluidPressure, self.atmospheric_pressure, ('atmospheric_pressure',)))
         elif "TeamBase" in robot_description:
             rospy.loginfo("teambase")
         elif "robotika_freyja_sensor_config" in robot_description:

--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -109,7 +109,7 @@ class main:
             topics.append(('/' + robot_name + '/top_scan', LaserScan, self.top_scan, ('top_scan',)))
             topics.append(('/' + robot_name + '/bottom_scan', LaserScan, self.bottom_scan, ('bottom_scan',)))
             topics.append(('/' + robot_name + '/odom_fused', Odometry, self.odom_fused, ('pose3d',)))
-            topics.append(('/' + robot_name + '/atmospheric_pressure', FluidPressure, self.atmospheric_pressure, ('atmospheric_pressure',)))
+            topics.append(('/' + robot_name + '/air_pressure', FluidPressure, self.air_pressure, ('air_pressure',)))
         elif "TeamBase" in robot_description:
             rospy.loginfo("teambase")
         elif "robotika_freyja_sensor_config" in robot_description:
@@ -208,10 +208,10 @@ class main:
         rospy.loginfo_throttle(10, "score callback: {}".format(self.score_count))
         self.bus.publish("score", msg.data)
 
-    def atmospheric_pressure(self, msg):
-        self.atmospheric_pressure_count += 1
-        rospy.loginfo_throttle(10, "atmospheric_pressure callback: {}".format(self.atmospheric_pressure_count))
-        self.bus.publish('atmospheric_pressure', msg.fluid_pressure)
+    def air_pressure(self, msg):
+        self.air_pressure_count += 1
+        rospy.loginfo_throttle(10, "air_pressure callback: {}".format(self.air_pressure_count))
+        self.bus.publish('air_pressure', msg.fluid_pressure)
 
 
 if __name__ == '__main__':

--- a/subt/drone.py
+++ b/subt/drone.py
@@ -29,6 +29,8 @@ class Drone(Node):
 #        self.publisherTwist = rospy.Publisher("/cmd_vel_drone", Twist, queue_size=50)
 
         self.accum = 0.0
+        self.debug_arr = []
+        self.verbose = False
 
     def on_bottom_scan(self, scan):
             self.lastScanDown = scan[0]
@@ -39,6 +41,9 @@ class Drone(Node):
     def on_desired_speed(self, data):
         linear = [data[0]/1000, 0.0, 0.0]
         angular = [0.0, 0.0, math.radians(data[1]/100.0)]
+
+        if self.verbose:
+            self.debug_arr.append((self.time, self.lastScanDown, self.lastScanUp))
 
         if data != [0, 0]:
             self.started = True  # TODO this logic has to be also in "rosmsg.py" and/or "ros_proxy_node.cc"
@@ -64,5 +69,17 @@ class Drone(Node):
         handler = getattr(self, "on_" + channel, None)
         if handler is not None:
             handler(getattr(self, channel))
+
+    def draw(self):
+        import matplotlib.pyplot as plt
+
+        t = [a[0].total_seconds() for a in self.debug_arr]
+        height = [(-a[1], a[2]) for a in self.debug_arr]
+        line = plt.plot(t, height, '-o', linewidth=2)
+
+        plt.xlabel('time (s)')
+        plt.axes().set_aspect('equal', 'datalim')
+        plt.legend()
+        plt.show()
 
 # vim: expandtab sw=4 ts=4

--- a/subt/drone.py
+++ b/subt/drone.py
@@ -50,47 +50,50 @@ class Drone(Node):
         self.lastScanUp = 0.0
         self.started = False
 
-#        self.subscriberTwist = rospy.Subscriber("/cmd_vel", Twist, self.twistCallback, queue_size=15)
-#        self.subscriberScanDown = rospy.Subscriber("/scan_down", LaserScan, self.scanDownCallback, queue_size=15)
-#        self.subscriberScanDown = rospy.Subscriber("/scan_up", LaserScan, self.scanUpCallback, queue_size=15)
-#        self.publisherTwist = rospy.Publisher("/cmd_vel_drone", Twist, queue_size=50)
-
         self.accum = 0.0
         self.debug_arr = []
         self.verbose = False
         self.z = None  # last Z coordinate
         self.altitude = None  # based on air_pressure
 
-    def on_bottom_scan(self, scan):
-            self.lastScanDown = scan[0]
+        # keep last command for independent update of XY and Z
+        self.linear = [0.0, 0.0, 0.0]
+        self.angular = [0.0, 0.0, 0.0]
 
-    def on_top_scan(self, scan):
-        self.lastScanUp = scan[0]
-
-    def on_desired_speed(self, data):
-        linear = [data[0]/1000, 0.0, 0.0]
-        angular = [0.0, 0.0, math.radians(data[1]/100.0)]
-
-        if self.verbose:
-            self.debug_arr.append((self.time, self.altitude, self.lastScanDown, self.lastScanUp, self.z))
-
-        if data != [0, 0]:
-            self.started = True  # TODO this logic has to be also in "rosmsg.py" and/or "ros_proxy_node.cc"
-
+    def send_speed_cmd(self):
         if self.started:
             height = min(HEIGHT, (self.lastScanDown + self.lastScanUp) / 2)
             diff = height - self.lastScanDown
             self.accum += diff
             desiredVel = max(-MAX_VERTICAL, min(MAX_VERTICAL, PID_P * diff + PID_I * self.accum))
-            linear[2] = desiredVel
+            self.linear[2] = desiredVel
 
             #this is because drone can't handle too aggressive rotation
-            if angular[2] > MAX_ANGULAR:
-                angular[2] = MAX_ANGULAR
-            elif angular[2] < -MAX_ANGULAR:
-                angular[2] = -MAX_ANGULAR
+            if self.angular[2] > MAX_ANGULAR:
+                self.angular[2] = MAX_ANGULAR
+            elif self.angular[2] < -MAX_ANGULAR:
+                self.angular[2] = -MAX_ANGULAR
 
-            self.publish('desired_speed_3d', [linear, angular])
+            self.publish('desired_speed_3d', [self.linear, self.angular])
+
+    def on_bottom_scan(self, scan):
+        self.lastScanDown = scan[0]
+        self.send_speed_cmd()
+
+    def on_top_scan(self, scan):
+        self.lastScanUp = scan[0]
+
+    def on_desired_speed(self, data):
+        self.linear = [data[0]/1000, 0.0, 0.0]
+        self.angular = [0.0, 0.0, math.radians(data[1]/100.0)]
+
+        if self.verbose:
+            self.debug_arr.append((self.time, self.altitude, self.lastScanDown, self.lastScanUp, self.z))
+
+        if data != [0, 0]:
+            self.started = True
+
+        self.send_speed_cmd()
 
     def on_pose3d(self, data):
         xyz, quat = data

--- a/subt/drone.py
+++ b/subt/drone.py
@@ -1,20 +1,62 @@
 """
   OSGAR Drone for control of flight height
 """
+# copy of drone_height.py
 import math
 
 from osgar.node import Node
 
+HEIGHT = 2.0
+MAX_ANGULAR = 0.7
+MAX_VERTICAL = 0.7
+PID_P = 1.0  # 0.5
+PID_I = 0.0  # 0.5
+
 
 class Drone(Node):
+    #class that listens all topics needed for controlling drone height
     def __init__(self, config, bus):
         super().__init__(config, bus)
         bus.register("desired_speed_3d")
 
+        self.lastScanDown = 0.0
+        self.lastScanUp = 0.0
+        self.started = False
+
+#        self.subscriberTwist = rospy.Subscriber("/cmd_vel", Twist, self.twistCallback, queue_size=15)
+#        self.subscriberScanDown = rospy.Subscriber("/scan_down", LaserScan, self.scanDownCallback, queue_size=15)
+#        self.subscriberScanDown = rospy.Subscriber("/scan_up", LaserScan, self.scanUpCallback, queue_size=15)
+#        self.publisherTwist = rospy.Publisher("/cmd_vel_drone", Twist, queue_size=50)
+
+        self.accum = 0.0
+
+    def on_bottom_scan(self, scan):
+            self.lastScanDown = scan[0]
+
+    def on_top_scan(self, scan):
+        self.lastScanUp = scan[0]
+
     def on_desired_speed(self, data):
         linear = [data[0]/1000, 0.0, 0.0]
         angular = [0.0, 0.0, math.radians(data[1]/100.0)]
-        self.publish('desired_speed_3d', [linear, angular])
+
+        if data != [0, 0]:
+            self.started = True  # TODO this logic has to be also in "rosmsg.py" and/or "ros_proxy_node.cc"
+
+        if self.started:
+            height = min(HEIGHT, (self.lastScanDown + self.lastScanUp) / 2)
+            diff = height - self.lastScanDown
+            self.accum += diff
+            desiredVel = max(-MAX_VERTICAL, min(MAX_VERTICAL, PID_P * diff + PID_I * self.accum))
+            linear[2] = desiredVel
+
+            #this is because drone can't handle too aggressive rotation
+            if angular[2] > MAX_ANGULAR:
+                angular[2] = MAX_ANGULAR
+            elif angular[2] < -MAX_ANGULAR:
+                angular[2] = -MAX_ANGULAR
+
+            self.publish('desired_speed_3d', [linear, angular])
 
     def update(self):
         channel = super().update()

--- a/subt/drone.py
+++ b/subt/drone.py
@@ -72,7 +72,7 @@ class Drone(Node):
         angular = [0.0, 0.0, math.radians(data[1]/100.0)]
 
         if self.verbose:
-            self.debug_arr.append((self.time, self.z, self.lastScanDown, self.lastScanUp, self.altitude))
+            self.debug_arr.append((self.time, self.altitude, self.lastScanDown, self.lastScanUp, self.z))
 
         if data != [0, 0]:
             self.started = True  # TODO this logic has to be also in "rosmsg.py" and/or "ros_proxy_node.cc"
@@ -112,7 +112,7 @@ class Drone(Node):
         t = [a[0].total_seconds() for a in self.debug_arr]
         height = [(a[1], a[1] - a[2], a[1] + a[3], a[4]) for a in self.debug_arr]
         line_obj = plt.plot(t, height, '-o', linewidth=2)
-        plt.legend(iter(line_obj), ('Z', 'Z - bottom', 'Z + top', 'altitude'))
+        plt.legend(iter(line_obj), ('altitude', 'alt - bottom', 'alt + top', 'pose3D.z'))
         plt.xlabel('time (s)')
         plt.legend()
         plt.show()

--- a/subt/drone.py
+++ b/subt/drone.py
@@ -111,8 +111,8 @@ class Drone(Node):
 
         t = [a[0].total_seconds() for a in self.debug_arr]
         height = [(a[1], a[1] - a[2], a[1] + a[3], a[4]) for a in self.debug_arr]
-        plt.plot(t, height, '-o', linewidth=2)
-
+        line_obj = plt.plot(t, height, '-o', linewidth=2)
+        plt.legend(iter(line_obj), ('Z', 'Z - bottom', 'Z + top', 'altitude'))
         plt.xlabel('time (s)')
         plt.legend()
         plt.show()

--- a/subt/ros/robot/launch/x4.launch
+++ b/subt/ros/robot/launch/x4.launch
@@ -2,16 +2,7 @@
 <launch>
   <node name="$(arg robot_name)_proxy" pkg="proxy" type="ros_proxy" args="$(arg robot_name)">
     <remap from="$(arg robot_name)/front_rgbd/image_raw/compressed" to="$(arg robot_name)/front/image_raw/compressed"/>
-    <remap from="$(arg robot_name)/cmd_vel" to="$(arg robot_name)/cmd_vel_osgar" />
     <remap from="$(arg robot_name)/odom" to="$(arg robot_name)/nonexistent_input_odom"/>
-  </node>
-
-
-  <node name="drone_height" pkg="robot" type="drone_height.py">
-    <remap from="scan_down" to="$(arg robot_name)/bottom_scan" />
-    <remap from="scan_up" to="$(arg robot_name)/top_scan" />
-    <remap from="cmd_vel_drone" to="$(arg robot_name)/cmd_vel" />
-    <remap from="cmd_vel" to="$(arg robot_name)/cmd_vel_osgar"/>
   </node>
 
   <!-- ICP Odometry based on planar lidar -->

--- a/subt/test_drone.py
+++ b/subt/test_drone.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import MagicMock, patch, call
 
 from osgar.bus import Bus
-from subt.drone import Drone, MAX_ANGULAR
+from subt.drone import Drone, MAX_ANGULAR, altitude_from_pressure
 
 
 class DroneTest(unittest.TestCase):
@@ -23,5 +23,8 @@ class DroneTest(unittest.TestCase):
         c.request_stop()
         c.join()
         self.assertEqual(tester.listen()[2], [[1.0, 0.0, 0.0], [0.0, 0.0, MAX_ANGULAR]])
+
+    def test_altitude_from_pressure(self):
+        self.assertEqual(altitude_from_pressure(101323.49836826918), 0.12500215269779752)
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_drone.py
+++ b/subt/test_drone.py
@@ -4,7 +4,7 @@ import unittest
 from unittest.mock import MagicMock, patch, call
 
 from osgar.bus import Bus
-from subt.drone import Drone
+from subt.drone import Drone, MAX_ANGULAR
 
 
 class DroneTest(unittest.TestCase):
@@ -22,6 +22,6 @@ class DroneTest(unittest.TestCase):
         tester.publish('desired_speed', [1000, 9000])
         c.request_stop()
         c.join()
-        self.assertEqual(tester.listen()[2], [[1.0, 0.0, 0.0], [0.0, 0.0, math.pi/2]])
+        self.assertEqual(tester.listen()[2], [[1.0, 0.0, 0.0], [0.0, 0.0, MAX_ANGULAR]])
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_drone.py
+++ b/subt/test_drone.py
@@ -27,4 +27,16 @@ class DroneTest(unittest.TestCase):
     def test_altitude_from_pressure(self):
         self.assertEqual(altitude_from_pressure(101323.49836826918), 0.12500215269779752)
 
+    def test_regular_update(self):
+        bus = MagicMock()
+        drone = Drone(bus=bus, config={})
+        drone.on_desired_speed([1000, 0])  # fly forward for ever
+        bus.publish.assert_called_with('desired_speed_3d', [[1.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+
+        bus.reset_mock()
+        drone.on_top_scan([10.1])  # order is unfortunately not defined -> extra trigger is on bottom scan
+        drone.on_bottom_scan([0.1])
+        bus.publish.assert_called_with('desired_speed_3d', [[1.0, 0.0, 0.7], [0.0, 0.0, 0.0]])
+
+
 # vim: expandtab sw=4 ts=4

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -154,6 +154,7 @@
 
               ["fromrospy.bottom_scan", "drone.bottom_scan"],
               ["fromrospy.top_scan", "drone.top_scan"],
+              ["offseter.pose3d", "drone.pose3d"],
 
               ["rosmsg.origin", "offseter.origin"],
               ["fromrospy.pose3d", "offseter.pose3d"]

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -152,6 +152,9 @@
               ["rosmsg.base_station", "reporter.base_station"],
               ["reporter.artf_cmd", "transmitter.raw"],
 
+              ["fromrospy.bottom_scan", "drone.bottom_scan"],
+              ["fromrospy.top_scan", "drone.top_scan"],
+
               ["rosmsg.origin", "offseter.origin"],
               ["fromrospy.pose3d", "offseter.pose3d"]
     ]

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -97,7 +97,7 @@
           "driver": "subt.pull:Pull",
 	      "init": {
 	        "outputs": ["rot", "acc", "orientation", "top_scan", "bottom_scan", "pose3d", "battery_state", "score",
-                        "atmospheric_pressure"]
+                        "air_pressure"]
 	      }
       },
       "radio": {
@@ -156,7 +156,7 @@
               ["fromrospy.bottom_scan", "drone.bottom_scan"],
               ["fromrospy.top_scan", "drone.top_scan"],
               ["offseter.pose3d", "drone.pose3d"],
-              ["fromrospy.atmospheric_pressure", "drone.atmospheric_pressure"],
+              ["fromrospy.air_pressure", "drone.air_pressure"],
 
               ["rosmsg.origin", "offseter.origin"],
               ["fromrospy.pose3d", "offseter.pose3d"]

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -96,7 +96,8 @@
       "fromrospy": {
           "driver": "subt.pull:Pull",
 	      "init": {
-	        "outputs": ["rot", "acc", "orientation", "top_scan", "bottom_scan", "pose3d", "battery_state", "score"]
+	        "outputs": ["rot", "acc", "orientation", "top_scan", "bottom_scan", "pose3d", "battery_state", "score",
+                        "atmospheric_pressure"]
 	      }
       },
       "radio": {
@@ -155,6 +156,7 @@
               ["fromrospy.bottom_scan", "drone.bottom_scan"],
               ["fromrospy.top_scan", "drone.top_scan"],
               ["offseter.pose3d", "drone.pose3d"],
+              ["fromrospy.atmospheric_pressure", "drone.atmospheric_pressure"],
 
               ["rosmsg.origin", "offseter.origin"],
               ["fromrospy.pose3d", "offseter.pose3d"]


### PR DESCRIPTION
This is copy & paste from ROS module to OSGAR to fly with X4 and height control with top/bottom lidars.

The test images have prefix `ver82fly` (first test `81a94f48-cf57-4355-ae1a-a8f0108df04e`)

Known issue is that `rosmsg.py` automatically publishes commands independently of received data - this is problem for drone because we do not want to send any until wait time elapsed.

In the "merge chain" we may need feature variable height control - @jisa do you have an example where drone is trapped in the hole and never returns because of steep walls? (until that the functionality is equal (or worse due to start) to ROS node).

Issues/TODO:

- [x] Do not publish command before first non-zero move

- [x] Send regular updates even when input is not regular