### PR TITLE
subt/docker/build.bash: use network=host when building

### DIFF
--- a/subt/docker/build.bash
+++ b/subt/docker/build.bash
@@ -41,7 +41,7 @@ image_plus_tag=$image_name:$datetime_tag
 
 shift
 
-docker build --rm -t $image_plus_tag -f $DIR/$image_name/Dockerfile $(git rev-parse --show-toplevel)
+docker build --rm --network host -t $image_plus_tag -f $DIR/$image_name/Dockerfile $(git rev-parse --show-toplevel)
 docker tag $image_plus_tag $image_name:latest
 
 echo


### PR DESCRIPTION
Docker uses the "bridge" network by default and that seems to not work for @jisa. Using the host network might help and it does not hurt (at least for me it is working as well as the default).