### PR TITLE
Add qualification worlds to run and submit tools

### DIFF
--- a/subt/script/bridge.bash
+++ b/subt/script/bridge.bash
@@ -14,6 +14,8 @@ case $WORLD in
     CIRCUIT="cave"; ;;
  *"tunnel"*):
     CIRCUIT="tunnel" ;;
+ *"finals"*):
+    CIRCUIT="finals" ;;
  *):
     echo "circuit not detected";
     exit 1;;

--- a/subt/script/sim.bash
+++ b/subt/script/sim.bash
@@ -12,6 +12,8 @@ case $WORLD in
     CIRCUIT="cave"; ;;
  *"tunnel"*):
     CIRCUIT="tunnel" ;;
+ *"finals"*):
+    CIRCUIT="finals" ;;
  *):
     echo "circuit not detected";
     exit 1;;

--- a/subt/submission/two-freyjas.toml
+++ b/subt/submission/two-freyjas.toml
@@ -1,0 +1,8 @@
+world = "uc1"
+timeout = 2000
+image = "ver99rev2"
+
+[robots]
+A900LXM = "freyja"
+B900RXM = "freyja"
+

--- a/subt/tools/run.py
+++ b/subt/tools/run.py
@@ -14,8 +14,8 @@ import toml
 
 from pprint import pprint
 
-WORLDS=dict(
-    #TUNNEL
+WORLDS = dict(
+    # TUNNEL
     tq  = "tunnel_qual_ign",
     ts1 = "simple_tunnel_01",
     ts2 = "simple_tunnel_02",
@@ -46,7 +46,7 @@ WORLDS=dict(
     uc7 = "urban_circuit_07",
     uc8 = "urban_circuit_08",
 
-    #CAVE
+    # CAVE
     cq  = "cave_qual",
     cs1 = "simple_cave_01",
     cs2 = "simple_cave_02",
@@ -54,6 +54,9 @@ WORLDS=dict(
     cp1 = "cave_circuit_practice_01",
     cp2 = "cave_circuit_practice_02",
     cp3 = "cave_circuit_practice_03",
+
+    # FINALS
+    fq="finals_qual",
 )
 
 ROBOTS=dict(
@@ -96,7 +99,7 @@ def validate_image(client, image):
 
 
 def validate_circuit(world):
-    for c in "tunnel", "urban", "cave":
+    for c in "tunnel", "urban", "cave", "finals":
         if c in world:
             return c
     sys.exit(f"autodetection of circuit failed for world {world}")

--- a/subt/tools/submit.py
+++ b/subt/tools/submit.py
@@ -133,7 +133,7 @@ def submit(token, simname, image, world, robots, dont_submit):
         'Private-Token': token
     }
 
-    req = requests.Request('POST', url="https://cloudsim.ignitionrobotics.org/1.0/simulations", files=data,
+    req = requests.Request('POST', url="https://cloudsim.subtchallenge.world/1.0/simulations", files=data,
                            headers=headers).prepare()
 
     if dont_submit:

--- a/subt/tools/submit.py
+++ b/subt/tools/submit.py
@@ -9,7 +9,8 @@ import pathlib
 import toml
 
 # See https://pkg.go.dev/gitlab.com/ignitionrobotics/web/cloudsim/simulations for original names
-WORLDS=dict(
+WORLDS = dict(
+    tq  = "Tunnel Qualification",
     tp1 = "Tunnel Practice 1",
     tp2 = "Tunnel Practice 2",
     tp3 = "Tunnel Practice 3",
@@ -22,6 +23,7 @@ WORLDS=dict(
     tc7 = "Tunnel Circuit World 7",
     tc8 = "Tunnel Circuit World 8",
 
+    uq  = "Urban Qualification",
     up1 = "Urban Practice 1",
     up2 = "Urban Practice 2",
     up3 = "Urban Practice 3",
@@ -50,6 +52,8 @@ WORLDS=dict(
     cc6 = "Cave Circuit World 6",
     cc7 = "Cave Circuit World 7",
     cc8 = "Cave Circuit World 8",
+
+    fq = "Finals Qualification",
 )
 
 ROBOTS=dict(
@@ -87,7 +91,7 @@ def validate_image(image):
     images = _cmd('aws', 'ecr', 'list-images', '--repository-name', 'subt/robotika', '--output', 'json')
     for img in json.loads(images)["imageIds"]:
         if img.get('imageTag') == image:
-            return f'200670743174.dkr.ecr.us-east-1.amazonaws.com/subt/robotika:{image}'
+            return f'138467776890.dkr.ecr.us-east-1.amazonaws.com/subt/robotika:{image}'
     sys.exit(f"image '{image}' not found in aws subt/robotika repository")
 
 


### PR DESCRIPTION
I tried to set it up on my new laptop, but I am doing something wrong, i.e. the changes are not properly tested yet :(. There is also change of AWS zone necessary for finals.

```
(osgar) md@md-ThinkPad-P50:~/git/osgar/subt/docker$ python -m subt.tools.submit ../submission/two-freyjas.toml 
world:   Urban Circuit World 1
image:   138467776890.dkr.ecr.us-east-1.amazonaws.com/subt/robotika:ver99rev2
simname: ver99rev2uc1r1
robots:  
     A900LXM: ROBOTIKA_FREYJA_SENSOR_CONFIG_2
     B900RXM: ROBOTIKA_FREYJA_SENSOR_CONFIG_2
       T2000: TEAMBASE
Traceback (most recent call last):
  File "/home/md/.virtualenvs/osgar/lib/python3.8/site-packages/urllib3/connection.py", line 159, in _new_conn
    conn = connection.create_connection(
  File "/home/md/.virtualenvs/osgar/lib/python3.8/site-packages/urllib3/util/connection.py", line 61, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
  File "/usr/lib/python3.8/socket.py", line 918, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
socket.gaierror: [Errno -5] No address associated with hostname

During handling of the above exception, another exception occurred:
```