### PR TITLE
Add 2nd artifact detector for Freyja and K2 robots

### DIFF
--- a/subt/artifacts.py
+++ b/subt/artifacts.py
@@ -431,16 +431,16 @@ class ArtifactDetector(Node):
             self.best_depth = None
 
 
-def debug2dir(filename, out_dir):
+def debug2dir(filename, out_dir, detector_name):
     from osgar.logger import LogReader, lookup_stream_names
     from osgar.lib.serialize import deserialize
 
     names = lookup_stream_names(filename)
-    assert 'detector.debug_rgbd' in names, names
-    assert 'detector.localized_artf' in names, names
+    assert detector_name + '.debug_rgbd' in names, names
+    assert detector_name + '.localized_artf' in names, names
     assert 'rosmsg.sim_time_sec' in names, names
-    rgbd_id = names.index('detector.debug_rgbd') + 1
-    artf_id = names.index('detector.localized_artf') + 1
+    rgbd_id = names.index(detector_name + '.debug_rgbd') + 1
+    artf_id = names.index(detector_name + '.localized_artf') + 1
     sim_sec_id = names.index('rosmsg.sim_time_sec') + 1
     sim_time_sec = None
     image = None
@@ -473,12 +473,13 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Run artifact detection and classification for given JPEG image')
     parser.add_argument('filename', help='JPEG filename')
     parser.add_argument('--debug2dir', help='dump clasified debug images into directory')
+    parser.add_argument('--detector-name', help='detector module name (detector, detector_rear)', default='detector')
     parser.add_argument('--depth', help='filename of depth image for tested together with JPEG image')
     parser.add_argument('-v', '--verbose', help='verbose mode', action='store_true')
     args = parser.parse_args()
 
     if args.debug2dir is not None:
-        debug2dir(args.filename, args.debug2dir)
+        debug2dir(args.filename, args.debug2dir, args.detector_name)
         sys.exit()
 
     with open(args.filename.replace('.npz', '.jpg'), 'rb') as f:

--- a/subt/main.py
+++ b/subt/main.py
@@ -868,7 +868,7 @@ class SubTChallenge:
         self.stdout('Final xyz (DARPA coord system):', self.xyz)
 
     def play_virtual_track(self):
-        self.stdout("SubT Challenge Ver102!")
+        self.stdout("SubT Challenge Ver103!")
         self.stdout("Waiting for robot_name ...")
         while self.robot_name is None:
             self.update()

--- a/subt/subt-freyja.json
+++ b/subt/subt-freyja.json
@@ -17,6 +17,11 @@
             "fx": 349.2
           }
       },
+      "detector_rear": {
+          "init": {
+            "fx": 349.2
+          }
+      },
       "depth2scan": {
         "init": {
           "depth_params": {

--- a/subt/subt-k2-virt.json
+++ b/subt/subt-k2-virt.json
@@ -16,6 +16,11 @@
             "fx": 337.22
           }
       },
+      "detector_rear": {
+          "init": {
+            "fx": 337.22
+          }
+      },
       "depth2scan": {
         "init": {
           "depth_params": {

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -21,6 +21,13 @@
           "init": {
           }
       },
+      "detector_rear": {
+          "driver": "subt.artf_node:ArtifactDetectorDNN",
+          "in": ["rgbd", "scan"],
+          "out": ["localized_artf", "dropped", "debug_artf", "debug_rgbd", "debug_result", "debug_cv_result", "stdout"],
+          "init": {
+          }
+      },
       "gas_detector": {
           "driver": "subt.artf_gas:ArtifactGasDetector",
           "in": ["gas_detected"],
@@ -134,11 +141,12 @@
               ["fromrospy.acc", "app.acc"],
 
               ["fromrospy.scan_front", "detector.scan"],
+              ["fromrospy.scan_rear", "detector_rear.scan"],
               ["fromrospy.scan_front", "depth2scan.scan"],
 
               ["fromrospy.rgbd_front", "depth2scan.rgbd"],
               ["fromrospy.rgbd_front", "detector.rgbd"],
-              ["fromrospy.rgbd_rear", "detector.rgbd"],
+              ["fromrospy.rgbd_rear", "detector_rear.rgbd"],
 
               ["depth2scan.scan", "app.scan"],
 
@@ -172,6 +180,8 @@
 
               ["detector.localized_artf", "app.localized_artf"],
               ["detector.stdout", "rosmsg.stdout"],
+              ["detector_rear.localized_artf", "app.localized_artf"],
+              ["detector_rear.stdout", "rosmsg.stdout"],
               ["app.artf_xyz", "reporter.artf_xyz"],
               ["rosmsg.base_station", "reporter.base_station"],
               ["reporter.artf_cmd", "transmitter.raw"],


### PR DESCRIPTION
The former version used mixed sources for detector, but due to dropped images there could be "interference" where only front or rear images are missing.