### PR TITLE
Fix deployment of breadcrumbs for Explorer R2

### DIFF
--- a/subt/breadcrumbs.py
+++ b/subt/breadcrumbs.py
@@ -19,7 +19,7 @@ class Breadcrumbs(Node):
 
         self.radius = config.get('radius')
         self.locations = [[0, 0, 0]]  # all locations + fake for the base
-        self.num_avail = 6  # Freyja, config 2
+        self.num_avail = config.get('num', 6)  # Freyja, config 2
 
     def should_deploy(self, xyz):
         if self.radius is None:

--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -112,7 +112,11 @@ class main:
                 rospy.loginfo("k2 1 (basic)")
             topics.append(('/' + robot_name + '/odom_fused', Odometry, self.odom_fused, ('pose3d',)))
         elif robot_config.startswith("EXPLORER_R2_SENSOR_CONFIG"):
-            rospy.loginfo("explorer R2")
+            if robot_config.endswith("_2"):
+                rospy.loginfo("explorer R2 #2 (with comms beacons)")
+                publishers['deploy'] = rospy.Publisher('/' + robot_name + '/breadcrumb/deploy', Empty, queue_size=1)
+            else:
+                rospy.loginfo("explorer R2 #1 (basic)")
             topics.append(('/' + robot_name + '/rs_front/color/image/compressed', CompressedImage, self.image_front, ('image_front',)))
             topics.append(('/' + robot_name + '/rs_front/depth/image', Image, self.depth_front, ('depth_front',)))
             topics.append(('/' + robot_name + '/points', PointCloud2, self.points, ('points',)))

--- a/subt/config/r2.json
+++ b/subt/config/r2.json
@@ -119,7 +119,8 @@
           "in": ["sim_time_sec"],
           "out": ["deploy"],
           "init": {
-            "radius": 30
+            "radius": 30,
+            "num": 12
           }
       }
     },

--- a/subt/test_breadcrumbs.py
+++ b/subt/test_breadcrumbs.py
@@ -52,5 +52,13 @@ class BreadcrumbsTest(unittest.TestCase):
 
         self.assertEqual(len(bread.locations), 1 + 6)
 
+    def test_num_available(self):
+        bus = MagicMock()
+        bread = Breadcrumbs(bus=bus, config={'radius':10})
+        self.assertEqual(bread.num_avail, 6)
+
+        bread = Breadcrumbs(bus=bus, config={'radius':10, 'num': 12})
+        self.assertEqual(bread.num_avail, 12)
+
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Explorer R2 config 2 has 12 breadcrumbs. The primary goal was to make marsupial drone working, but the next step is to use the payload.

Reference run is `ver94exbread1tc4`, 5255e55a-121e-4529-939a-3e598823b718.