### PR TITLE
Second attempt to fix lost of log files due to 2GB limit overflow

### DIFF
--- a/subt/ros/proxy/sendlog.py
+++ b/subt/ros/proxy/sendlog.py
@@ -7,7 +7,7 @@ import time
 import rospy
 import std_msgs.msg
 
-ROSBAG_SIZE_LIMIT = 2 * 1048576000  # 2GB
+ROSBAG_SIZE_LIMIT = 2000000000  # 2GB
 
 
 def main(*args):


### PR DESCRIPTION
Well, it is running probably in parallel and "does not stop in time" :(
```
robot_data_072efe38-1ac8-42a5-9e96-b923f9b17c9c_B10W1800R_1.bag	1 048 818 864	04.03.2021 19:18	-a--
robot_data_072efe38-1ac8-42a5-9e96-b923f9b17c9c_B10W1800R_2.bag.active	11 859 394	04.03.2021 19:19	-a--
```
so I would drop these extra 2x 48MB :( 