### PR TITLE
Plan safer route in octomap

### DIFF
--- a/subt/main.py
+++ b/subt/main.py
@@ -293,7 +293,7 @@ class SubTChallenge:
                     tmp_trace.trace = self.waypoints
                     self.waypoints = None
                     tmp_trace.reverse()
-                    self.follow_trace(tmp_trace, timeout=timedelta(minutes=10))  # hmm, external parameter?
+                    self.follow_trace(tmp_trace, timeout=timedelta(seconds=10), max_target_distance=2)  # hmm, external parameter?
                     continue
 
                 if (channel == 'scan' and not self.flipped) or (channel == 'scan_back' and self.flipped) or channel == 'scan360':

--- a/subt/octomap.py
+++ b/subt/octomap.py
@@ -222,7 +222,7 @@ class Octomap(Node):
     def on_octomap(self, data):
         if self.sim_time_sec is None or self.pose3d is None or self.sim_time_sec < self.time_limit_sec:
             return
-        self.time_limit_sec += 15  # simulated seconds
+        self.time_limit_sec += 5  # simulated seconds
 
         # bit unlucky conversion from existing Python2 data
         assert len(data) % 2 == 0, len(data)

--- a/subt/octomap.py
+++ b/subt/octomap.py
@@ -173,9 +173,14 @@ def frontiers(img, start, draw=False):
     # note, that the "safe path" does not touch external boundary so it would never find path
     # to frontier. As a workaround add also all 8-neighbors of frontiers.
     goals = []
+    xy = np.array(xy)[:, score > limit_score]
     for dx in [-1, 0, 1]:
         for dy in [-1, 0, 1]:
-            goals.extend([(xy[1][i] + dx, xy[0][i] + dy) for i in range(len(xy[0])) if score[i] > limit_score])
+            goals.append(xy + np.repeat(np.asarray([[dy], [dx]]), xy.shape[1], axis=1))
+    goals = np.hstack(goals).T[:, ::-1]
+
+    # the path planner currently expects goals as tuple (x, y) and operation "in"
+    goals = set(map(tuple, goals))
     path = find_path(drivable, start, goals, verbose=False)
 
     img[mask, 0] = 255  # pink

--- a/subt/octomap.py
+++ b/subt/octomap.py
@@ -155,10 +155,20 @@ def frontiers(img, start, draw=False):
         plt.show()
 
     driveable = white[:1023, :1023] | white[1:, :1023] | white[1:, 1:] | white[:1023, 1:]
+
+    # use 1 pixel surounding
+    d = driveable[:, :]
+    d2 = d[1:, :] & d[:-1, :]
+    d3 = d2[:, 1:] & d2[:, :-1]
+    z = np.zeros((1022, 1), dtype=np.bool)
+    d = np.hstack([z, d3, z])
+    z = np.zeros((1, 1024), dtype=np.bool)
+    driveable = np.vstack([z, d, z])
+
     i = np.argmax(score)
     limit_score = 3*max(score)/4
     goals = [(xy[1][i], xy[0][i]) for i in range(len(xy[0])) if score[i] > limit_score]
-    path = find_path(driveable, start, goals, verbose=False)
+    path = find_path(driveable[1:, 1:], start, goals, verbose=False)
 
     img[mask, 0] = 255  # pink
     img[mask, 1] = 0


### PR DESCRIPTION
This is follow up of #772 where the image slide is optimized for computation (and not for nicer picture). The box/voxel black borders are removed and now 1024x1024 pixel image covers 512m (still 0.5m resolution).

This is exploration in Finals Qualification for 5 minutes and return home.
![state tlog-cut](https://user-images.githubusercontent.com/5664353/111187393-3b464300-85b4-11eb-8503-14116d64e0e7.png)
