### PR TITLE
list artifacts sorted by name (subt.tools.ignstate)

### DIFF
--- a/subt/tools/ignstate.py
+++ b/subt/tools/ignstate.py
@@ -237,7 +237,7 @@ def main():
     artifacts = read_artifacts(args.filename)
 
     if args.artifacts:
-        for kind, p in artifacts:
+        for kind, p in sorted(artifacts):
             formatted = ", ".join(f"{aa:.2f}".rstrip('0').rstrip('.') for aa in p)
             print(f"{kind:<15}", f"[{formatted}]")
         return


### PR DESCRIPTION
Motivation: better overview of how many artifacts of each type is present

Urban worlds have different number of each type and in unsorted list it was really hard to make sure I did not overlook some.
p.s. yes, this PR is way to trivial, sorry for that ...