### PR TITLE
Release OSGAR v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,73 @@
 # Changelog
 
-[Full Changelog](https://github.com/robotika/osgar/compare/v0.2.0...master)
+[Full Changelog](https://github.com/robotika/osgar/compare/v0.3.0...master)
+
+## [v0.3.0](https://github.com/robotika/osgar/tree/v0.3.0) (2020-11-30)
+[Full Changelog](https://github.com/robotika/osgar/compare/v0.2.0...v0.3.0)
+
+**osgar:**
+- Base for SubT Tunnel/Urban/Cave Circuits and Moon project
+- Raise minimum python version to 3.6
+- ZMQRouter - run nodes in separate processes
+- New Bus API
+- Drivers for robots: Kloubak K2, K3, MOBoS, Maria
+- New sensor drivers:
+   - Velodyne driver (#626)
+   - LoRa (Long Range Radio)
+   - RealSense2 (RGBD and Tracking camera)
+   - winsen_gas_detector
+   - LORD IMU 3DM-GX5-25
+   - e-stop for SubT
+   - USB lidar
+   - Peak CAN
+   - vESC driver for experiments with motor controller
+   - usb cameras on chained usb hubs
+   - SICK lidar TIM310
+- osgar.lib.config: allow overrides in dict merging (#612) 
+- osgar.lib.unittest: add custom TestCase (#562) 
+- Upgrade rosmsg to provide multiple devices (#545) 
+- logzeromq 
+   - provide Request/Response option for ROS services (#514)
+   - add conditional log saving based on config['save_data']
+- osgar.bus: track max delay during recording
+- osgar.logger
+   - add walltime to format string
+   - make --times default behavior and --raw change to dump raw data
+   - make --stat default behavior and use --all to dump all streams  
+- osgar.replay: show modules available for replay
+- serialize
+   - add option to store packed data
+   - serialize numpy arrays
+- canserial.py - transition from raw bytes to PCAN triplets [addr, payload, flags]
+- osgar.lib.quaternion support
+- Lazyload drivers
+- Implement ReplayDriver for reprocessing of logfiles
+- Add pyusb into requirements
+- Add opencv to requirements
+- (over 400 master commits related to OSGAR)
+
+**osgar-tools:**
+- Upgrade lidarview
+  - window resizable (#575)
+  - display multiple fields in the title bar (#572)
+  - add --bbox option to draw object bounding box (#464)
+  - add options for lidar limit and window size
+  - fix visual overflow in depth images
+  - save image based on selected camera
+  - draw K3 robot with two joints 
+  - integrated 2nd lidar for Kloubak robots
+  - add parameter --jump to given time
+  - add parameter for optional --title
+  - use numpy and colormap
+  - allow keyframes stream for faster search
+  - support lidar FOV controlled by command line --deg
+  - add Framer (LogIndexedReader based) for faster replay
+- log2video
+  - create mp4 next to source logfile 
+  - add --camera2 option for dual camera setup
+  - add option for horizontal flip (upside down mounted camera)
+  - add option --end-time-sec for video cut
+- strip - added tool logfile size reduction
 
 ## [v0.2.0](https://github.com/robotika/osgar/tree/v0.2.0) (2019-02-07)
 [Full Changelog](https://github.com/robotika/osgar/compare/v0.1.0...v0.2.0)

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="osgar",
-    version="0.2.0",
+    version="0.3.0",
     install_requires=[
           'msgpack>=1.0.0',
       ],


### PR DESCRIPTION
There was no OSGAR release for almost two years (due to other priorities, mainly SubT). The release was requested by @tajgr half year ago and also I need it for another project as a base.

Note, that I picked ~400 commits to master, which are related to OSGAR (majority is SubT, part is Moon) so I could easily overlook some important bits. I was also thinking if we should keep proprietary robot drivers in "core OSAGAR" but we may review it "later" (already OSGAR v0.2.0 supported external drivers in JSON configuration).

p.s. the tag `v0.3.0` does not exists yet, I would create it after merge into master