### PR TITLE
Integrate octomap into OSGAR for Freyja

### DIFF
--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -19,6 +19,7 @@ from sensor_msgs.msg import Imu, LaserScan, CompressedImage, Image, PointCloud2
 from nav_msgs.msg import Odometry
 from std_msgs.msg import Empty, Int32
 from sensor_msgs.msg import BatteryState, FluidPressure
+from octomap_msgs.msg import Octomap
 
 sys.path.append("/osgar-ws/src/osgar/osgar/lib")
 import serialize as osgar_serialize
@@ -101,6 +102,7 @@ class main:
             topics.append(('/' + robot_name + '/scan_rear', LaserScan, self.scan_rear, ('scan_rear',)))
             topics.append(('/' + robot_name + '/rgbd_front/depth', Image, self.depth_front, ('depth_front',)))
             topics.append(('/' + robot_name + '/rgbd_rear/depth', Image, self.depth_rear, ('depth_rear',)))
+            topics.append(('/mapping/octomap_binary', Octomap, self.octomap, ('octomap',)))
         elif robot_config.startswith("ROBOTIKA_KLOUBAK_SENSOR_CONFIG"):
             if robot_config.endswith("_2"):
                 rospy.loginfo("k2 2 (with comms beacons)")
@@ -262,6 +264,11 @@ class main:
         self.points_count += 1
         rospy.loginfo_throttle(10, "points callback: {}".format(self.points_count))
         self.bus.publish('points', self.convert_points(msg))
+
+    def octomap(self, msg):
+        self.octomap_count += 1
+        rospy.loginfo_throttle(10, "octomap callback: {}".format(self.octomap_count))
+        self.bus.publish('octomap', msg.data)
 
 
 if __name__ == '__main__':

--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -105,7 +105,8 @@ class main:
             topics.append(('/' + robot_name + '/scan_rear', LaserScan, self.scan_rear, ('scan_rear',)))
             topics.append(('/' + robot_name + '/rgbd_front/depth', Image, self.depth_front, ('depth_front',)))
             topics.append(('/' + robot_name + '/rgbd_rear/depth', Image, self.depth_rear, ('depth_rear',)))
-            topics.append(('/mapping/octomap_binary', Octomap, self.octomap, ('octomap',)))
+            if robot_name.endswith('XM'):
+                topics.append(('/mapping/octomap_binary', Octomap, self.octomap, ('octomap',)))
         elif robot_config.startswith("ROBOTIKA_KLOUBAK_SENSOR_CONFIG"):
             if robot_config.endswith("_2"):
                 rospy.loginfo("k2 2 (with comms beacons)")

--- a/subt/main.py
+++ b/subt/main.py
@@ -911,7 +911,7 @@ class SubTChallenge:
         self.stdout('Final xyz (DARPA coord system):', self.xyz)
 
     def play_virtual_track(self):
-        self.stdout("SubT Challenge Ver95!")
+        self.stdout("SubT Challenge Ver96!")
         self.stdout("Waiting for robot_name ...")
         while self.robot_name is None:
             self.update()

--- a/subt/name_decoder.py
+++ b/subt/name_decoder.py
@@ -8,6 +8,9 @@ New coding:
 
 The last action is by default Home. There is no default direction.
 The time for Home is optional (default is 2 times sum of previous exploration).
+
+There is also eXtended or eXtra part of optional parameters separated by 'X' character.
+Currently only 'M' is used for enable mapping, i.e. name ends with 'XM'.
 """
 
 def split_multi(s, delimiters):
@@ -32,6 +35,8 @@ def parse_robot_name(robot_name):
         'W': 'wait',
         'H': 'home'
     }
+    # remove extra parameters (encoded after 'X')
+    robot_name = robot_name[0] + robot_name[1:].split('X')[0]
     parts = split_multi(robot_name[1:], options.keys())
     ret = []
     sum_t = 0

--- a/subt/ros/robot/launch/freyja.launch
+++ b/subt/ros/robot/launch/freyja.launch
@@ -177,6 +177,8 @@
   <node ns="mapping" pkg="octomap_server" type="octomap_server_node" name="octomap">
     <remap from="cloud_in" to="/$(arg robot_name)/rgbd_all/points"/>
     <param name="frame_id" value="odom"/>
+    <!-- resolution in meters per pixel -->
+    <param name="resolution" value="0.5" />
     <!-- In case we want to filter out ceilings.
     <param name="pointcloud_max_z" value="1.5"/>
     -->

--- a/subt/ros/robot/launch/freyja.launch
+++ b/subt/ros/robot/launch/freyja.launch
@@ -177,7 +177,7 @@
   <node if="$(eval arg('robot_name').endswith('XM'))" ns="mapping" pkg="octomap_server" type="octomap_server_node" name="octomap">
     <remap from="cloud_in" to="/$(arg robot_name)/rgbd_all/points"/>
     <param name="frame_id" value="odom"/>
-    <!-- resolution in meters per pixel -->
+    <!-- resolution in meters per voxel -->
     <param name="resolution" value="0.5" />
     <!-- In case we want to filter out ceilings.
     <param name="pointcloud_max_z" value="1.5"/>

--- a/subt/ros/robot/launch/freyja.launch
+++ b/subt/ros/robot/launch/freyja.launch
@@ -174,7 +174,7 @@
   <node pkg="topic_tools" type="relay" name="points_merge_front" args="$(arg robot_name)/rgbd_front/points $(arg robot_name)/rgbd_all/points"/>
   <node pkg="topic_tools" type="relay" name="points_merge_rear" args="$(arg robot_name)/rgbd_rear/points $(arg robot_name)/rgbd_all/points"/>
 
-  <node ns="mapping" pkg="octomap_server" type="octomap_server_node" name="octomap">
+  <node if="$(eval arg('robot_name').endswith('XM'))" ns="mapping" pkg="octomap_server" type="octomap_server_node" name="octomap">
     <remap from="cloud_in" to="/$(arg robot_name)/rgbd_all/points"/>
     <param name="frame_id" value="odom"/>
     <!-- resolution in meters per pixel -->

--- a/subt/ros/robot/launch/freyja.launch
+++ b/subt/ros/robot/launch/freyja.launch
@@ -174,7 +174,7 @@
   <node pkg="topic_tools" type="relay" name="points_merge_front" args="$(arg robot_name)/rgbd_front/points $(arg robot_name)/rgbd_all/points"/>
   <node pkg="topic_tools" type="relay" name="points_merge_rear" args="$(arg robot_name)/rgbd_rear/points $(arg robot_name)/rgbd_all/points"/>
 
-  <node if="0" ns="mapping" pkg="octomap_server" type="octomap_server_node" name="octomap">
+  <node ns="mapping" pkg="octomap_server" type="octomap_server_node" name="octomap">
     <remap from="cloud_in" to="/$(arg robot_name)/rgbd_all/points"/>
     <param name="frame_id" value="odom"/>
     <!-- In case we want to filter out ceilings.

--- a/subt/test_name_decoder.py
+++ b/subt/test_name_decoder.py
@@ -41,5 +41,13 @@ class NameDecoderTest(unittest.TestCase):
         steps = parse_robot_name('A100C')
         self.assertEqual(steps, [('enter-center', None), ('center', 100), ('home', 200)])
 
+    def test_extra_params(self):
+        # enable extra mapping
+        steps = parse_robot_name('A100LXM')
+        self.assertEqual(steps, [('enter-left', None), ('left', 100), ('home', 200)])
+
+        steps = parse_robot_name('X100L')
+        self.assertEqual(steps, [('enter-left', None), ('left', 100), ('home', 200)])
+
 # vim: expandtab sw=4 ts=4
 

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -80,7 +80,8 @@
           "driver": "subt.pull:Pull",
           "init": {
             "outputs": ["rot", "acc", "orientation", "battery_state", "score", "pose3d",
-                        "image_front", "image_rear", "scan_front", "scan_rear", "depth_front:null", "depth_rear:null"]
+                        "image_front", "image_rear", "scan_front", "scan_rear", "depth_front:null", "depth_rear:null",
+                        "octomap:gz"]
           }
       },
       "torospy": {


### PR DESCRIPTION
This is a experiment mentioned in #736. It allows Freyja to log octomap binary data for names with 'XM' extension, i.e. `A600LXM` will explore left side for 600 seconds and store Map. Note, that the map is conditional both in launch file and in `cloudsim2osgar`.