### PR TITLE
Reduce ROS bag limit size to 2GB

### DIFF
--- a/subt/main.py
+++ b/subt/main.py
@@ -911,7 +911,7 @@ class SubTChallenge:
         self.stdout('Final xyz (DARPA coord system):', self.xyz)
 
     def play_virtual_track(self):
-        self.stdout("SubT Challenge Ver98!")
+        self.stdout("SubT Challenge Ver99!")
         self.stdout("Waiting for robot_name ...")
         while self.robot_name is None:
             self.update()

--- a/subt/ros/proxy/sendlog.py
+++ b/subt/ros/proxy/sendlog.py
@@ -7,7 +7,7 @@ import time
 import rospy
 import std_msgs.msg
 
-ROSBAG_SIZE_LIMIT = 3000000000  #3GB
+ROSBAG_SIZE_LIMIT = 2 * 1048576000  # 2GB
 
 
 def main(*args):


### PR DESCRIPTION
SubT changed limit to original 2GB specified in WiKi. According to already recorded files in final qualification world the cut sizes are limited by 1024*1024 * 1000(?) = 1_048_576_000
```
robot_data_9b58abce-64c0-4405-bc27-0e8613bc96df_A600LXM_1.bag	1 048 783 731	04.03.2021 09:03	-a--
robot_data_9b58abce-64c0-4405-bc27-0e8613bc96df_A600LXM_2.bag	913 934 750	04.03.2021 11:01	-a--

robot_data_9b58abce-64c0-4405-bc27-0e8613bc96df_B600RXM_0.bag	1 048 744 643	04.03.2021 09:42	-a--
robot_data_9b58abce-64c0-4405-bc27-0e8613bc96df_B600RXM_1.bag.active	49 672 192	04.03.2021 11:01	-a--
```