### PR TITLE
launch/x4.launch - use velocities instead of relative position change

### DIFF
--- a/subt/ros/robot/launch/freyja.launch
+++ b/subt/ros/robot/launch/freyja.launch
@@ -153,7 +153,7 @@
     <!-- The order of the values is x, y, z, roll, pitch, yaw, vx, vy, vz, vroll, vpitch, vyaw, ax, ay, az. -->
     <!-- We barely trust the ICP odometry on 2d scan with X and Y coordinates. Totally not anything more 3d. -->
     <rosparam param="odom0_config">[false, false, false,
-                                    false, false, true,
+                                    false, false, false,
                                     true, false, false,
                                     false, false, false,
                                     false, false, false]</rosparam>
@@ -190,9 +190,6 @@
 
     <!-- The unit of the threshold is a Mahalanobis distance (i.e. sum) of numbers of sigmas in each dimension -->
     <rosparam param="odom0_twist_rejection_threshold">4</rosparam>
-    <rosparam param="odom2_twist_rejection_threshold">4</rosparam>
-    <rosparam param="odom3_twist_rejection_threshold">4</rosparam>
-    <rosparam param="odom4_twist_rejection_threshold">4</rosparam>
 
     <!-- When some data arrive late, we are willing to go back in time and correct the estimate. -->
     <param name="smooth_lagged_data" value="true"/>

--- a/subt/ros/robot/launch/freyja.launch
+++ b/subt/ros/robot/launch/freyja.launch
@@ -132,11 +132,11 @@
     <!-- IMU -->
     <param name="imu0" value="$(arg robot_name)/imu/data"/>
 
-    <param name="odom0_differential" value="true"/>
-    <param name="odom1_differential" value="true"/>
-    <param name="odom2_differential" value="true"/>
-    <param name="odom3_differential" value="true"/>
-    <param name="odom4_differential" value="true"/>
+    <param name="odom0_differential" value="false"/>
+    <param name="odom1_differential" value="false"/>
+    <param name="odom2_differential" value="false"/>
+    <param name="odom3_differential" value="false"/>
+    <param name="odom4_differential" value="false"/>
     <param name="pose0_differential" value="false"/>
     <param name="imu0_differential" value="false"/>
 
@@ -145,35 +145,36 @@
     <param name="odom2_relative" value="false"/>
     <param name="odom3_relative" value="false"/>
     <param name="odom4_relative" value="false"/>
+    <param name="pose0_relative" value="true"/>
     <param name="imu0_relative" value="false"/>
 
     <param name="imu0_remove_gravitational_acceleration" value="true"/>
 
     <!-- The order of the values is x, y, z, roll, pitch, yaw, vx, vy, vz, vroll, vpitch, vyaw, ax, ay, az. -->
     <!-- We barely trust the ICP odometry on 2d scan with X and Y coordinates. Totally not anything more 3d. -->
-    <rosparam param="odom0_config">[true, true, false,
+    <rosparam param="odom0_config">[false, false, false,
                                     false, false, false,
-                                    false, false, false,
-                                    false, false, false,
-                                    false, false, false]</rosparam>
-    <rosparam param="odom1_config">[true, true, false,
-                                    false, false, false,
-                                    false, false, false,
+                                    true, true, true,
                                     false, false, false,
                                     false, false, false]</rosparam>
-    <rosparam param="odom2_config">[true, true, false,
+    <rosparam param="odom1_config">[false, false, false,
                                     false, false, false,
-                                    false, false, false,
-                                    false, false, false,
-                                    false, false, false]</rosparam>
-    <rosparam param="odom3_config">[true, true, false,
-                                    false, false, false,
-                                    false, false, false,
+                                    true, true, false,
                                     false, false, false,
                                     false, false, false]</rosparam>
-    <rosparam param="odom4_config">[true, true, true,
+    <rosparam param="odom2_config">[false, false, false,
                                     false, false, false,
+                                    true, true, false,
                                     false, false, false,
+                                    false, false, false]</rosparam>
+    <rosparam param="odom3_config">[false, false, false,
+                                    false, false, false,
+                                    true, true, true,
+                                    false, false, false,
+                                    false, false, false]</rosparam>
+    <rosparam param="odom4_config">[false, false, false,
+                                    false, false, false,
+                                    true, true, true,
                                     false, false, false,
                                     false, false, false]</rosparam>
     <rosparam param="pose0_config">[false, false, true,
@@ -187,11 +188,20 @@
                                    true,  true,  true,
                                    true,  true,  true] </rosparam>
 
+    <!-- The unit of the threshold is a Mahalanobis distance (i.e. sum) of numbers of sigmas in each dimension -->
+    <rosparam param="odom0_twist_rejection_threshold">4</rosparam>
+    <rosparam param="odom2_twist_rejection_threshold">4</rosparam>
+    <rosparam param="odom3_twist_rejection_threshold">4</rosparam>
+    <rosparam param="odom4_twist_rejection_threshold">4</rosparam>
+
     <!-- When some data arrive late, we are willing to go back in time and correct the estimate. -->
     <param name="smooth_lagged_data" value="true"/>
     <param name="history_length" value="1.0"/>
 
-    <!-- <param name="print_diagnostics" value="true"/> -->
+    <!-- -->
+    <param name="print_diagnostics" value="true"/>
+    <remap from="/diagnostics" to="$(arg robot_name)/odom_diagnostics"/>
+    <!-- -->
 
     <remap from="odometry/filtered" to="/$(arg robot_name)/odom_fused"/>
   </node>

--- a/subt/ros/robot/launch/freyja.launch
+++ b/subt/ros/robot/launch/freyja.launch
@@ -153,8 +153,8 @@
     <!-- The order of the values is x, y, z, roll, pitch, yaw, vx, vy, vz, vroll, vpitch, vyaw, ax, ay, az. -->
     <!-- We barely trust the ICP odometry on 2d scan with X and Y coordinates. Totally not anything more 3d. -->
     <rosparam param="odom0_config">[false, false, false,
-                                    false, false, false,
-                                    true, true, true,
+                                    false, false, true,
+                                    true, false, false,
                                     false, false, false,
                                     false, false, false]</rosparam>
     <rosparam param="odom1_config">[false, false, false,

--- a/subt/ros/robot/launch/x4.launch
+++ b/subt/ros/robot/launch/x4.launch
@@ -87,8 +87,8 @@
     <!-- IMU -->
     <param name="imu0" value="$(arg robot_name)/imu/data"/>
 
-    <param name="odom0_differential" value="true"/>
-    <param name="odom1_differential" value="true"/>
+    <param name="odom0_differential" value="false"/>
+    <param name="odom1_differential" value="false"/>
     <param name="pose0_differential" value="false"/>
     <param name="imu0_differential" value="false"/>
 
@@ -101,14 +101,14 @@
 
     <!-- The order of the values is x, y, z, roll, pitch, yaw, vx, vy, vz, vroll, vpitch, vyaw, ax, ay, az. -->
     <!-- We barely trust the ICP odometry on 2d scan with X and Y coordinates. Totally not anything more 3d. -->
-    <rosparam param="odom0_config">[true, true, false,
+    <rosparam param="odom0_config">[false, false, false,
                                     false, false, false,
-                                    false, false, false,
+                                    true, true, false,
                                     false, false, false,
                                     false, false, false]</rosparam>
-    <rosparam param="odom1_config">[true, true, true,
+    <rosparam param="odom1_config">[false, false, false,
                                     false, false, false,
-                                    false, false, false,
+                                    true, true, true,
                                     false, false, false,
                                     false, false, false]</rosparam>
     <rosparam param="pose0_config">[false, false, true,
@@ -126,7 +126,10 @@
     <param name="smooth_lagged_data" value="true"/>
     <param name="history_length" value="1.0"/>
 
-    <!-- <param name="print_diagnostics" value="true"/> -->
+    <!--
+    <param name="print_diagnostics" value="true"/>
+    <remap from="/diagnostics" to="$(arg robot_name)/odom_diagnostics"/>
+    -->
 
     <remap from="odometry/filtered" to="/$(arg robot_name)/odom_fused"/>
   </node>


### PR DESCRIPTION
This Kalman change to X4 looks much better than attempt in tested before in https://github.com/robotika/osgar/pull/680
(see run `ver82quat1`, `e0b1ce5a-d6f3-4d57-af26-6d5d6eae3184`)