### PR TITLE
Fix localization for marsupial robots

### DIFF
--- a/osgar/lib/quaternion.py
+++ b/osgar/lib/quaternion.py
@@ -31,6 +31,7 @@ def identity():
     return [0, 0, 0, 1]
 
 def rotate_vector(vector, quaternion):
+    # https://en.wikipedia.org/wiki/Quaternions_and_spatial_rotation
     qvector = vector + [0]
     con = conjugate(quaternion)
     part1 = multiply(quaternion, qvector)

--- a/subt/offseter.py
+++ b/subt/offseter.py
@@ -1,4 +1,3 @@
-import math
 from threading import Thread
 
 from osgar.bus import BusShutdownException
@@ -13,7 +12,7 @@ class Offseter:
         #self.thread.name = bus.name
         self.bus = bus
         self.is_alive = self.thread.is_alive
-        self.yaw_offset = None  # unknown
+        self.init_quat = None  # unknown
 
     def start(self):
         self.thread.start()
@@ -30,13 +29,8 @@ class Offseter:
                 if len(data) == 8:
                     robot_name, x, y, z, qa, qb, qc, qd = data
                     origin = [x, y, z]
-                    yaw = quaternion.heading((qa, qb, qc, qd))
-                    if self.yaw_offset is None:
-                        # normalize yaw offset only to 0 (normal) and PI (Marsupial)
-                        if abs(yaw) < 0.1:
-                            self.yaw_offset = 0.0
-                        else:
-                            self.yaw_offset = math.pi
+                    if self.init_quat is None:
+                        self.init_quat = (qa, qb, qc, qd)
             elif channel == "pose3d":
                 xyz, orientation = data
             else:

--- a/subt/offseter.py
+++ b/subt/offseter.py
@@ -1,5 +1,8 @@
+import math
 from threading import Thread
+
 from osgar.bus import BusShutdownException
+from osgar.lib import quaternion
 
 
 class Offseter:
@@ -10,6 +13,7 @@ class Offseter:
         #self.thread.name = bus.name
         self.bus = bus
         self.is_alive = self.thread.is_alive
+        self.yaw_offset = None  # unknown
 
     def start(self):
         self.thread.start()
@@ -26,6 +30,13 @@ class Offseter:
                 if len(data) == 8:
                     robot_name, x, y, z, qa, qb, qc, qd = data
                     origin = [x, y, z]
+                    yaw = quaternion.heading((qa, qb, qc, qd))
+                    if self.yaw_offset is None:
+                        # normalize yaw offset only to 0 (normal) and PI (Marsupial)
+                        if abs(yaw) < 0.1:
+                            self.yaw_offset = 0.0
+                        else:
+                            self.yaw_offset = math.pi
             elif channel == "pose3d":
                 xyz, orientation = data
             else:

--- a/subt/offseter.py
+++ b/subt/offseter.py
@@ -1,4 +1,6 @@
 from threading import Thread
+from osgar.bus import BusShutdownException
+
 
 class Offseter:
 
@@ -15,7 +17,7 @@ class Offseter:
     def join(self, timeout=None):
         self.thread.join(timeout=timeout)
 
-    def run(self):
+    def _run(self):
         origin = None
         xyz = None
         while None in (origin, xyz):
@@ -45,6 +47,11 @@ class Offseter:
             else:
                 raise RuntimeError(f"unknown channel '{channel}'")
 
+    def run(self):
+        try:
+            self._run()
+        except BusShutdownException:
+            pass
 
     def request_stop(self):
         self.bus.shutdown()

--- a/subt/test_offseter.py
+++ b/subt/test_offseter.py
@@ -17,12 +17,22 @@ class OffseterTest(unittest.TestCase):
         tester.register('origin', 'pose3d')
         bus.connect('tester.origin', 'offseter.origin')
         bus.connect('tester.pose3d', 'offseter.pose3d')
+        bus.connect('offseter.pose3d', 'tester.pose3d')
         c.start()
-        tester.publish('origin', [b'A300W600R', -6.409662, 5.000274, 0.805016, -0.005923, -1.8e-05, 0.999982, -1e-05])
-        tester.publish('pose3d', [[2.2540965890777053e-05, -1.7848595179941423e-05, -5.095526932796975e-12], [0, 0, 0, 1]])
+        tester.publish('origin', [b'A300W600R', -6.4, 5.0, 0.8, 0.0, 0.0, 1.0, 0])
+        tester.publish('pose3d', [[0, 0, 0], [0, 0, 0, 1]])  # first pose is "consumed"
+        tester.publish('pose3d', [[-2, -1, 0], [0, 0, 0, 1]])
+        tester.publish('pose3d', [[-2, -3, 1], [0, 0, 0.7071068, 0.7071068]])  # 90 deg
         c.request_stop()
         c.join()
         self.assertIsNotNone(c.init_quat)
+        xyz, ori = tester.listen()[2]
+        self.assertEqual(xyz, [-6.4 + 2, 5.0 + 1, 0.8])
+        self.assertEqual(ori, [0.0, 0.0, 1.0, 0])
+
+        xyz, ori = tester.listen()[2]
+        self.assertEqual(xyz, [-6.4 + 2, 5.0 + 3, 0.8 + 1])
+        self.assertEqual(ori, [0, 0, 0.7071068, -0.7071068])  # 270 deg
 
 # vim: expandtab sw=4 ts=4
 

--- a/subt/test_offseter.py
+++ b/subt/test_offseter.py
@@ -1,0 +1,28 @@
+import unittest
+from unittest.mock import MagicMock
+import datetime
+
+from subt.offseter import Offseter
+from osgar.bus import Bus
+
+
+class OffseterTest(unittest.TestCase):
+
+    def test_usage(self):
+        logger = MagicMock()
+        bus = Bus(logger)
+        logger.write = MagicMock(return_value=datetime.timedelta(microseconds=9721))
+        c = Offseter(bus=bus.handle('offseter'), config={})
+        tester = bus.handle('tester')
+        tester.register('origin', 'pose3d')
+        bus.connect('tester.origin', 'offseter.origin')
+        bus.connect('tester.pose3d', 'offseter.pose3d')
+        c.start()
+        tester.publish('origin', [1000, 9000])
+        c.request_stop()
+        c.join()
+        self.assertEqual(tester.listen()[2], [[1.0, 0.0, 0.0], [0.0, 0.0, MAX_ANGULAR]])
+
+
+# vim: expandtab sw=4 ts=4
+

--- a/subt/test_offseter.py
+++ b/subt/test_offseter.py
@@ -1,7 +1,6 @@
 import unittest
 from unittest.mock import MagicMock
 import datetime
-import math
 
 from subt.offseter import Offseter
 from osgar.bus import Bus
@@ -23,7 +22,7 @@ class OffseterTest(unittest.TestCase):
         tester.publish('pose3d', [[2.2540965890777053e-05, -1.7848595179941423e-05, -5.095526932796975e-12], [0, 0, 0, 1]])
         c.request_stop()
         c.join()
-        self.assertEqual(c.yaw_offset, math.pi)
+        self.assertIsNotNone(c.init_quat)
 
 # vim: expandtab sw=4 ts=4
 

--- a/subt/test_offseter.py
+++ b/subt/test_offseter.py
@@ -21,7 +21,6 @@ class OffseterTest(unittest.TestCase):
         tester.publish('origin', [1000, 9000])
         c.request_stop()
         c.join()
-        self.assertEqual(tester.listen()[2], [[1.0, 0.0, 0.0], [0.0, 0.0, MAX_ANGULAR]])
 
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_offseter.py
+++ b/subt/test_offseter.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import MagicMock
 import datetime
+import math
 
 from subt.offseter import Offseter
 from osgar.bus import Bus
@@ -18,10 +19,11 @@ class OffseterTest(unittest.TestCase):
         bus.connect('tester.origin', 'offseter.origin')
         bus.connect('tester.pose3d', 'offseter.pose3d')
         c.start()
-        tester.publish('origin', [1000, 9000])
+        tester.publish('origin', [b'A300W600R', -6.409662, 5.000274, 0.805016, -0.005923, -1.8e-05, 0.999982, -1e-05])
+        tester.publish('pose3d', [[2.2540965890777053e-05, -1.7848595179941423e-05, -5.095526932796975e-12], [0, 0, 0, 1]])
         c.request_stop()
         c.join()
-
+        self.assertEqual(c.yaw_offset, math.pi)
 
 # vim: expandtab sw=4 ts=4
 


### PR DESCRIPTION
Handle initial non-zero rotation for marsupial robot (the drone has opposite direction, see #729).