### PR TITLE
Use virtualgl egl backend to run simulation without X server.

### DIFF
--- a/subt/docker/cloudsim/Dockerfile
+++ b/subt/docker/cloudsim/Dockerfile
@@ -1,0 +1,11 @@
+FROM osrf/subt-virtual-testbed:cloudsim_sim_latest
+
+RUN cd /tmp && \
+    curl -sSO https://s3.amazonaws.com/virtualgl-pr/dev/linux/virtualgl_2.6.80_amd64.deb && \
+    sudo apt-get install ./virtualgl_*
+
+#ENTRYPOINT ["/usr/bin/env"]
+
+COPY subt/docker/cloudsim/run_wrapped.bash .
+
+ENTRYPOINT ["./run_wrapped.bash"]

--- a/subt/docker/cloudsim/run_wrapped.bash
+++ b/subt/docker/cloudsim/run_wrapped.bash
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "running wrapped"
+
+xvfb-run -a -s '-screen 0 1x1x24' vglrun -d /dev/dri/card1 ./run_sim.bash $@

--- a/subt/tools/run.py
+++ b/subt/tools/run.py
@@ -113,9 +113,9 @@ def _create_docker(client, name, image, command, mounts=[], environment={}):
         privileged = True,
         #network_mode = "host",
         environment = {
-            "DISPLAY": os.environ["DISPLAY"],
-            "QT_X11_NO_MITSHM": 1,
-            "XAUTHORITY": str(XAUTH),
+            #"DISPLAY": os.environ["DISPLAY"],
+            #"QT_X11_NO_MITSHM": 1,
+            #"XAUTHORITY": str(XAUTH),
         },
         #stdout = True,
         #stderr = True,
@@ -126,10 +126,10 @@ def _create_docker(client, name, image, command, mounts=[], environment={}):
         #entrypoint="/bin/bash",
         #command = "/opt/ros/melodic/bin/rviz",
         mounts = [
-            docker.types.Mount(str(XAUTH), str(XAUTH), "bind"),
-            docker.types.Mount("/tmp/.X11-unix/", "/tmp/.X11-unix/", "bind"),
+            #docker.types.Mount(str(XAUTH), str(XAUTH), "bind"),
+            #docker.types.Mount("/tmp/.X11-unix/", "/tmp/.X11-unix/", "bind"),
             docker.types.Mount("/etc/localtime", "/etc/localtime", "bind", read_only=True),
-            docker.types.Mount("/dev/input/", "/dev/input/", "bind"),
+            #docker.types.Mount("/dev/input/", "/dev/input/", "bind"),
         ],
     )
     opts["mounts"] += mounts
@@ -170,7 +170,7 @@ def _run_sim(client, circuit, logdir, world, robots):
             f"robotName{n}:={name}",
             f"robotConfig{n}:={kind}"
         ]
-    sim = _create_docker(client, "sim", "osrf/subt-virtual-testbed:cloudsim_sim_latest", command, mounts, environment)
+    sim = _create_docker(client, "sim", "cloudsim:latest", command, mounts, environment)
     print(f"  connecting to simnet as 172.28.1.1")
     simnet.connect(sim, ipv4_address="172.28.1.1")
     sim.start()


### PR DESCRIPTION
To test please run

```
$ docker pull osrf/subt-virtual-testbed:cloudsim_sim_latest
$ ./subt/docker/build.bash cloudsim
$ python -m subt.tools.run <your_favorite_config.toml>
```

It should be possible to get a successful run even on a computer with no running X server or when the X server runs as a different user.
