### PR TITLE
Adapt to 3D lidar VLP-16 resolution change

### DIFF
--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -269,12 +269,12 @@ class main:
     def convert_points(self, msg):
         # accept only Velodyne VLC-16 (for the ver0)
         assert msg.height == 16, msg.height
-        assert msg.width == 10000, msg.width
+        assert msg.width == 1000, msg.width
         assert msg.point_step == 32, msg.point_step
-        assert msg.row_step == 320000, msg.row_step
+        assert msg.row_step == 32000, msg.row_step
         arr = np.frombuffer(msg.data, dtype=np.float32)
         points3d = arr.reshape((msg.height, msg.width, 8))[:, :, 0:3]  # keep only (x, y, z)
-        return points3d[:, ::10, :]  # downsample to everh 10th
+        return points3d
 
     def points(self, msg):
         self.points_count += 1

--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -269,9 +269,9 @@ class main:
     def convert_points(self, msg):
         # accept only Velodyne VLC-16 (for the ver0)
         assert msg.height == 16, msg.height
-        assert msg.width == 1000, msg.width
+        assert msg.width == 1800, msg.width
         assert msg.point_step == 32, msg.point_step
-        assert msg.row_step == 32000, msg.row_step
+        assert msg.row_step == 57600, msg.row_step
         arr = np.frombuffer(msg.data, dtype=np.float32)
         points3d = arr.reshape((msg.height, msg.width, 8))[:, :, 0:3]  # keep only (x, y, z)
         return points3d

--- a/subt/main.py
+++ b/subt/main.py
@@ -911,7 +911,7 @@ class SubTChallenge:
         self.stdout('Final xyz (DARPA coord system):', self.xyz)
 
     def play_virtual_track(self):
-        self.stdout("SubT Challenge Ver96!")
+        self.stdout("SubT Challenge Ver97!")
         self.stdout("Waiting for robot_name ...")
         while self.robot_name is None:
             self.update()

--- a/subt/points2scan.py
+++ b/subt/points2scan.py
@@ -17,9 +17,9 @@ class PointsToScan(Node):
         self.debug_arr = []
 
     def on_points(self, data):
-        assert data.shape == (16, 1000, 3), data.shape
+        assert data.shape == (16, 1800, 3), data.shape
         self.debug_arr = data
-        index = (np.arange(360) * (1000/360)).astype(int)
+        index = (np.arange(360) * (1800/360)).astype(int)
         xyz = data[8][index]  # mid index for 16 lidars
         X, Y, Z = xyz[:, 0], xyz[:, 1], xyz[:, 2]
         dist_i = (np.hypot(X, Y) * 1000).astype(int)

--- a/subt/test_points2scan.py
+++ b/subt/test_points2scan.py
@@ -13,8 +13,7 @@ class PointsToScanTest(unittest.TestCase):
         bus = MagicMock()
         conv = PointsToScan(bus=bus, config={})
 
-        orig_data = np.zeros((16, 10000, 3), dtype=np.float32)
-        data = orig_data[:, ::10, :]  # downsample to everh 10th
+        data = np.zeros((16, 1800, 3), dtype=np.float32)
         conv.on_points(data)
         bus.publish.assert_called()
 


### PR DESCRIPTION
Since release 2021-01-21 the 3D lidar has realistic resolution 1800pts running at 10Hz (instead of 10000 at 15Hz).