### PR TITLE
subt/docker/gui: start gazebo gui in a container

### DIFF
--- a/subt/docker/gui/Dockerfile
+++ b/subt/docker/gui/Dockerfile
@@ -1,0 +1,11 @@
+FROM osrf/subt-virtual-testbed:cloudsim_sim_latest
+
+RUN mkdir -p /home/developer/.ignition/gazebo/
+
+COPY ./subt/docker/gui/entrypoint.bash .
+
+ENTRYPOINT ["./entrypoint.bash"]
+
+ENV IGN_PARTITION=sim
+
+CMD ["ign", "gazebo", "-g"]

--- a/subt/docker/gui/Dockerfile
+++ b/subt/docker/gui/Dockerfile
@@ -2,6 +2,9 @@ FROM osrf/subt-virtual-testbed:cloudsim_sim_latest
 
 RUN mkdir -p /home/developer/.ignition/gazebo/
 
+RUN cd /home/developer/.ignition/fuel/fuel.ignitionrobotics.org/OpenRobotics/models/ && \
+    ln -s Robotika_Freyja_Sensor_Config_2 ROBOTIKA_FREYJA_SENSOR_CONFIG_2
+
 COPY ./subt/docker/gui/entrypoint.bash .
 
 ENTRYPOINT ["./entrypoint.bash"]

--- a/subt/docker/gui/entrypoint.bash
+++ b/subt/docker/gui/entrypoint.bash
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# We need to look for NVidia libraries, but they are not around yet when
+# building the image, so `ldconfig` in Dockerfile is not a working solution.
+# https://gitlab.com/nvidia/container-images/cuda/-/issues/34
+sudo ldconfig
+
+exec "$@"


### PR DESCRIPTION
Running ./subt/docker/run.bash gui opens gazebo gui and connects it
to a simulation started by subt.tools.run. It should be able to connect
over a local network (the simulation and gui running on different
computers).