### PR TITLE
Reduce size of logs with RGBD data

### DIFF
--- a/subt/image_extractor.py
+++ b/subt/image_extractor.py
@@ -1,0 +1,37 @@
+"""
+  Extract image from RGBD + robot/camera pose bundle
+"""
+import math
+
+import cv2
+import numpy as np
+
+from osgar.node import Node
+from osgar.bus import BusShutdownException
+from osgar.lib.depth import decompress as decompress_depth
+
+
+class ImageExtractor(Node):
+    def __init__(self, config, bus):
+        super().__init__(config, bus)
+        bus.register("image", "depth:gz")
+
+    def on_rgbd(self, data):
+        robot_pose, camera_pose, rgb_compressed, depth_compressed = data
+        self.publish('image', rgb_compressed)
+
+        arr = decompress_depth(depth_compressed) * 1000
+        arr = np.clip(arr, 1, 0xFFFF)
+        arr = np.ndarray.astype(arr, dtype=np.dtype('H'))
+        self.publish('depth', arr)
+
+    def update(self):
+        channel = super().update()
+        handler = getattr(self, "on_" + channel, None)
+        if handler is not None:
+            handler(getattr(self, channel))
+        else:
+            assert False, channel  # unsupported channel
+        return channel
+
+# vim: expandtab sw=4 ts=4

--- a/subt/script/virtual-depth-view.bat
+++ b/subt/script/virtual-depth-view.bat
@@ -1,1 +1,1 @@
-python -m osgar.tools.lidarview --pose2d app.pose2d --lidar depth2scan.scan --rgbd fromrospy.rgbd_front --camera2 rosmsg.depth --keyframes detector.localized_artf --title rosmsg.sim_time_sec %*
+python -m osgar.tools.lidarview --pose2d app.pose2d --lidar depth2scan.scan --camera logimage.image --camera2 logimage.depth --keyframes detector.localized_artf --title rosmsg.sim_time_sec %*

--- a/subt/script/virtual-depth-view.bat
+++ b/subt/script/virtual-depth-view.bat
@@ -1,1 +1,1 @@
-python -m osgar.tools.lidarview --pose2d app.pose2d --lidar depth2scan.scan --camera rosmsg.image --camera2 rosmsg.depth --keyframes detector.artf --title rosmsg.sim_time_sec %*
+python -m osgar.tools.lidarview --pose2d app.pose2d --lidar depth2scan.scan --rgbd fromrospy.rgbd_front --camera2 rosmsg.depth --keyframes detector.localized_artf --title rosmsg.sim_time_sec %*

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -87,6 +87,11 @@
       "torospy": {
           "driver": "subt.push:Push"
       },
+      "logimage": {
+          "driver": "subt.image_extractor:ImageExtractor",
+          "in": ["rgbd"],
+          "out": ["image", "depth"]
+      },
       "radio": {
           "driver": "subt.radio:Radio",
           "in": ["radio", "pose3d", "artf", "sim_time_sec"],
@@ -171,7 +176,9 @@
 
               ["fromrospy.octomap", "octomap.octomap"],
               ["fromrospy.pose3d", "octomap.pose3d"],
-              ["octomap.waypoints", "app.waypoints"]
+              ["octomap.waypoints", "app.waypoints"],
+
+              ["fromrospy.rgbd_front", "logimage.rgbd"]
     ]
   }
 }

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -90,7 +90,18 @@
       "logimage": {
           "driver": "subt.image_extractor:ImageExtractor",
           "in": ["rgbd"],
-          "out": ["image", "depth"]
+          "out": ["image", "depth"],
+          "init": {
+            "image_sampling": 3
+          }
+      },
+      "logimage_rear": {
+          "driver": "subt.image_extractor:ImageExtractor",
+          "in": ["rgbd"],
+          "out": ["image", "depth"],
+          "init": {
+            "image_sampling": 10
+          }
       },
       "radio": {
           "driver": "subt.radio:Radio",
@@ -178,7 +189,8 @@
               ["fromrospy.pose3d", "octomap.pose3d"],
               ["octomap.waypoints", "app.waypoints"],
 
-              ["fromrospy.rgbd_front", "logimage.rgbd"]
+              ["fromrospy.rgbd_front", "logimage.rgbd"],
+              ["fromrospy.rgbd_rear", "logimage_rear.rgbd"]
     ]
   }
 }

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -80,7 +80,7 @@
           "driver": "subt.pull:Pull",
           "init": {
             "outputs": ["rot", "acc", "orientation", "battery_state", "score", "pose3d",
-                        "scan_front", "scan_rear", "rgbd_front", "rgbd_rear", "origin",
+                        "scan_front", "scan_rear", "rgbd_front:null", "rgbd_rear:null", "origin",
                         "octomap:gz"]
           }
       },

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -110,6 +110,11 @@
       "torospy": {
           "driver": "subt.push:Push"
       },
+      "logimage": {
+          "driver": "subt.image_extractor:ImageExtractor",
+          "in": ["rgbd"],
+          "out": ["image", "depth"]
+      },
       "radio": {
           "driver": "subt.radio:Radio",
           "in": ["radio", "pose3d", "artf", "sim_time_sec"],
@@ -197,7 +202,9 @@
 
               ["fromrospy.octomap", "octomap.octomap"],
               ["fromrospy.pose3d", "octomap.pose3d"],
-              ["octomap.waypoints", "app.waypoints"]
+              ["octomap.waypoints", "app.waypoints"],
+
+              ["fromrospy.rgbd_front", "logimage.rgbd"]
     ]
   }
 }

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -104,7 +104,7 @@
           "driver": "subt.pull:Pull",
 	      "init": {
 	        "outputs": ["rot", "acc", "orientation", "top_scan", "bottom_scan", "pose3d", "battery_state", "score",
-                        "rgbd_front", "air_pressure", "scan360", "octomap:gz", "origin"]
+                        "rgbd_front:null", "air_pressure", "scan360", "octomap:gz", "origin"]
 	      }
       },
       "torospy": {


### PR DESCRIPTION
Disable logging of synchronized RGBD data for Freyja, K2 and X4 (R2 is ignored for the moment). There is optional `image_extractor` which saves images and depth with given rate. Depth is by default not logged.