### PR TITLE
Rework startup to increase robustness.

### DIFF
--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -2,7 +2,6 @@
 
 from __future__ import print_function
 
-import errno
 import math
 import socket
 import sys
@@ -29,35 +28,6 @@ def py3round(f):
         return int(2.0 * round(f / 2.0))
     return int(round(f))
 
-
-def has_breadcrumbs(robot_name):
-    # possibly fragile detection if robot has bredcrumbs
-    rospy.sleep(1)
-    _publishers, subscribers = rostopic.get_topic_list()
-    for name, type, _ in subscribers:
-        if name == "/{}/breadcrumb/deploy".format(robot_name):
-            return True
-    return False
-
-def wait_for_master():
-    """Return when /use_sim_time is set in rosparams. If rospy.init_node is called before /use_sim_time
-    is set, it uses real time."""
-    print("Waiting for rosmaster")
-    start = time.time()
-    last_params = []
-    while not rospy.is_shutdown():
-        try:
-            params = rospy.get_param_names()
-            if params != last_params:
-                print(time.time()-start, params)
-                if '/use_sim_time' in params:
-                    return True
-                last_params = params
-            time.sleep(0.01)
-        except socket.error as serr:
-            if serr.errno != errno.ECONNREFUSED:
-                raise serr  # re-raise error if its not the one we want
-            time.sleep(0.5)
 
 class Bus:
     def __init__(self):
@@ -94,9 +64,7 @@ class Bus:
 
 
 class main:
-    def __init__(self, robot_name):
-        # get cloudsim ready
-        wait_for_master()
+    def __init__(self, robot_name, robot_config):
         rospy.init_node('cloudsim2osgar', log_level=rospy.DEBUG)
         self.bus = Bus()
 
@@ -110,18 +78,18 @@ class main:
 
         # configuration specific topics
         robot_description = rospy.get_param("/{}/robot_description".format(robot_name))
-        if "robotika_x2_sensor_config_1" in robot_description:
+        if robot_config == "ROBOTIKA_X2_SENSOR_CONFIG_1":
             rospy.loginfo("robotika x2")
-        elif "ssci_x4_sensor_config_2" in robot_description:
+        elif robot_config == "SSCI_X4_SENSOR_CONFIG_2":
             rospy.loginfo("ssci drone")
             topics.append(('/' + robot_name + '/top_scan', LaserScan, self.top_scan, ('top_scan',)))
             topics.append(('/' + robot_name + '/bottom_scan', LaserScan, self.bottom_scan, ('bottom_scan',)))
             topics.append(('/' + robot_name + '/odom_fused', Odometry, self.odom_fused, ('pose3d',)))
             topics.append(('/' + robot_name + '/air_pressure', FluidPressure, self.air_pressure, ('air_pressure',)))
-        elif "TeamBase" in robot_description:
+        elif robot_config == "TEAMBASE":
             rospy.loginfo("teambase")
-        elif "robotika_freyja_sensor_config" in robot_description:
-            if has_breadcrumbs(robot_name):
+        elif robot_config.startswith("ROBOTIKA_FREYJA_SENSOR_CONFIG"):
+            if robot_config.endswith("_2"):
                 rospy.loginfo("freya 2 (with comms beacons)")
                 publishers['deploy'] = rospy.Publisher('/' + robot_name + '/breadcrumb/deploy', Empty, queue_size=1)
             else:
@@ -133,14 +101,14 @@ class main:
             topics.append(('/' + robot_name + '/scan_rear', LaserScan, self.scan_rear, ('scan_rear',)))
             topics.append(('/' + robot_name + '/rgbd_front/depth', Image, self.depth_front, ('depth_front',)))
             topics.append(('/' + robot_name + '/rgbd_rear/depth', Image, self.depth_rear, ('depth_rear',)))
-        elif "robotika_kloubak_sensor_config" in robot_description:
-            if has_breadcrumbs(robot_name):
+        elif robot_config.startswith("ROBOTIKA_KLOUBAK_SENSOR_CONFIG"):
+            if robot_config.endswith("_2"):
                 rospy.loginfo("k2 2 (with comms beacons)")
                 publishers['deploy'] = rospy.Publisher('/' + robot_name + '/breadcrumb/deploy', Empty, queue_size=1)
             else:
                 rospy.loginfo("k2 1 (basic)")
             topics.append(('/' + robot_name + '/odom_fused', Odometry, self.odom_fused, ('pose3d',)))
-        elif "explorer_r2_sensor_config" in robot_description:
+        elif robot_config.startswith("EXPLORER_R2_SENSOR_CONFIG"):
             rospy.loginfo("explorer R2")
             topics.append(('/' + robot_name + '/rs_front/color/image/compressed', CompressedImage, self.image_front, ('image_front',)))
             topics.append(('/' + robot_name + '/rs_front/depth/image', Image, self.depth_front, ('depth_front',)))
@@ -149,7 +117,7 @@ class main:
             rospy.logerr("unknown configuration")
             return
 
-        if "robotika_kloubak_sensor_config" in robot_description:
+        if robot_config.startswith("ROBOTIKA_KLOUBAK_SENSOR_CONFIG"):
             topics.append(('/' + robot_name + '/imu/front/data', Imu, self.imu, ('rot', 'acc', 'orientation')))
         else:
             topics.append(('/' + robot_name + '/imu/data', Imu, self.imu, ('rot', 'acc', 'orientation')))
@@ -297,11 +265,11 @@ class main:
 
 
 if __name__ == '__main__':
-    if len(sys.argv) < 2:
-        print("need robot name as argument", file=sys.stderr)
+    if len(sys.argv) < 3:
+        print("need robot name and config as arguments", file=sys.stderr)
         sys.exit(2)
     try:
-        main(sys.argv[1])
+        main(sys.argv[1], sys.argv[2])
     except rospy.exceptions.ROSInterruptException:
         rospy.loginfo("shutdown")
 

--- a/subt/docker/robotika/run_solution.bash
+++ b/subt/docker/robotika/run_solution.bash
@@ -10,75 +10,69 @@ trap "echo 'got signal... exiting'; exit;" HUP INT TERM
 # and wait for them to finish
 trap "echo 'exiting... killing children...';  kill -s SIGINT 0; wait" EXIT
 
-echo "Waiting for robot name"
-while [ -z "$ROBOT_NAME" ]; do
-    ROBOT_NAME=$(rosparam get /robot_names)
-    sleep 0.5
-done
+rosrun proxy wait.py
+
+ROBOT_NAME=$(rosparam get /robot_names)
 echo "Robot name is '$ROBOT_NAME'"
 
-echo "Waiting for robot description"
-while [ -z "$ROBOT_DESCRIPTION" ]; do
-    ROBOT_DESCRIPTION=$(rosparam get /$ROBOT_NAME/robot_description)
-    sleep 0.5
-done
-echo "Robot description is '$ROBOT_DESCRIPTION'"
-
-grep -q ssci_x4_sensor_config <<< $ROBOT_DESCRIPTION && IS_X4=true || IS_X4=false
-grep -q TeamBase <<< $ROBOT_DESCRIPTION && IS_TEAMBASE=true || IS_TEAMBASE=false
-grep -q robotika_freyja_sensor_config <<< $ROBOT_DESCRIPTION && IS_FREYJA=true || IS_FREYJA=false
-grep -q explorer_r2_sensor_config <<< $ROBOT_DESCRIPTION && IS_EXPLORER_R2=true || IS_EXPLORER_R2=false
-grep -q robotika_kloubak_sensor_config <<< $ROBOT_DESCRIPTION && IS_K2=true || IS_K2=false
+ROBOT_CONFIG=$(rosparam get /robot_config)
+echo "Robot config is '$ROBOT_CONFIG'"
 
 # Defaults
 WALLDIST=0.8
 SPEED=1.0
 
-if $IS_X4
-then
-    echo "Robot is X4 drone"    
+case $ROBOT_CONFIG in
+  "SSCI_X4_SENSOR_CONFIG_2"):
+    echo "Robot is X4 drone"
     LAUNCH_FILE="robot x4.launch"
     CONFIG_FILES=("zmq-subt-x4.json")
     SPEED=1.5
     WALLDIST=1.2
-elif $IS_TEAMBASE
-then
+    ;;
+  "TEAMBASE"):
     echo "Robot is TEAMBASE"
     LAUNCH_FILE="proxy teambase.launch"
     CONFIG_FILES=("zmq-subt-teambase.json")
-elif $IS_FREYJA
-then
+    ;;
+  "ROBOTIKA_FREYJA_SENSOR_CONFIG"*):
     echo "Robot is Freyja"
     LAUNCH_FILE="robot freyja.launch"
     CONFIG_FILES=("zmq-subt-x2.json" "subt-freyja.json")
     WALLDIST=1.0
     SPEED=1.5
-elif $IS_EXPLORER_R2
-then
+    ;;
+  "EXPLORER_R2_SENSOR_CONFIG"*):
     echo "Robot is Explorer R2"
     LAUNCH_FILE="robot r2.launch"
     CONFIG_FILES=("config/r2.json")
     WALLDIST=1.5
     SPEED=1.5
-elif $IS_K2
-then
+    ;;
+  "ROBOTIKA_KLOUBAK_SENSOR_CONFIG"*):
     echo "Robot is K2"
     LAUNCH_FILE="robot k2-virt.launch"
     CONFIG_FILES=("zmq-subt-x2.json" "subt-k2-virt.json")
     WALLDIST=1.0
     SPEED=1.5
-else
+    ;;
+  "ROBOTIKA_X2_SENSOR_CONFIG_1"):
     echo "Robot is default X2 wheeled robot"
     LAUNCH_FILE="proxy sim.launch"
     CONFIG_FILES=("zmq-subt-x2.json")
-fi
+    ;;
+  *):
+    echo "unknown robot config";
+    exit 1
+    ;;
+esac
 
 echo "Starting ros<->osgar proxy"
 # Wait for ROS master, then start ros nodes
 # http://wiki.ros.org/roslaunch/Commandline%20Tools#line-45 
 roslaunch $LAUNCH_FILE --wait robot_name:=$ROBOT_NAME &
 
-/osgar-ws/src/osgar/subt/cloudsim2osgar.py $ROBOT_NAME &
+/osgar-ws/src/osgar/subt/cloudsim2osgar.py $ROBOT_NAME $ROBOT_CONFIG &
 
 if [ -f "$1" ];
 then
@@ -96,8 +90,8 @@ PYTHON=/osgar-ws/env/bin/python3
 
 rosrun proxy sendlog.py $LOG_FILE &
 
-echo "Starting osgar"
-if $IS_TEAMBASE
+echo "Starting osgar" ${CONFIG_FILE_PATHS[@]}
+if [ $ROBOT_CONFIG == "TEAMBASE" ]
 then
     $PYTHON -m subt.teambase ${CONFIG_FILE_PATHS[@]} --robot-name $ROBOT_NAME --log $LOG_FILE --note "run teambase" &
 else

--- a/subt/ros/proxy/wait.py
+++ b/subt/ros/proxy/wait.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python2
+
+import errno
+import time
+import socket
+
+import rospy
+import rostopic
+
+
+def wait_for_master():
+    """Return when /use_sim_time is set in rosparams. If rospy.init_node is called before /use_sim_time
+    is set, it uses real time."""
+    print("waiting for rosmaster...")
+    last_params = []
+    while not rospy.is_shutdown():
+        try:
+            params = rospy.get_param_names()
+            if params != last_params:
+                if '/use_sim_time' in params:
+                    print("rosmaster ready")
+                    return True
+                last_params = params
+            time.sleep(0.1)
+        except socket.error as serr:
+            if serr.errno != errno.ECONNREFUSED:
+                raise serr  # re-raise error if its not the one we want
+            time.sleep(0.5)
+
+
+def wait_for_bridge(robot_name):
+    prefix = "/{}/".format(robot_name)
+    last_sub = set([])
+    last_pub = set([])
+    same_num = 0
+    while True:
+        publishers, subscribers = rostopic.get_topic_list()
+        names_sub = set([a[0] for a in subscribers if a[0].startswith(prefix)])
+        names_pub = set([a[0] for a in publishers if a[0].startswith(prefix)])
+        status = "{} subscribers, {} publishers".format(len(names_sub), len(names_pub))
+        if names_sub == last_sub and names_pub == last_pub:
+            if same_num >= 3:
+                rospy.loginfo("bridge ready: " + status)
+                break
+            else:
+                same_num += 1
+        else:
+            same_num = 0
+        rospy.loginfo("waiting for bridge "+prefix+"... " + status)
+        rospy.sleep(1)
+        last_sub = names_sub
+        last_pub = names_pub
+
+
+def has_breadcrumbs(robot_name):
+    prefix = "/{}/".format(robot_name)
+    breadcrumbs = prefix + "breadcrumb/deploy"
+    publishers, subscribers = rostopic.get_topic_list()
+    for name, _, _ in subscribers:
+        if name == breadcrumbs:
+            return True
+    return False
+
+
+def detect_config(robot_name):
+    robot_description = rospy.get_param("/{}/robot_description".format(robot_name))
+    if "robotika_x2_sensor_config_1" in robot_description:
+        return "ROBOTIKA_X2_SENSOR_CONFIG_1"
+    elif "ssci_x4_sensor_config_2" in robot_description:
+        return "SSCI_X4_SENSOR_CONFIG_2"
+    elif "TeamBase" in robot_description:
+        return "TEAMBASE"
+    elif "robotika_freyja_sensor_config" in robot_description:
+        if has_breadcrumbs(robot_name):
+            return "ROBOTIKA_FREYJA_SENSOR_CONFIG_2"
+        return "ROBOTIKA_FREYJA_SENSOR_CONFIG_1"
+    elif "robotika_kloubak_sensor_config" in robot_description:
+        if has_breadcrumbs(robot_name):
+            return "ROBOTIKA_KLOUBAK_SENSOR_CONFIG_2"
+        return "ROBOTIKA_KLOUBAK_SENSOR_CONFIG_1"
+    elif "explorer_r2_sensor_config" in robot_description:
+        if has_breadcrumbs(robot_name):
+            return "EXPLORER_R2_SENSOR_CONFIG_2"
+        return "EXPLORER_R2_SENSOR_CONFIG_1"
+    else:
+        rospy.logerr("unknown configuration")
+        return
+
+
+def main():
+    wait_for_master()
+    rospy.init_node('wait', log_level=rospy.DEBUG)
+    robot_name = rospy.get_param("/robot_names")
+    wait_for_bridge(robot_name)
+    robot_config = detect_config(robot_name)
+    rospy.set_param("/robot_config", robot_config)
+
+
+if __name__ == '__main__':
+    main()

--- a/subt/tools/run.py
+++ b/subt/tools/run.py
@@ -60,6 +60,9 @@ ROBOTS=dict(
     teambase = "TEAMBASE",
     drone = "SSCI_X4_SENSOR_CONFIG_2",
     freyja = "ROBOTIKA_FREYJA_SENSOR_CONFIG_2",
+    k2 = "ROBOTIKA_KLOUBAK_SENSOR_CONFIG_2",
+    r2 = "EXPLORER_R2_SENSOR_CONFIG_2",
+    x2 = "ROBOTIKA_X2_SENSOR_CONFIG_1",
 )
 
 XAUTH = pathlib.Path("/tmp/.docker.xauth")
@@ -208,7 +211,7 @@ def _prune_containers(client, robots):
                 sys.exit(str(e))
 
 
-def main(argv):
+def main(argv=None):
     parser = argparse.ArgumentParser(description='Submit cloudsim run')
     parser.add_argument("config", nargs="?", default=str(pathlib.Path('./run.toml')))
     parser.add_argument("-n", action="store_true", help="dry run")


### PR DESCRIPTION
Changes:
 - As we had a special routine to wait for master, we now have a similar one for waiting for bridge.
 - The bridge creates subscribers and publishers as it makes connections with the simulation so this transitively waits for the simulation to start up. There is also less stress on the computer during startup since there is less parallelization.
 - It also improves the detection of breadcrumb abilities. 
 - The robot config detection is now in one place only - `wait.py`. I imagine that once cloudsim adds robot config to rosparam, we can further simplify.

Tested with freyja 2 only so far.