### PR TITLE
Collect and distribute traces for all robots

### DIFF
--- a/subt/config/r2.json
+++ b/subt/config/r2.json
@@ -122,6 +122,12 @@
             "radius": 30,
             "num": 12
           }
+      },
+      "mtm": {
+          "driver": "subt.multitrace:MultiTraceManager",
+          "in": ["robot_xyz", "trace_info", "robot_trace"],
+          "out": ["trace_info", "robot_trace"],
+          "init": {}
       }
     },
     "links": [["app.desired_speed", "rosmsg.desired_speed"],
@@ -161,6 +167,12 @@
               ["radio.radio", "rosmsg.broadcast"],
               ["rosmsg.radio", "radio.radio"],
               ["rosmsg.sim_time_sec", "radio.sim_time_sec"],
+
+              ["radio.robot_xyz", "mtm.robot_xyz"],
+              ["radio.trace_info", "mtm.trace_info"],
+              ["radio.robot_trace", "mtm.robot_trace"],
+              ["mtm.trace_info", "radio.trace_info"],
+              ["mtm.robot_trace", "radio.robot_trace"],
 
               ["rosmsg.sim_time_sec", "breadcrumbs.sim_time_sec"],
               ["localization.pose3d", "breadcrumbs.pose3d"],

--- a/subt/multitrace.py
+++ b/subt/multitrace.py
@@ -1,6 +1,9 @@
 """
   Multi-Trace-Manager for Virtual SubT
 
+The MTM has input "robot_xyz" and publishes overview info of known positions of other robots "trace_info".
+This "trace_info" contains list of time intervals for each known robot. The response is then "robot_trace"
+which is limited in size and contains missing bits of received "trace_info".
 """
 from datetime import timedelta
 

--- a/subt/multitrace.py
+++ b/subt/multitrace.py
@@ -11,6 +11,10 @@ from osgar.lib.serialize import serialize, deserialize
 # Note:
 #  Payload size is limited to 1500 bytes - CommsClient::SendTo()
 
+SIZE_LIMIT = 1000  # just guess, not to reach the limit
+CUT_NUM = 50  # guess how many positions will fit in the limit
+
+
 def get_intervals(seq):
     ret = []
     if len(seq) == 0:
@@ -71,7 +75,12 @@ class MultiTraceManager(Node):
             else:
                 update[name] = positions
         if len(update) > 0:
-            self.publish('robot_trace', update)
+            if len(str(update)) < SIZE_LIMIT:
+                self.publish('robot_trace', update)
+            else:
+                # cut first part for now
+                for name in update:
+                    self.publish('robot_trace', {name : update[name][:CUT_NUM]})
 
     def update(self):
         channel = super().update()  # define self.time

--- a/subt/multitrace.py
+++ b/subt/multitrace.py
@@ -113,6 +113,7 @@ class MultiTraceManager(Node):
         Alternative 3D plot not available via --draw. At the moment the view is very limited
         but it is an example how 3D points can be shown/analyzed.
         """
+        # https://matplotlib.org/mpl_toolkits/mplot3d/tutorial.html
         import matplotlib as mpl
         from mpl_toolkits.mplot3d import Axes3D
         import matplotlib.pyplot as plt

--- a/subt/multitrace.py
+++ b/subt/multitrace.py
@@ -10,6 +10,22 @@ from osgar.lib.serialize import serialize, deserialize
 
 # Note:
 #  Payload size is limited to 1500 bytes - CommsClient::SendTo()
+
+def get_intervals(seq):
+    ret = []
+    if len(seq) == 0:
+        return ret
+    prev = seq[0]
+    start = prev
+    for i in seq[1:]:
+        if prev + 1 != i:
+            ret.append([start, prev])
+            start = i
+        prev = i
+    ret.append([start, prev])
+    return ret
+
+
 class MultiTraceManager(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
@@ -19,7 +35,7 @@ class MultiTraceManager(Node):
     def publish_trace_info(self):
         info = {}
         for name in sorted(self.traces.keys()):
-            info[name] = [p[0] for p in self.traces[name]]
+            info[name] = get_intervals([p[0] for p in self.traces[name]])
         self.publish('trace_info', info)
 
     def on_robot_trace(self, data):

--- a/subt/multitrace.py
+++ b/subt/multitrace.py
@@ -56,12 +56,22 @@ class MultiTraceManager(Node):
         self.publish_trace_info()
 
     def on_trace_info(self, data):
-        needs_update = False
-        for name in self.traces.keys():
-            if name not in data:
-                needs_update = True
-        if needs_update:
-            self.publish('robot_trace', self.traces)
+        update = {}
+        for name, positions in self.traces.items():
+            if name in data:
+                part = []
+                for t, xyz in positions:
+                    for from_index, to_index in data[name]:
+                        if from_index <= t <= to_index:
+                            break
+                    else:
+                        part.append([t, xyz])
+                if len(part) > 0:
+                    update[name] = part
+            else:
+                update[name] = positions
+        if len(update) > 0:
+            self.publish('robot_trace', update)
 
     def update(self):
         channel = super().update()  # define self.time

--- a/subt/multitrace.py
+++ b/subt/multitrace.py
@@ -12,7 +12,7 @@ from osgar.lib.serialize import serialize, deserialize
 #  Payload size is limited to 1500 bytes - CommsClient::SendTo()
 
 SIZE_LIMIT = 1000  # just guess, not to reach the limit
-CUT_NUM = 50  # guess how many positions will fit in the limit
+CUT_NUM = 40  # limit number of positions to fit 1500 bytes limit (50 positions = 1620 bytes)
 
 
 def get_intervals(seq):

--- a/subt/multitrace.py
+++ b/subt/multitrace.py
@@ -23,7 +23,14 @@ class MultiTraceManager(Node):
         self.publish('trace_info', info)
 
     def on_robot_trace(self, data):
-        pass
+        for name, positions in data.items():
+            if name in self.traces:
+                for p in positions:
+                    if p not in self.traces[name]:
+                        self.traces[name].append(p)
+                self.traces[name] = sorted(self.traces[name])
+            else:
+                self.traces[name] = positions
 
     def on_robot_xyz(self, data):
         name, position = data

--- a/subt/multitrace.py
+++ b/subt/multitrace.py
@@ -92,6 +92,17 @@ class MultiTraceManager(Node):
         return channel
 
     def draw(self):
-        pass
+        import matplotlib.pyplot as plt
+        robot_ids = sorted(self.traces)
+        print('Robot IDs', robot_ids)
+
+        for robot_id in robot_ids:
+            x = [a[1][0] for a in self.traces[robot_id]]
+            y = [a[1][1] for a in self.traces[robot_id]]
+            line = plt.plot(x, y, '-o', linewidth=2, label=robot_id)
+
+        plt.axes().set_aspect('equal', 'datalim')
+        plt.legend()
+        plt.show()
 
 # vim: expandtab sw=4 ts=4

--- a/subt/multitrace.py
+++ b/subt/multitrace.py
@@ -1,0 +1,36 @@
+"""
+  Multi-Trace-Manager for Virtual SubT
+
+"""
+from datetime import timedelta
+
+from osgar.node import Node
+from osgar.bus import BusShutdownException
+from osgar.lib.serialize import serialize, deserialize
+
+# Note:
+#  Payload size is limited to 1500 bytes - CommsClient::SendTo()
+class MultiTraceManager(Node):
+    def __init__(self, config, bus):
+        super().__init__(config, bus)
+        bus.register('robot_trace', 'trace_info')
+
+    def on_robot_trace(self, data):
+        pass
+
+    def on_robot_xyz(self, data):
+        pass
+
+    def update(self):
+        channel = super().update()  # define self.time
+        handler = getattr(self, "on_" + channel, None)
+        if handler is not None:
+            handler(getattr(self, channel))
+        else:
+            assert False, channel  # not supported
+        return channel
+
+    def draw(self):
+        pass
+
+# vim: expandtab sw=4 ts=4

--- a/subt/multitrace.py
+++ b/subt/multitrace.py
@@ -108,4 +108,29 @@ class MultiTraceManager(Node):
         plt.legend()
         plt.show()
 
+    def draw3d(self):
+        """
+        Alternative 3D plot not available via --draw. At the moment the view is very limited
+        but it is an example how 3D points can be shown/analyzed.
+        """
+        import matplotlib as mpl
+        from mpl_toolkits.mplot3d import Axes3D
+        import matplotlib.pyplot as plt
+
+        robot_ids = sorted(self.traces)
+        print('Robot IDs', robot_ids)
+
+        mpl.rcParams['legend.fontsize'] = 10
+        fig = plt.figure()
+        ax = fig.gca(projection='3d')
+
+        for robot_id in robot_ids:
+            x = [a[1][0] for a in self.traces[robot_id]]
+            y = [a[1][1] for a in self.traces[robot_id]]
+            z = [a[1][2] for a in self.traces[robot_id]]
+            ax.plot(x, y, z, 'o-', label=robot_id)
+            ax.legend()
+
+        plt.show()
+
 # vim: expandtab sw=4 ts=4

--- a/subt/radio.py
+++ b/subt/radio.py
@@ -75,6 +75,12 @@ class Radio(Node):
     def on_artf(self, data):
         self.send_data('artf', data)
 
+    def on_trace_info(self, data):
+        self.send_data('trace_info', data)
+
+    def on_robot_trace(self, data):
+        self.send_data('robot_trace', data)
+
     def on_sim_time_sec(self, data):
         self.sim_time_sec = data  # duplicate for super().update(), used just for easier unittesting
         self.send_data('sim_time_sec', data)

--- a/subt/radio.py
+++ b/subt/radio.py
@@ -35,7 +35,7 @@ def draw_positions(arr):
 class Radio(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
-        bus.register('radio', 'artf_xyz', 'breadcrumb', 'robot_xyz')
+        bus.register('radio', 'artf_xyz', 'breadcrumb', 'robot_xyz', 'trace_info', 'robot_trace')
         self.min_transmit_dt = 0  # i.e. every sim_time_sec -> every simulated second
         self.last_transmit = None
         self.sim_time_sec = None
@@ -55,7 +55,7 @@ class Radio(Node):
         __, channel, msg_data = deserialize(packet)
         if channel == 'artf':
             self.publish('artf_xyz', msg_data)  # topic rename - beware of limits 1500bytes!
-        elif channel == 'breadcrumb':
+        elif channel in ['breadcrumb', 'trace_info', 'robot_trace']:
             self.publish(channel, msg_data)
         elif channel == 'xyz':
             self.publish('robot_xyz', [name, msg_data])

--- a/subt/test_multitrace.py
+++ b/subt/test_multitrace.py
@@ -17,14 +17,14 @@ class MultiTraceManagerTest(unittest.TestCase):
                          call.publish('trace_info', {'A150L': [[505, 506]]}))
 
         bus.reset_mock()
-        mtm.on_trace_info({'B100R': [1, 10]})
+        mtm.on_trace_info({'B100R': [[1, 10]]})
         bus.publish.assert_called()
         self.assertEqual(bus.method_calls[-1],
                          call.publish('robot_trace', {'A150L': [[505, [6.127597694909277, 2.640278491024048, 1.9188244676330934]],
                                                                 [506, [5.07939188538461, 2.0835104023227147, 1.9305388336683675]]]}))
 
         bus.reset_mock()
-        mtm.on_trace_info({'A150L': [505, 506]})
+        mtm.on_trace_info({'A150L': [[505, 506]]})
         bus.publish.assert_not_called()
 
     def test_on_robot_trace(self):
@@ -48,5 +48,17 @@ class MultiTraceManagerTest(unittest.TestCase):
         self.assertEqual(get_intervals([1, 2, 3, 4]), [[1, 4]])
         self.assertEqual(get_intervals([]), [])
         self.assertEqual(get_intervals([1, 3, 5]), [[1, 1], [3, 3], [5, 5]])
+
+    def test_partial_update(self):
+        bus = MagicMock()
+        mtm = MultiTraceManager(bus=bus, config={})
+        for i in range(10):
+            mtm.on_robot_xyz(['A10L', [i, [2*i, 0, 0]]])
+
+        bus.reset_mock()
+        mtm.on_trace_info({'A10L': [[1, 8]]})
+        bus.publish.assert_called()
+        self.assertEqual(bus.method_calls[-1],
+                         call.publish('robot_trace', {'A10L': [[0, [0, 0, 0]], [9, [18, 0, 0]]]}))
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_multitrace.py
+++ b/subt/test_multitrace.py
@@ -2,7 +2,7 @@
 import unittest
 from unittest.mock import MagicMock, patch, call
 
-from subt.multitrace import MultiTraceManager
+from subt.multitrace import MultiTraceManager, get_intervals
 
 
 class MultiTraceManagerTest(unittest.TestCase):
@@ -14,7 +14,7 @@ class MultiTraceManagerTest(unittest.TestCase):
         mtm.on_robot_xyz(['A150L', [506, [5.07939188538461, 2.0835104023227147, 1.9305388336683675]]])
         bus.publish.assert_called()
         self.assertEqual(bus.method_calls[-1],
-                         call.publish('trace_info', {'A150L': [505, 506]}))
+                         call.publish('trace_info', {'A150L': [[505, 506]]}))
 
         bus.reset_mock()
         mtm.on_trace_info({'B100R': [1, 10]})
@@ -37,5 +37,16 @@ class MultiTraceManagerTest(unittest.TestCase):
         self.assertEqual(len(mtm.traces['A150L']), 3)
         mtm.on_robot_trace({'A150L': [[500, [10.098783014125825, 2.4058896366987415, 2.0341068401239615]]]})
         self.assertEqual(len(mtm.traces['A150L']), 3)
+
+        bus.reset_mock()
+        mtm.publish_trace_info()
+        bus.publish.assert_called()
+        self.assertEqual(bus.method_calls[-1],
+                         call.publish('trace_info', {'A150L': [[500, 500], [505, 506]]}))
+
+    def test_get_intervals(self):
+        self.assertEqual(get_intervals([1, 2, 3, 4]), [[1, 4]])
+        self.assertEqual(get_intervals([]), [])
+        self.assertEqual(get_intervals([1, 3, 5]), [[1, 1], [3, 3], [5, 5]])
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_multitrace.py
+++ b/subt/test_multitrace.py
@@ -1,5 +1,6 @@
 
 import unittest
+from unittest.mock import MagicMock, patch, call
 
 from subt.multitrace import MultiTraceManager
 
@@ -7,7 +8,23 @@ from subt.multitrace import MultiTraceManager
 class MultiTraceManagerTest(unittest.TestCase):
 
     def test_usage(self):
-        pass
+        bus = MagicMock()
+        mtm = MultiTraceManager(bus=bus, config={})
+        mtm.on_robot_xyz(['A150L', [505, [6.127597694909277, 2.640278491024048, 1.9188244676330934]]])
+        mtm.on_robot_xyz(['A150L', [506, [5.07939188538461, 2.0835104023227147, 1.9305388336683675]]])
+        bus.publish.assert_called()
+        self.assertEqual(bus.method_calls[-1],
+                         call.publish('trace_info', {'A150L': [505, 506]}))
 
+        bus.reset_mock()
+        mtm.on_trace_info({'B100R': [1, 10]})
+        bus.publish.assert_called()
+        self.assertEqual(bus.method_calls[-1],
+                         call.publish('robot_trace', {'A150L': [[505, [6.127597694909277, 2.640278491024048, 1.9188244676330934]],
+                                                                [506, [5.07939188538461, 2.0835104023227147, 1.9305388336683675]]]}))
+
+        bus.reset_mock()
+        mtm.on_trace_info({'A150L': [505, 506]})
+        bus.publish.assert_not_called()
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_multitrace.py
+++ b/subt/test_multitrace.py
@@ -1,0 +1,13 @@
+
+import unittest
+
+from subt.multitrace import MultiTraceManager
+
+
+class MultiTraceManagerTest(unittest.TestCase):
+
+    def test_usage(self):
+        pass
+
+
+# vim: expandtab sw=4 ts=4

--- a/subt/test_multitrace.py
+++ b/subt/test_multitrace.py
@@ -61,4 +61,16 @@ class MultiTraceManagerTest(unittest.TestCase):
         self.assertEqual(bus.method_calls[-1],
                          call.publish('robot_trace', {'A10L': [[0, [0, 0, 0]], [9, [18, 0, 0]]]}))
 
+    def test_too_large_update(self):
+        bus = MagicMock()
+        mtm = MultiTraceManager(bus=bus, config={})
+        for i in range(1000):
+            mtm.on_robot_xyz(['A10L', [i, [2*i, 0, 0]]])
+
+        bus.reset_mock()
+        mtm.on_trace_info({'B10R': [[1, 8]]})
+        bus.publish.assert_called()
+        # AssertionError: 20362 not less than 1000
+        self.assertLess(len(str(bus.method_calls[-1][1])), 1000)
+
 # vim: expandtab sw=4 ts=4

--- a/subt/test_multitrace.py
+++ b/subt/test_multitrace.py
@@ -27,4 +27,15 @@ class MultiTraceManagerTest(unittest.TestCase):
         mtm.on_trace_info({'A150L': [505, 506]})
         bus.publish.assert_not_called()
 
+    def test_on_robot_trace(self):
+        bus = MagicMock()
+        mtm = MultiTraceManager(bus=bus, config={})
+        mtm.on_robot_trace({'A150L': [[505, [6.127597694909277, 2.640278491024048, 1.9188244676330934]],
+                                      [506, [5.07939188538461, 2.0835104023227147, 1.9305388336683675]]]})
+        self.assertIn('A150L', mtm.traces)
+        mtm.on_robot_trace({'A150L': [[500, [10.098783014125825, 2.4058896366987415, 2.0341068401239615]]]})
+        self.assertEqual(len(mtm.traces['A150L']), 3)
+        mtm.on_robot_trace({'A150L': [[500, [10.098783014125825, 2.4058896366987415, 2.0341068401239615]]]})
+        self.assertEqual(len(mtm.traces['A150L']), 3)
+
 # vim: expandtab sw=4 ts=4

--- a/subt/zmq-subt-teambase.json
+++ b/subt/zmq-subt-teambase.json
@@ -47,6 +47,12 @@
           "in": ["radio", "pose3d", "artf", "sim_time_sec"],
           "out": ["radio", "artf_xyz"],
           "init": {}
+      },
+      "mtm": {
+          "driver": "subt.multitrace:MultiTraceManager",
+          "in": ["robot_xyz", "trace_info", "robot_trace"],
+          "out": ["trace_info", "robot_trace"],
+          "init": {}
       }
     },
     "links": [["app.stdout", "rosmsg.stdout"],
@@ -61,6 +67,12 @@
               ["radio.artf_xyz", "app.artf_xyz"],
               ["radio.robot_xyz", "app.robot_xyz"],
               ["radio.radio", "rosmsg.broadcast"],
+
+              ["radio.robot_xyz", "mtm.robot_xyz"],
+              ["radio.trace_info", "mtm.trace_info"],
+              ["radio.robot_trace", "mtm.robot_trace"],
+              ["mtm.trace_info", "radio.trace_info"],
+              ["mtm.robot_trace", "radio.robot_trace"],
 
               ["app.artf_xyz", "reporter.artf_xyz"],
               ["reporter.artf_cmd", "transmitter.raw"]]

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -102,6 +102,12 @@
       },
       "offseter": {
         "driver": "subt.offseter:Offseter"
+      },
+      "mtm": {
+          "driver": "subt.multitrace:MultiTraceManager",
+          "in": ["robot_xyz", "trace_info", "robot_trace"],
+          "out": ["trace_info", "robot_trace"],
+          "init": {}
       }
     },
     "links": [["app.desired_speed", "rosmsg.desired_speed"],
@@ -144,6 +150,12 @@
               ["radio.radio", "rosmsg.broadcast"],
               ["rosmsg.radio", "radio.radio"],
               ["rosmsg.sim_time_sec", "radio.sim_time_sec"],
+
+              ["radio.robot_xyz", "mtm.robot_xyz"],
+              ["radio.trace_info", "mtm.trace_info"],
+              ["radio.robot_trace", "mtm.robot_trace"],
+              ["mtm.trace_info", "radio.trace_info"],
+              ["mtm.robot_trace", "radio.robot_trace"],
 
               ["rosmsg.sim_time_sec", "breadcrumbs.sim_time_sec"],
               ["offseter.pose3d", "breadcrumbs.pose3d"],

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -125,6 +125,12 @@
           "out": ["detach"],
           "init": {
           }
+      },
+      "mtm": {
+          "driver": "subt.multitrace:MultiTraceManager",
+          "in": ["robot_xyz", "trace_info", "robot_trace"],
+          "out": ["trace_info", "robot_trace"],
+          "init": {}
       }
     },
     "links": [["app.desired_speed", "drone.desired_speed"],
@@ -165,6 +171,12 @@
               ["radio.radio", "rosmsg.broadcast"],
               ["rosmsg.radio", "radio.radio"],
               ["rosmsg.sim_time_sec", "radio.sim_time_sec"],
+
+              ["radio.robot_xyz", "mtm.robot_xyz"],
+              ["radio.trace_info", "mtm.trace_info"],
+              ["radio.robot_trace", "mtm.robot_trace"],
+              ["mtm.trace_info", "radio.trace_info"],
+              ["mtm.robot_trace", "radio.robot_trace"],
 
               ["rosmsg.sim_time_sec", "marsupial.sim_time_sec"],
               ["rosmsg.origin", "marsupial.origin"],


### PR DESCRIPTION
This is the first PR necessary for coordinated exploration/navigation. The position of all robots is shared and broadcasted "on demand". The MTM (Multi Trace Manager) publishes "trace_info", which is just overview of known robots and time intervals. If there are some missing bits then MTM publishes "robot_trace" with positions of all robots. Note, that due to limited packet size (1500bytes) the extra large messages are cut into smaller ones if necessary. See reference run "ver95mtm3ts2" with drone and Teambase (`178838c4-3122-4a16-b71a-1cecbc824927`).

Visibility from Teambase:
`python -m osgar.replay --module app logs\aws\tunnel\TS2\ver95mtm3\T\T400.log --verbose --draw`
![mtm-before](https://user-images.githubusercontent.com/5664353/102657880-c3b07580-4176-11eb-8b61-86bd8a4b0fa2.png)
and data received on teambase via MTM
`python -m osgar.replay --module mtm logs\aws\tunnel\TS2\ver95mtm3\T\T400.log --verbose --draw`
![mtm-after](https://user-images.githubusercontent.com/5664353/102657927-d7f47280-4176-11eb-98a7-5169689ae214.png)

The primary application is to share shortest return home, but alternative example is _Simple Tunnel 3_ where the drone could warn UGV that there is a drop (or the UGV/Freyja could autodetect it from the trace) - `ver95mtm4ts3` fd38317f-522c-488f-956f-74cf374cef86
![ver95mtm4tc3](https://user-images.githubusercontent.com/5664353/102688771-33674480-41f9-11eb-877a-05b6af2917fc.png)
(info from Teambase, but Freyja/G200L has similar data)
