### PR TITLE
Feature/subt binary radio msg

### DIFF
--- a/subt/config/r2.json
+++ b/subt/config/r2.json
@@ -110,7 +110,7 @@
       },
       "radio": {
           "driver": "subt.radio:Radio",
-          "in": ["radio", "pose2d", "artf"],
+          "in": ["radio", "pose3d", "artf", "sim_time_sec"],
           "out": ["radio", "artf_xyz"],
           "init": {}
       },
@@ -154,11 +154,12 @@
               ["rosmsg.gas_detected", "gas_detector.gas_detected"],
               ["gas_detector.artf", "app.artf"],
 
-              ["app.pose2d", "radio.pose2d"],
+              ["localization.pose3d", "radio.pose3d"],
               ["reporter.artf_all", "radio.artf"],
               ["radio.artf_xyz", "reporter.artf_xyz"],
               ["radio.radio", "rosmsg.broadcast"],
               ["rosmsg.radio", "radio.radio"],
+              ["rosmsg.sim_time_sec", "radio.sim_time_sec"],
 
               ["rosmsg.sim_time_sec", "breadcrumbs.sim_time_sec"],
               ["localization.pose3d", "breadcrumbs.pose3d"],

--- a/subt/main.py
+++ b/subt/main.py
@@ -911,7 +911,7 @@ class SubTChallenge:
         self.stdout('Final xyz (DARPA coord system):', self.xyz)
 
     def play_virtual_track(self):
-        self.stdout("SubT Challenge Ver93!")
+        self.stdout("SubT Challenge Ver94!")
         self.stdout("Waiting for robot_name ...")
         while self.robot_name is None:
             self.update()

--- a/subt/radio.py
+++ b/subt/radio.py
@@ -67,6 +67,10 @@ class Radio(Node):
     def on_breadcrumb(self, data):
         self.send_data(bytes(str({'breadcrumb':data}), encoding='ascii'))
 
+    def on_sim_time_sec(self, data):
+        to_send = bytes([i % 256 for i in range(data)])
+        self.send_data(to_send)
+
     def update(self):
         channel = super().update()  # define self.time
         handler = getattr(self, "on_" + channel, None)

--- a/subt/radio.py
+++ b/subt/radio.py
@@ -68,7 +68,7 @@ class Radio(Node):
         self.send_data(bytes(str({'breadcrumb':data}), encoding='ascii'))
 
     def on_sim_time_sec(self, data):
-        to_send = bytes([i % 256 for i in range(data)])
+        to_send = bytes([i % 256 for i in range(data * 50)])
         self.send_data(to_send)
 
     def update(self):

--- a/subt/radio.py
+++ b/subt/radio.py
@@ -64,17 +64,18 @@ class Radio(Node):
     def on_breadcrumb(self, data):
         self.send_data('breadcrumb', data)
 
-    def on_pose2d(self, data):
+    def on_pose3d(self, data):
         if self.sim_time_sec is None:
             return
         if self.last_transmit is None or self.sim_time_sec > self.last_transmit + self.min_transmit_dt:
-            self.send_data('pose2d', data)
+            self.send_data('xyz', [self.sim_time_sec, data[0]])
             self.last_transmit = self.sim_time_sec
 
     def on_artf(self, data):
         self.send_data('artf', data)
 
     def on_sim_time_sec(self, data):
+        self.sim_time_sec = data  # duplicate for super().update(), used just for easier unittesting
         # experimental code to confirm overflow at 1500 bytes
         to_send = bytes([i % 256 for i in range(data)])
         self.send_data('sim_time_sec', to_send)

--- a/subt/radio.py
+++ b/subt/radio.py
@@ -76,9 +76,7 @@ class Radio(Node):
 
     def on_sim_time_sec(self, data):
         self.sim_time_sec = data  # duplicate for super().update(), used just for easier unittesting
-        # experimental code to confirm overflow at 1500 bytes
-        to_send = bytes([i % 256 for i in range(data)])
-        self.send_data('sim_time_sec', to_send)
+        self.send_data('sim_time_sec', data)
 
     def update(self):
         channel = super().update()  # define self.time

--- a/subt/radio.py
+++ b/subt/radio.py
@@ -36,21 +36,23 @@ class Radio(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
         bus.register('radio', 'artf_xyz', 'breadcrumb')
-        self.min_transmit_dt = 10
+        self.min_transmit_dt = 0  # i.e. every sim_time_sec -> every simulated second
         self.last_transmit = None
         self.sim_time_sec = None
         self.recent_packets = []
         self.verbose = config.get('verbose', False)
         self.debug_robot_poses = []
+        self.message_counter = 0
 
     def send_data(self, channel, data):
-        raw = serialize([channel, data])
+        raw = serialize([self.message_counter, channel, data])
         self.publish('radio', raw)
+        self.message_counter += 1
 
     def on_radio(self, data):
         src, packet = data
         name = src.decode('ascii')
-        channel, msg_data = deserialize(packet)
+        __, channel, msg_data = deserialize(packet)
         if channel == 'artf':
             self.publish('artf_xyz', msg_data)  # topic rename - beware of limits 1500bytes!
         elif channel == 'breadcrumb':

--- a/subt/radio.py
+++ b/subt/radio.py
@@ -35,7 +35,7 @@ def draw_positions(arr):
 class Radio(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
-        bus.register('radio', 'artf_xyz', 'breadcrumb')
+        bus.register('radio', 'artf_xyz', 'breadcrumb', 'robot_xyz')
         self.min_transmit_dt = 0  # i.e. every sim_time_sec -> every simulated second
         self.last_transmit = None
         self.sim_time_sec = None
@@ -57,9 +57,10 @@ class Radio(Node):
             self.publish('artf_xyz', msg_data)  # topic rename - beware of limits 1500bytes!
         elif channel == 'breadcrumb':
             self.publish(channel, msg_data)
-        elif channel == 'pose2d':
+        elif channel == 'xyz':
+            self.publish('robot_xyz', [name, msg_data])
             if self.verbose:
-                self.debug_robot_poses.append((self.time, name, msg_data))  # TODO sim_time_sec
+                self.debug_robot_poses.append((self.time, name, msg_data))
 
     def on_breadcrumb(self, data):
         self.send_data('breadcrumb', data)

--- a/subt/ros/proxy/ros_proxy_node.cc
+++ b/subt/ros/proxy/ros_proxy_node.cc
@@ -323,15 +323,6 @@ void Controller::CommClientCallback(const std::string &_srcAddress,
                                     const uint32_t _dstPort,
                                     const std::string &_data)
 {
-  subt::msgs::ArtifactScore res;
-  if (!res.ParseFromString(_data))
-  {
-    ROS_INFO("Message Contents[%s]", _data.c_str());
-  }
-
-  // Add code to handle communication callbacks.
-  ROS_INFO("Message from [%s] to [%s] on port [%u]:\n [%s]", _srcAddress.c_str(),
-      _dstAddress.c_str(), _dstPort, res.DebugString().c_str());
   sendReceivedMessage(_srcAddress, _data);
 }
 
@@ -583,8 +574,7 @@ void Controller::receiveZmqThread(Controller * self)
     }
     else if(strncmp(buffer, "broadcast ", 10) == 0)
     {
-        std::string content(buffer + 10);
-        ROS_INFO_STREAM("BROADCAST RECEIVED " << content);
+        std::string content(buffer + 10, size - 10);
         if(self->broadcast(content))
         {
           ROS_INFO("MD BROADCAST SUCCESS\n");

--- a/subt/ros/proxy/ros_proxy_teambase.cc
+++ b/subt/ros/proxy/ros_proxy_teambase.cc
@@ -287,8 +287,7 @@ void receiveZmqThread()
     }
     else if(strncmp(buffer, "broadcast ", 10) == 0)
     {
-        std::string content(buffer + 10);
-        ROS_INFO_STREAM("BROADCAST RECEIVED " << content);
+        std::string content(buffer + 10, size - 10);
         if(broadcast(content))
         {
           ROS_INFO("MD BROADCAST SUCCESS\n");

--- a/subt/teambase.py
+++ b/subt/teambase.py
@@ -9,7 +9,7 @@ from osgar.node import Node
 class Teambase(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
-        bus.register("broadcast")
+        bus.register()
 
         self.robot_name = config.get('robot_name')
         self.start_time = None  # unknown
@@ -26,6 +26,12 @@ class Teambase(Node):
             self.start_time = data
         if self.finish_time is not None and data - self.start_time > self.finish_time:
             self.request_stop()
+
+    def on_robot_xyz(self, data):
+        name, arr = data
+        self.robot_positions[name] = arr
+        if self.verbose:
+            self.debug_arr.append((name, arr))
 
     def Xon_radio(self, data):
         src, packet = data

--- a/subt/teambase.py
+++ b/subt/teambase.py
@@ -22,14 +22,12 @@ class Teambase(Node):
         self.verbose = False
 
     def on_sim_time_sec(self, data):
-        # broadcast simulation time every second
-        self.publish('broadcast', b'%d' % data)
         if self.start_time is None:
             self.start_time = data
         if self.finish_time is not None and data - self.start_time > self.finish_time:
             self.request_stop()
 
-    def on_radio(self, data):
+    def Xon_radio(self, data):
         src, packet = data
         name = src.decode('ascii')
         if packet.startswith(b'['):

--- a/subt/teambase.py
+++ b/subt/teambase.py
@@ -64,8 +64,8 @@ class Teambase(Node):
         print('Robot IDs', robot_ids)
 
         for robot_id in robot_ids:
-            x = [a[1][0] / 1000.0 for a in self.debug_arr if a[0] == robot_id]
-            y = [a[1][1] / 1000.0 for a in self.debug_arr if a[0] == robot_id]
+            x = [a[1][1][0] for a in self.debug_arr if a[0] == robot_id]
+            y = [a[1][1][1] for a in self.debug_arr if a[0] == robot_id]
             line = plt.plot(x, y, '-o', linewidth=2, label=robot_id)
 
         artf_types = set([artf[0] for artf in self.artifacts])

--- a/subt/teambase.py
+++ b/subt/teambase.py
@@ -33,23 +33,11 @@ class Teambase(Node):
         if self.verbose:
             self.debug_arr.append((name, arr))
 
-    def Xon_radio(self, data):
-        src, packet = data
-        name = src.decode('ascii')
-        if packet.startswith(b'['):
-            arr = literal_eval(packet.decode('ascii'))
-            if len(arr) == 3:
-                # position
-                self.robot_positions[name] = arr
-                if self.verbose:
-                    self.debug_arr.append((name, arr))
-            elif len(arr) == 4:
-                # artifact
-                if arr not in self.artifacts:
-                    print(self.time, 'received:', arr)
-                    self.artifacts.append(arr)
-            else:
-                assert False, arr  # unexpected size/type
+    def on_artf_xyz(self, data):
+        for arr in data:
+            if arr not in self.artifacts:
+                print(self.time, 'received:', arr)
+                self.artifacts.append(arr)
 
     def update(self):
         channel = super().update()
@@ -57,6 +45,8 @@ class Teambase(Node):
         handler = getattr(self, "on_" + channel, None)
         if handler is not None:
             handler(getattr(self, channel))
+        else:
+            assert False, channel  # not supported channel
 
     def draw(self):
         import matplotlib.pyplot as plt

--- a/subt/test_radio.py
+++ b/subt/test_radio.py
@@ -50,4 +50,17 @@ class RadioTest(unittest.TestCase):
         self.assertEqual(bus.method_calls[-1],
                          call.publish('radio', serialize([1, 'dummy_artf', [1, 2, 3]])))
 
+    def test_pose3d(self):
+        bus = MagicMock()
+        dev = Radio(bus=bus, config={})
+        bus.reset_mock()
+        data = [[-5.999917943872727, 4.999913526023388, 0.12287766016353471], [6.229389211972107e-12, -7.943606405014296e-12, 1.5034993858140517e-12, 1.0]]
+        dev.on_pose3d(data)
+        bus.publish.assert_not_called()  # not defined sim_time
+        dev.on_sim_time_sec(13)
+        dev.on_pose3d(data)
+        bus.publish.assert_called()
+        self.assertEqual(bus.method_calls[-1],
+                         call.publish('radio', serialize([1, 'xyz', [13, [-5.999917943872727, 4.999913526023388, 0.12287766016353471]]])))
+
 # vim: expandtab sw=4 ts=4

--- a/subt/test_radio.py
+++ b/subt/test_radio.py
@@ -4,20 +4,21 @@ from unittest.mock import MagicMock, patch, call
 
 from subt.radio import Radio
 from osgar.bus import Bus
+from osgar.lib.serialize import serialize
 
 
 class RadioTest(unittest.TestCase):
 
     def test_on_radio(self):
         # virtual world
-        data = [b'A0F150L', b"['TYPE_RESCUE_RANDY', 15982, 104845, 3080]\n"]
+        data = [b'A0F150L', serialize(['artf', ['TYPE_RESCUE_RANDY', 15982, 104845, 3080]])]
         bus = MagicMock()
         dev = Radio(bus=bus, config={})
         bus.reset_mock()
         dev.on_radio(data)
         bus.publish.assert_called()
 
-        data = [b'A0F150L', b'[11896, 7018, -11886]\n']
+        data = [b'A0F150L', serialize(['pose2d', [11896, 7018, -11886]])]
         bus.reset_mock()
         dev.on_radio(data)
         bus.publish.assert_not_called()
@@ -30,11 +31,20 @@ class RadioTest(unittest.TestCase):
         dev.on_breadcrumb(data)
         bus.publish.assert_called()
         self.assertEqual(bus.method_calls[0],
-                         call.publish('radio', b"{'breadcrumb': [29.929257253892082, -1.5821685677914703, 1.575092509709292]}\n"))
+                         call.publish('radio', serialize(['breadcrumb', [29.929257253892082, -1.5821685677914703, 1.575092509709292]])))
 
-        new_msg = b"{'breadcrumb': [29.929257253892082, -1.5821685677914703, 1.575092509709292]}\n"
+        new_msg = serialize(['breadcrumb', [29.929257253892082, -1.5821685677914703, 1.575092509709292]])
         bus.reset_mock()
         dev.on_radio([b'A1300L', new_msg])
         bus.publish.assert_called()
+
+    def test_msg_pack(self):
+        bus = MagicMock()
+        dev = Radio(bus=bus, config={})
+        bus.reset_mock()
+        dev.send_data('dummy_artf', [1, 2, 3])
+        bus.publish.assert_called()
+        self.assertEqual(bus.method_calls[0],
+                         call.publish('radio', serialize(['dummy_artf', [1, 2, 3]])))
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_radio.py
+++ b/subt/test_radio.py
@@ -11,14 +11,14 @@ class RadioTest(unittest.TestCase):
 
     def test_on_radio(self):
         # virtual world
-        data = [b'A0F150L', serialize(['artf', ['TYPE_RESCUE_RANDY', 15982, 104845, 3080]])]
+        data = [b'A0F150L', serialize([13, 'artf', ['TYPE_RESCUE_RANDY', 15982, 104845, 3080]])]
         bus = MagicMock()
         dev = Radio(bus=bus, config={})
         bus.reset_mock()
         dev.on_radio(data)
         bus.publish.assert_called()
 
-        data = [b'A0F150L', serialize(['pose2d', [11896, 7018, -11886]])]
+        data = [b'A0F150L', serialize([0, 'pose2d', [11896, 7018, -11886]])]
         bus.reset_mock()
         dev.on_radio(data)
         bus.publish.assert_not_called()
@@ -31,9 +31,9 @@ class RadioTest(unittest.TestCase):
         dev.on_breadcrumb(data)
         bus.publish.assert_called()
         self.assertEqual(bus.method_calls[0],
-                         call.publish('radio', serialize(['breadcrumb', [29.929257253892082, -1.5821685677914703, 1.575092509709292]])))
+                         call.publish('radio', serialize([0, 'breadcrumb', [29.929257253892082, -1.5821685677914703, 1.575092509709292]])))
 
-        new_msg = serialize(['breadcrumb', [29.929257253892082, -1.5821685677914703, 1.575092509709292]])
+        new_msg = serialize([0, 'breadcrumb', [29.929257253892082, -1.5821685677914703, 1.575092509709292]])
         bus.reset_mock()
         dev.on_radio([b'A1300L', new_msg])
         bus.publish.assert_called()
@@ -44,7 +44,10 @@ class RadioTest(unittest.TestCase):
         bus.reset_mock()
         dev.send_data('dummy_artf', [1, 2, 3])
         bus.publish.assert_called()
-        self.assertEqual(bus.method_calls[0],
-                         call.publish('radio', serialize(['dummy_artf', [1, 2, 3]])))
+        self.assertEqual(bus.method_calls[-1],
+                         call.publish('radio', serialize([0, 'dummy_artf', [1, 2, 3]])))
+        dev.send_data('dummy_artf', [1, 2, 3])
+        self.assertEqual(bus.method_calls[-1],
+                         call.publish('radio', serialize([1, 'dummy_artf', [1, 2, 3]])))
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_teambase.py
+++ b/subt/test_teambase.py
@@ -8,30 +8,15 @@ from subt.teambase import Teambase
 
 class TeambaseTest(unittest.TestCase):
 
-    def test_usage(self):
-        logger = MagicMock()
-        bus = Bus(logger)
-        logger.write = MagicMock(return_value=datetime.timedelta(microseconds=9721))
-        c = Teambase(bus=bus.handle('teambase'), config={})
-        tester = bus.handle('tester')
-        tester.register('sim_time_sec')
-        bus.connect('tester.sim_time_sec', 'teambase.sim_time_sec')
-        bus.connect('teambase.broadcast', 'tester.broadcast')
-        c.start()
-        tester.publish('sim_time_sec', 13)
-        c.request_stop()
-        c.join()
-        self.assertEqual(tester.listen()[2], b'13')
-
     def test_finish_time(self):
         tb = Teambase(bus=MagicMock(), config={'robot_name':'T42'})
         self.assertEqual(tb.finish_time, 42)
 
-    def test_on_radio(self):
+    def test_on_robot_xyz(self):
         tb = Teambase(bus=MagicMock(), config={'robot_name':'T300'})
         self.assertEqual(tb.robot_positions, {})
-        data = [b'A0F150L', b'[11896, 7018, -11886]\n']
-        tb.on_radio(data)
+        data = ['A0F150L', [11896, 7018, -11886]]
+        tb.on_robot_xyz(data)
         self.assertEqual(tb.robot_positions, {'A0F150L': [11896, 7018, -11886]})
 
 # vim: expandtab sw=4 ts=4

--- a/subt/zmq-subt-teambase.json
+++ b/subt/zmq-subt-teambase.json
@@ -41,6 +41,12 @@
           "init": {
             "downsample": 2
           }
+      },
+      "radio": {
+          "driver": "subt.radio:Radio",
+          "in": ["radio", "pose3d", "artf", "sim_time_sec"],
+          "out": ["radio", "artf_xyz"],
+          "init": {}
       }
     },
     "links": [["app.stdout", "rosmsg.stdout"],
@@ -51,6 +57,12 @@
               ["rosmsg.sim_time_sec", "app.sim_time_sec"],
               ["app.broadcast", "rosmsg.broadcast"],
               ["rosmsg.radio", "app.radio"],
+
+              ["rosmsg.radio", "radio.radio"],
+              ["rosmsg.sim_time_sec", "radio.sim_time_sec"],
+              ["radio.artf_xyz", "app.artf_xyz"],
+              ["radio.robot_xyz", "app.robot_xyz"],
+              ["radio.radio", "rosmsg.broadcast"],
 
               ["app.artf_xyz", "reporter.artf_xyz"],
               ["reporter.artf_cmd", "transmitter.raw"]]

--- a/subt/zmq-subt-teambase.json
+++ b/subt/zmq-subt-teambase.json
@@ -55,8 +55,6 @@
               ["rosmsg.cmd", "transmitter.raw"],
 
               ["rosmsg.sim_time_sec", "app.sim_time_sec"],
-              ["app.broadcast", "rosmsg.broadcast"],
-              ["rosmsg.radio", "app.radio"],
 
               ["rosmsg.radio", "radio.radio"],
               ["rosmsg.sim_time_sec", "radio.sim_time_sec"],

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -88,7 +88,7 @@
       },
       "radio": {
           "driver": "subt.radio:Radio",
-          "in": ["radio", "pose2d", "artf"],
+          "in": ["radio", "pose3d", "artf", "sim_time_sec"],
           "out": ["radio", "artf_xyz"],
           "init": {}
       },
@@ -138,11 +138,12 @@
               ["rosmsg.gas_detected", "gas_detector.gas_detected"],
               ["gas_detector.artf", "app.artf"],
 
-              ["app.pose2d", "radio.pose2d"],
+              ["offseter.pose3d", "radio.pose3d"],
               ["reporter.artf_all", "radio.artf"],
               ["radio.artf_xyz", "reporter.artf_xyz"],
               ["radio.radio", "rosmsg.broadcast"],
               ["rosmsg.radio", "radio.radio"],
+              ["rosmsg.sim_time_sec", "radio.sim_time_sec"],
 
               ["rosmsg.sim_time_sec", "breadcrumbs.sim_time_sec"],
               ["offseter.pose3d", "breadcrumbs.pose3d"],

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -164,6 +164,7 @@
               ["radio.artf_xyz", "reporter.artf_xyz"],
               ["radio.radio", "rosmsg.broadcast"],
               ["rosmsg.radio", "radio.radio"],
+              ["rosmsg.sim_time_sec", "radio.sim_time_sec"],
 
               ["rosmsg.sim_time_sec", "marsupial.sim_time_sec"],
               ["rosmsg.origin", "marsupial.origin"],

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -112,7 +112,7 @@
       },
       "radio": {
           "driver": "subt.radio:Radio",
-          "in": ["radio", "pose2d", "artf"],
+          "in": ["radio", "pose3d", "artf", "sim_time_sec"],
           "out": ["radio", "artf_xyz"],
           "init": {}
       },

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -159,7 +159,7 @@
               ["rosmsg.gas_detected", "gas_detector.gas_detected"],
               ["gas_detector.artf", "app.artf"],
 
-              ["app.pose2d", "radio.pose2d"],
+              ["offseter.pose3d", "radio.pose3d"],
               ["reporter.artf_all", "radio.artf"],
               ["radio.artf_xyz", "reporter.artf_xyz"],
               ["radio.radio", "rosmsg.broadcast"],


### PR DESCRIPTION
This is the first step to use binary radio messages among robots. Note, that the limit is 1500 bytes per message (including serialization). This implementation is using `osgar.lib.serialize` methods.

The original functionality slightly changes:
- artifacts are reported as the whole list of all currently available artifacts
- `pose2d` is replaced by `xyz` taken from `pose3d` + `sim_time_sec`
- the broadcast of position is every simulated second
- all robots broadcast their `sim_time_sec` (i.e. not only Teambase as it used to be)