### PR TITLE
provide first sketch for marsupial robots (R2)

### DIFF
--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -113,6 +113,7 @@ class main:
             topics.append(('/' + robot_name + '/rs_front/color/image/compressed', CompressedImage, self.image_front, ('image_front',)))
             topics.append(('/' + robot_name + '/rs_front/depth/image', Image, self.depth_front, ('depth_front',)))
             topics.append(('/' + robot_name + '/points', PointCloud2, self.points, ('points',)))
+            publishers['detach'] = rospy.Publisher('/' + robot_name + '/detach', Empty, queue_size=1)
         else:
             rospy.logerr("unknown configuration")
             return

--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -64,7 +64,7 @@ class Bus:
 
 
 class main:
-    def __init__(self, robot_name, robot_config):
+    def __init__(self, robot_name, robot_config, robot_is_marsupial):
         rospy.init_node('cloudsim2osgar', log_level=rospy.DEBUG)
         self.bus = Bus()
 
@@ -86,7 +86,9 @@ class main:
             topics.append(('/' + robot_name + '/bottom_scan', LaserScan, self.bottom_scan, ('bottom_scan',)))
             topics.append(('/' + robot_name + '/odom_fused', Odometry, self.odom_fused, ('pose3d',)))
             topics.append(('/' + robot_name + '/air_pressure', FluidPressure, self.air_pressure, ('air_pressure',)))
-            publishers['detach'] = rospy.Publisher('/' + robot_name + '/detach', Empty, queue_size=1)
+            if robot_is_marsupial:
+                rospy.loginfo("X4 is marsupial")
+                publishers['detach'] = rospy.Publisher('/' + robot_name + '/detach', Empty, queue_size=1)
         elif robot_config == "TEAMBASE":
             rospy.loginfo("teambase")
         elif robot_config.startswith("ROBOTIKA_FREYJA_SENSOR_CONFIG"):
@@ -266,11 +268,11 @@ class main:
 
 
 if __name__ == '__main__':
-    if len(sys.argv) < 3:
-        print("need robot name and config as arguments", file=sys.stderr)
+    if len(sys.argv) < 4:
+        print("need robot name, config and is_marsupial as arguments", file=sys.stderr)
         sys.exit(2)
     try:
-        main(sys.argv[1], sys.argv[2])
+        main(sys.argv[1], sys.argv[2], sys.argv[3])
     except rospy.exceptions.ROSInterruptException:
         rospy.loginfo("shutdown")
 

--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -113,7 +113,7 @@ class main:
             topics.append(('/' + robot_name + '/rs_front/color/image/compressed', CompressedImage, self.image_front, ('image_front',)))
             topics.append(('/' + robot_name + '/rs_front/depth/image', Image, self.depth_front, ('depth_front',)))
             topics.append(('/' + robot_name + '/points', PointCloud2, self.points, ('points',)))
-            publishers['detach'] = rospy.Publisher('/' + robot_name + '/detach', Empty, queue_size=1)
+            publishers['detach'] = rospy.Publisher('/A100L/detach', Empty, queue_size=1)  # TODO proper child detection
         else:
             rospy.logerr("unknown configuration")
             return

--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -86,6 +86,7 @@ class main:
             topics.append(('/' + robot_name + '/bottom_scan', LaserScan, self.bottom_scan, ('bottom_scan',)))
             topics.append(('/' + robot_name + '/odom_fused', Odometry, self.odom_fused, ('pose3d',)))
             topics.append(('/' + robot_name + '/air_pressure', FluidPressure, self.air_pressure, ('air_pressure',)))
+            publishers['detach'] = rospy.Publisher('/' + robot_name + '/detach', Empty, queue_size=1)
         elif robot_config == "TEAMBASE":
             rospy.loginfo("teambase")
         elif robot_config.startswith("ROBOTIKA_FREYJA_SENSOR_CONFIG"):
@@ -113,7 +114,6 @@ class main:
             topics.append(('/' + robot_name + '/rs_front/color/image/compressed', CompressedImage, self.image_front, ('image_front',)))
             topics.append(('/' + robot_name + '/rs_front/depth/image', Image, self.depth_front, ('depth_front',)))
             topics.append(('/' + robot_name + '/points', PointCloud2, self.points, ('points',)))
-            publishers['detach'] = rospy.Publisher('/A100L/detach', Empty, queue_size=1)  # TODO proper child detection
         else:
             rospy.logerr("unknown configuration")
             return

--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -86,7 +86,7 @@ class main:
             topics.append(('/' + robot_name + '/bottom_scan', LaserScan, self.bottom_scan, ('bottom_scan',)))
             topics.append(('/' + robot_name + '/odom_fused', Odometry, self.odom_fused, ('pose3d',)))
             topics.append(('/' + robot_name + '/air_pressure', FluidPressure, self.air_pressure, ('air_pressure',)))
-            if robot_is_marsupial:
+            if robot_is_marsupial == 'true':
                 rospy.loginfo("X4 is marsupial")
                 publishers['detach'] = rospy.Publisher('/' + robot_name + '/detach', Empty, queue_size=1)
         elif robot_config == "TEAMBASE":

--- a/subt/config/r2.json
+++ b/subt/config/r2.json
@@ -121,7 +121,7 @@
           "in": ["sim_time_sec"],
           "out": ["detach"],
           "init": {
-            "release_at": 10
+            "release_at": 30
           }
       }
     },

--- a/subt/config/r2.json
+++ b/subt/config/r2.json
@@ -115,14 +115,6 @@
           "init": {
             "radius": 30
           }
-      },
-      "marsupial": {
-          "driver": "subt.marsupial:Marsupial",
-          "in": ["sim_time_sec"],
-          "out": ["detach"],
-          "init": {
-            "release_at": 30
-          }
       }
     },
     "links": [["app.desired_speed", "rosmsg.desired_speed"],
@@ -166,9 +158,6 @@
               ["breadcrumbs.deploy", "torospy.deploy"],
               ["breadcrumbs.location", "radio.breadcrumb"],
               ["radio.breadcrumb", "breadcrumbs.external"],
-
-              ["rosmsg.sim_time_sec", "marsupial.sim_time_sec"],
-              ["marsupial.detach", "torospy.detach"],
 
               ["detector.artf", "app.artf"],
               ["detector.stdout", "rosmsg.stdout"],

--- a/subt/config/r2.json
+++ b/subt/config/r2.json
@@ -115,6 +115,14 @@
           "init": {
             "radius": 30
           }
+      },
+      "marsupial": {
+          "driver": "subt.marsupial:Marsupial",
+          "in": ["sim_time_sec"],
+          "out": ["detach"],
+          "init": {
+            "release_at": 10
+          }
       }
     },
     "links": [["app.desired_speed", "rosmsg.desired_speed"],
@@ -158,6 +166,9 @@
               ["breadcrumbs.deploy", "torospy.deploy"],
               ["breadcrumbs.location", "radio.breadcrumb"],
               ["radio.breadcrumb", "breadcrumbs.external"],
+
+              ["rosmsg.sim_time_sec", "marsupial.sim_time_sec"],
+              ["marsupial.detach", "torospy.detach"],
 
               ["detector.artf", "app.artf"],
               ["detector.stdout", "rosmsg.stdout"],

--- a/subt/docker/robotika/run_solution.bash
+++ b/subt/docker/robotika/run_solution.bash
@@ -18,6 +18,9 @@ echo "Robot name is '$ROBOT_NAME'"
 ROBOT_CONFIG=$(rosparam get /robot_config)
 echo "Robot config is '$ROBOT_CONFIG'"
 
+ROBOT_IS_MARSUPIAL=$(rosparam get /robot_is_marsupial)
+echo "Robot is marsupial '$ROBOT_IS_MARSUPIAL'"
+
 # Defaults
 WALLDIST=0.8
 SPEED=1.0
@@ -72,7 +75,7 @@ echo "Starting ros<->osgar proxy"
 # http://wiki.ros.org/roslaunch/Commandline%20Tools#line-45 
 roslaunch $LAUNCH_FILE --wait robot_name:=$ROBOT_NAME &
 
-/osgar-ws/src/osgar/subt/cloudsim2osgar.py $ROBOT_NAME $ROBOT_CONFIG &
+/osgar-ws/src/osgar/subt/cloudsim2osgar.py $ROBOT_NAME $ROBOT_CONFIG $ROBOT_IS_MARSUPIAL &
 
 if [ -f "$1" ];
 then

--- a/subt/marsupial.py
+++ b/subt/marsupial.py
@@ -2,10 +2,7 @@
   Dual robots - typically a UGV taking care of UAV
   https://en.wikipedia.org/wiki/Marsupial
 """
-from ast import literal_eval
-
 from osgar.node import Node
-from subt.trace import distance3D
 from subt.name_decoder import parse_robot_name
 
 

--- a/subt/marsupial.py
+++ b/subt/marsupial.py
@@ -1,0 +1,40 @@
+"""
+  Dual robots - typically a UGV taking care of UAV
+  https://en.wikipedia.org/wiki/Marsupial
+"""
+from ast import literal_eval
+
+from osgar.node import Node
+from subt.trace import distance3D
+
+
+class Marsupial(Node):
+    def __init__(self, config, bus):
+        super().__init__(config, bus)
+        bus.register("detach")
+
+        self.start_time = None  # unknown
+        self.release_at = config.get('release_at')
+        self.drone_available = True
+
+    def detach(self):
+        self.publish('deploy', [])  # ROS std_msg/Empty expects empty list as input
+        self.drone_available = False
+
+    def on_sim_time_sec(self, data):
+        if self.start_time is None:
+            self.start_time = data
+
+        if self.release_at is None:
+            return
+
+        if self.start_time + self.release_at <= data and self.drone_available:
+            self.detach()
+
+    def update(self):
+        channel = super().update()
+        handler = getattr(self, "on_" + channel, None)
+        if handler is not None:
+            handler(getattr(self, channel))
+
+# vim: expandtab sw=4 ts=4

--- a/subt/marsupial.py
+++ b/subt/marsupial.py
@@ -1,7 +1,12 @@
 """
   Dual robots - typically a UGV taking care of UAV
   https://en.wikipedia.org/wiki/Marsupial
+
+  This marsupial node is necessary for the "child", i.e. drone, which can call "detach" itself.
+  There is no need to communicate this with the parent (UGV).
 """
+# For more details see https://github.com/osrf/subt/issues/697
+
 from osgar.node import Node
 from subt.name_decoder import parse_robot_name
 

--- a/subt/marsupial.py
+++ b/subt/marsupial.py
@@ -18,7 +18,7 @@ class Marsupial(Node):
         self.drone_available = True
 
     def detach(self):
-        self.publish('deploy', [])  # ROS std_msg/Empty expects empty list as input
+        self.publish('detach', [])  # ROS std_msg/Empty expects empty list as input
         self.drone_available = False
 
     def on_sim_time_sec(self, data):

--- a/subt/ros/proxy/wait.py
+++ b/subt/ros/proxy/wait.py
@@ -62,16 +62,19 @@ def has_breadcrumbs(robot_name):
     return False
 
 
-def check_marsupials(robot_name):
+def is_marsupial(robot_name):
+    prefix = "/{}/".format(robot_name)
+    detach_name = prefix + "detach"
     publishers, subscribers = rostopic.get_topic_list()
     for name, _, _ in subscribers:
-        if 'detach' in name:
+        if name == detach_name:
             rospy.loginfo('Marsupial: ' + name)
+            return True
+    return False
 
 
 def detect_config(robot_name):
     robot_description = rospy.get_param("/{}/robot_description".format(robot_name))
-    check_marsupials(robot_name)
     if "robotika_x2_sensor_config_1" in robot_description:
         return "ROBOTIKA_X2_SENSOR_CONFIG_1"
     elif "ssci_x4_sensor_config_2" in robot_description:
@@ -102,6 +105,7 @@ def main():
     wait_for_bridge(robot_name)
     robot_config = detect_config(robot_name)
     rospy.set_param("/robot_config", robot_config)
+    rospy.set_param("/robot_is_marsupial", is_marsupial(robot_name))
 
 
 if __name__ == '__main__':

--- a/subt/ros/proxy/wait.py
+++ b/subt/ros/proxy/wait.py
@@ -62,8 +62,16 @@ def has_breadcrumbs(robot_name):
     return False
 
 
+def check_marsupials(robot_name):
+    publishers, subscribers = rostopic.get_topic_list()
+    for name, _, _ in subscribers:
+        if 'detach' in name:
+            rospy.loginfo('Marsupial: ' + name)
+
+
 def detect_config(robot_name):
     robot_description = rospy.get_param("/{}/robot_description".format(robot_name))
+    check_marsupials(robot_name)
     if "robotika_x2_sensor_config_1" in robot_description:
         return "ROBOTIKA_X2_SENSOR_CONFIG_1"
     elif "ssci_x4_sensor_config_2" in robot_description:

--- a/subt/test_marsupial.py
+++ b/subt/test_marsupial.py
@@ -18,4 +18,12 @@ class MarsupialTest(unittest.TestCase):
         robot.on_sim_time_sec(15)
         bus.publish.assert_not_called()
 
+    def test_origin(self):
+        bus = bus=MagicMock()
+        robot = Marsupial(bus=bus, config={})
+        self.assertIsNone(robot.release_at)
+        origin_data = [b'A10W100L', -6.410452, 5.000274, 0.807016, -0.005923, -1.8e-05, 0.999982, -2.4e-05]
+        robot.on_origin(origin_data)
+        self.assertEqual(robot.release_at, 10)
+
 # vim: expandtab sw=4 ts=4

--- a/subt/test_marsupial.py
+++ b/subt/test_marsupial.py
@@ -1,0 +1,20 @@
+import unittest
+from unittest.mock import MagicMock
+
+from subt.marsupial import Marsupial
+from osgar.lib import quaternion
+
+class MarsupialTest(unittest.TestCase):
+
+    def test_detach(self):
+        bus = bus=MagicMock()
+        robot = Marsupial(bus=bus, config={'release_at':10})
+        robot.on_sim_time_sec(3)
+        bus.publish.assert_not_called()
+        robot.on_sim_time_sec(14)
+        bus.publish.assert_called()
+        bus.publish.reset_mock()
+        robot.on_sim_time_sec(15)
+        bus.publish.assert_not_called()
+
+# vim: expandtab sw=4 ts=4

--- a/subt/test_marsupial.py
+++ b/subt/test_marsupial.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, call
 
 from subt.marsupial import Marsupial
 from osgar.lib import quaternion
@@ -13,6 +13,7 @@ class MarsupialTest(unittest.TestCase):
         bus.publish.assert_not_called()
         robot.on_sim_time_sec(14)
         bus.publish.assert_called()
+        bus.publish.assert_has_calls([call('detach', [])])
         bus.publish.reset_mock()
         robot.on_sim_time_sec(15)
         bus.publish.assert_not_called()

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -121,7 +121,6 @@
           "in": ["sim_time_sec"],
           "out": ["detach"],
           "init": {
-            "release_at": 30
           }
       }
     },
@@ -164,6 +163,7 @@
               ["rosmsg.radio", "radio.radio"],
 
               ["rosmsg.sim_time_sec", "marsupial.sim_time_sec"],
+              ["rosmsg.origin", "marsupial.origin"],
               ["marsupial.detach", "torospy.detach"],
 
               ["detector.artf", "app.artf"],

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -107,6 +107,9 @@
                         "air_pressure"]
 	      }
       },
+      "torospy": {
+          "driver": "subt.push:Push"
+      },
       "radio": {
           "driver": "subt.radio:Radio",
           "in": ["radio", "pose2d", "artf"],

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -121,7 +121,7 @@
       },
       "marsupial": {
           "driver": "subt.marsupial:Marsupial",
-          "in": ["sim_time_sec"],
+          "in": ["origin", "sim_time_sec"],
           "out": ["detach"],
           "init": {
           }

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -109,6 +109,14 @@
       },
       "offseter": {
         "driver": "subt.offseter:Offseter"
+      },
+      "marsupial": {
+          "driver": "subt.marsupial:Marsupial",
+          "in": ["sim_time_sec"],
+          "out": ["detach"],
+          "init": {
+            "release_at": 30
+          }
       }
     },
     "links": [["app.desired_speed", "drone.desired_speed"],
@@ -147,6 +155,9 @@
               ["radio.artf_xyz", "reporter.artf_xyz"],
               ["radio.radio", "rosmsg.broadcast"],
               ["rosmsg.radio", "radio.radio"],
+
+              ["rosmsg.sim_time_sec", "marsupial.sim_time_sec"],
+              ["marsupial.detach", "torospy.detach"],
 
               ["detector.artf", "app.artf"],
               ["detector.stdout", "rosmsg.stdout"],


### PR DESCRIPTION
This is experiment with marsupial robots (R2 + SSCI X4 drone) - the first attempt is here `ver92marscp2`, `e70821b7-ca98-4e5c-8248-043a854e843e`.

Beside real `detach` action there is still work to do **when to do it?**
- when the parent (R2) decides
- when the drone decides
- encoded in robot name

At the moment it is stored in `marsupial` config and in robot name. Parent does not have to anything. Last (successful) version was `ver93mars7`