### PR TITLE
osgar/drivers/logsocket.py - set TCP_NODELAY for static IP

### DIFF
--- a/osgar/drivers/logsocket.py
+++ b/osgar/drivers/logsocket.py
@@ -71,6 +71,7 @@ class LogTCPBase(LogSocket):
     def __init__(self, config, bus):
         soc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         # https://stackoverflow.com/questions/31826762/python-socket-send-immediately
+        # https://stackoverflow.com/questions/3761276/when-should-i-use-tcp-nodelay-and-when-tcp-cork
         soc.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         super().__init__(soc, config, bus)
 

--- a/osgar/drivers/logsocket.py
+++ b/osgar/drivers/logsocket.py
@@ -70,6 +70,8 @@ class LogTCPBase(LogSocket):
     """
     def __init__(self, config, bus):
         soc = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # https://stackoverflow.com/questions/31826762/python-socket-send-immediately
+        soc.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         super().__init__(soc, config, bus)
 
     def _send(self, data):


### PR DESCRIPTION
This is WIP (or rather evaluation in progress) and I would like to check how the OSGAR part should look like - there could be configurable parameter if needed, for example. The motivation is device SICK RFU620 (RFID reader) which talks via TCP, but every reading is triggered by empty (!) packet - a bit strange but confirmed via WireShark and SOPAS tool. OSGAR is getting update ~ 2Hz while SOPAS around 20Hz and my guess is that it is related to this TCP_NODELAY ... but usage is in different repository (for now).
Or should be have it set always as it is in this PR?
thanks
m.