### PR TITLE
Remove duplicity streams for Freyja and K2

### DIFF
--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -117,6 +117,12 @@ class main:
             else:
                 rospy.loginfo("k2 1 (basic)")
             topics.append(('/' + robot_name + '/odom_fused', Odometry, self.odom_fused, ('pose3d',)))
+            topics.append(('/' + robot_name + '/rgbd_front/image_raw/compressed', CompressedImage, self.image_front, ('image_front',)))
+            topics.append(('/' + robot_name + '/rgbd_rear/image_raw/compressed', CompressedImage, self.image_rear, ('image_rear',)))
+            topics.append(('/' + robot_name + '/front_scan', LaserScan, self.scan_front, ('scan_front',)))
+            topics.append(('/' + robot_name + '/rear_scan', LaserScan, self.scan_rear, ('scan_rear',)))
+            topics.append(('/' + robot_name + '/rgbd_front/depth', Image, self.depth_front, ('depth_front',)))
+            topics.append(('/' + robot_name + '/rgbd_rear/depth', Image, self.depth_rear, ('depth_rear',)))
         elif robot_config.startswith("EXPLORER_R2_SENSOR_CONFIG"):
             if robot_config.endswith("_2"):
                 rospy.loginfo("explorer R2 #2 (with comms beacons)")

--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -119,8 +119,8 @@ class main:
             topics.append(('/' + robot_name + '/odom_fused', Odometry, self.odom_fused, ('pose3d',)))
             topics.append(('/' + robot_name + '/rgbd_front/image_raw/compressed', CompressedImage, self.image_front, ('image_front',)))
             topics.append(('/' + robot_name + '/rgbd_rear/image_raw/compressed', CompressedImage, self.image_rear, ('image_rear',)))
-            topics.append(('/' + robot_name + '/front_scan', LaserScan, self.scan_front, ('scan_front',)))
-            topics.append(('/' + robot_name + '/rear_scan', LaserScan, self.scan_rear, ('scan_rear',)))
+            topics.append(('/' + robot_name + '/scan_front', LaserScan, self.scan_front, ('scan_front',)))
+            topics.append(('/' + robot_name + '/scan_rear', LaserScan, self.scan_rear, ('scan_rear',)))
             topics.append(('/' + robot_name + '/rgbd_front/depth', Image, self.depth_front, ('depth_front',)))
             topics.append(('/' + robot_name + '/rgbd_rear/depth', Image, self.depth_rear, ('depth_rear',)))
         elif robot_config.startswith("EXPLORER_R2_SENSOR_CONFIG"):

--- a/subt/ros/proxy/ros_proxy_node.cc
+++ b/subt/ros/proxy/ros_proxy_node.cc
@@ -305,10 +305,6 @@ Controller::Controller(const std::string &_name)
   ros::service::waitForService("/subt/start", -1);
   ros::service::waitForService("/subt/pose_from_artifact_origin", -1);
 
-  ROS_INFO_STREAM("Sleeping 1 simulated second to let simulation start up");
-  ros::Duration(1).sleep();
-  ROS_INFO_STREAM("Simulation hopefully up and running");
-
   this->updateTimer = this->n.createTimer(ros::Duration(0.05), &Controller::Update, this);
   this->m_receiveZmq = std::thread(Controller::receiveZmqThread, this);
 }

--- a/subt/ros/proxy/ros_proxy_node.cc
+++ b/subt/ros/proxy/ros_proxy_node.cc
@@ -305,10 +305,6 @@ Controller::Controller(const std::string &_name)
   ros::service::waitForService("/subt/start", -1);
   ros::service::waitForService("/subt/pose_from_artifact_origin", -1);
 
-  // Waiting from some message related to robot so that we know the robot is already in the simulation
-  ROS_INFO_STREAM("Waiting for " << this->name << "/front/depth");
-  ros::topic::waitForMessage<sensor_msgs::Image>(this->name + "/front/depth", this->n);
-
   ROS_INFO_STREAM("Sleeping 1 simulated second to let simulation start up");
   ros::Duration(1).sleep();
   ROS_INFO_STREAM("Simulation hopefully up and running");

--- a/subt/ros/robot/launch/freyja.launch
+++ b/subt/ros/robot/launch/freyja.launch
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <launch>
   <node name="$(arg robot_name)_proxy" pkg="proxy" type="ros_proxy" args="$(arg robot_name)">
-    <remap from="$(arg robot_name)/front_scan" to="$(arg robot_name)/scan_front"/>
-    <remap from="$(arg robot_name)/image_raw/compressed" to="$(arg robot_name)/rgbd_front/image_raw/compressed"/>
-    <remap from="$(arg robot_name)/front/depth" to="$(arg robot_name)/rgbd_front/depth"/>
-    <remap from="$(arg robot_name)/points" to="$(arg robot_name)/rgbd_front/points"/>
+    <remap from="$(arg robot_name)/front_scan" to="$(arg robot_name)/nonexistent_scan_front"/>
+    <remap from="$(arg robot_name)/image_raw/compressed" to="$(arg robot_name)/nonexistent_rgbd_front/image_raw/compressed"/>
+    <remap from="$(arg robot_name)/front/depth" to="$(arg robot_name)/nonexistent_rgbd_front/depth"/>
+    <remap from="$(arg robot_name)/points" to="$(arg robot_name)/nonexistent_rgbd_front/points"/>
   </node>
 
   <!-- Combining front RGBD depth and image data into a single message. -->

--- a/subt/ros/robot/launch/k2-virt.launch
+++ b/subt/ros/robot/launch/k2-virt.launch
@@ -8,10 +8,10 @@
   </node>
 
   <node name="$(arg robot_name)_proxy" pkg="proxy" type="ros_proxy" args="$(arg robot_name)" output="screen">
-    <remap from="$(arg robot_name)/front_scan" to="$(arg robot_name)/scan_front"/>
-    <remap from="$(arg robot_name)/image_raw/compressed" to="$(arg robot_name)/rgbd_front/image_raw/compressed"/>
-    <remap from="$(arg robot_name)/front/depth" to="$(arg robot_name)/rgbd_front/depth"/>
-    <remap from="$(arg robot_name)/points" to="$(arg robot_name)/rgbd_front/points"/>
+    <remap from="$(arg robot_name)/front_scan" to="$(arg robot_name)/nonexistent_scan_front"/>
+    <remap from="$(arg robot_name)/image_raw/compressed" to="$(arg robot_name)/nonexistent_rgbd_front/image_raw/compressed"/>
+    <remap from="$(arg robot_name)/front/depth" to="$(arg robot_name)/nonexistent_rgbd_front/depth"/>
+    <remap from="$(arg robot_name)/points" to="$(arg robot_name)/nonexistent_rgbd_front/points"/>
   </node>
 
   <!-- ICP Odometry based on front planar lidar -->

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -130,8 +130,8 @@
               ["fromrospy.rot", "depth2scan.rot"],
               ["fromrospy.acc", "app.acc"],
 
-              ["rosmsg.scan", "detector.scan"],
-              ["rosmsg.scan", "depth2scan.scan"],
+              ["fromrospy.scan_front", "detector.scan"],
+              ["fromrospy.scan_front", "depth2scan.scan"],
 
               ["fromrospy.image_front", "detector.image"],
               ["fromrospy.image_front", "app.image"],

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -133,12 +133,12 @@
               ["rosmsg.scan", "detector.scan"],
               ["rosmsg.scan", "depth2scan.scan"],
 
-              ["rosmsg.image", "detector.image"],
-              ["rosmsg.image", "app.image"],
+              ["fromrospy.image_front", "detector.image"],
+              ["fromrospy.image_front", "app.image"],
 
-              ["rosmsg.depth", "depth2scan.depth"],
+              ["fromrospy.depth_front", "depth2scan.depth"],
               ["depth2scan.scan", "app.scan"],
-              ["rosmsg.depth", "detector.depth"],
+              ["fromrospy.depth_front", "detector.depth"],
 
               ["offseter.pose3d", "app.pose3d"],
               ["rosmsg.sim_time_sec", "app.sim_time_sec"],


### PR DESCRIPTION
This is the first part of refactoring of rosmsg -> cloudsim2osgar. Removed wait for `depth` from rosproxy and relinked configs for Freyja and Kloubak K2 (X2 is no longer supported).