### PR TITLE
Step towards 3D octomap planning

### DIFF
--- a/osgar/lib/pplanner.py
+++ b/osgar/lib/pplanner.py
@@ -17,7 +17,7 @@ def find_path(img, start, finish, verbose=False):
     """
     if len(img.shape) == 2:
         # old 2D images - add extra dimension
-        img = np.expand_dims(img.copy(), axis=2)
+        img = np.expand_dims(img, axis=2)
         start = (start[0], start[1], 0)
         finish = [(x, y, 0) for x, y in finish]
     max_x, max_y, max_z = img.shape

--- a/osgar/lib/pplanner.py
+++ b/osgar/lib/pplanner.py
@@ -2,6 +2,8 @@
 Simple Path Planner
 """
 
+import numpy as np
+
 
 def find_path(img, start, finish, verbose=False):
     """
@@ -13,12 +15,17 @@ def find_path(img, start, finish, verbose=False):
     :param verbose: true for debugging
     :return: path (list of coordinates) or None if path not found
     """
-    max_x, max_y = img.shape
+    if len(img.shape) == 2:
+        # old 2D images - add extra dimension
+        img = np.expand_dims(img.copy(), axis=2)
+        start = (start[0], start[1], 0)
+        finish = [(x, y, 0) for x, y in finish]
+    max_x, max_y, max_z = img.shape
 
-    if not (0 <= start[0] < max_x and 0 <=start[1] < max_y):
+    if not (0 <= start[0] < max_x and 0 <= start[1] < max_y and 0 <= start[2] < max_z):
         return None
 
-    if not img[start[1]][start[0]]:
+    if not img[start[1]][start[0]][start[2]]:
         return None
 
     queue = [(start, None)]  # start location has no predecessor
@@ -47,15 +54,19 @@ def find_path(img, start, finish, verbose=False):
         assert node not in prev, (node, node_prev)
         prev[node] = node_prev
 
-        x, y = node
-        if x + 1 < max_x and img[y][x + 1] and (x + 1, y) not in expanded:
-            queue.append(((x + 1, y), (x, y)))
-        if x > 0 and img[y][x - 1] and (x - 1, y) not in expanded:
-            queue.append(((x - 1, y), (x, y)))
-        if y + 1 < max_y and img[y + 1][x] and (x, y + 1) not in expanded:
-            queue.append(((x, y + 1), (x, y)))
-        if y > 0 and img[y - 1][x] and (x, y - 1) not in expanded:
-            queue.append(((x, y - 1), (x, y)))
+        x, y, z = node
+        if x + 1 < max_x and img[y][x + 1][z] and (x + 1, y, z) not in expanded:
+            queue.append(((x + 1, y, z), (x, y, z)))
+        if x > 0 and img[y][x - 1][z] and (x - 1, y, z) not in expanded:
+            queue.append(((x - 1, y, z), (x, y, z)))
+        if y + 1 < max_y and img[y + 1][x][z] and (x, y + 1, z) not in expanded:
+            queue.append(((x, y + 1, z), (x, y, z)))
+        if y > 0 and img[y - 1][x][z] and (x, y - 1, z) not in expanded:
+            queue.append(((x, y - 1, z), (x, y, z)))
+        if z + 1 < max_z and img[y][x][z + 1] and (x, y, z + 1) not in expanded:
+            queue.append(((x, y, z + 1), (x, y, z)))
+        if z > 0 and img[y][x][z - 1] and (x, y, z - 1) not in expanded:
+            queue.append(((x, y, z - 1), (x, y, z)))
 
     return None
 

--- a/osgar/lib/test_pplanner.py
+++ b/osgar/lib/test_pplanner.py
@@ -18,8 +18,8 @@ class PathPlannerTest(unittest.TestCase):
         self.assertIsNone(find_path(img, (3, 3), [(3, 3)]))
 
         path = find_path(img, (0, 0), [(5, 5)])
-        self.assertEqual(path[0], (0, 0))
-        self.assertEqual(path[-1], (5, 5))
+        self.assertEqual(path[0], (0, 0, 0))
+        self.assertEqual(path[-1], (5, 5, 0))
         self.assertEqual(len(path), 5 + 1 + 5)
 
     def test_multiple_goals(self):
@@ -28,7 +28,7 @@ class PathPlannerTest(unittest.TestCase):
         img[:, 0] = True
 
         path = find_path(img, (0, 0), [(3, 3), (5, 5)])
-        self.assertEqual(path[-1], (5, 5))
+        self.assertEqual(path[-1], (5, 5, 0))
         self.assertEqual(len(path), 5 + 1 + 5)
 
     def test_start_out_of_range(self):
@@ -36,6 +36,16 @@ class PathPlannerTest(unittest.TestCase):
         path = find_path(img, (200, 0), [(3, 3), (5, 5)])
         self.assertIsNone(path)
 
+        img = np.zeros((10, 10, 5), dtype=bool)
+        path = find_path(img, (0, 0, 13), [(3, 3, 0)])
+        self.assertIsNone(path)
+
+    def test_3d_planner(self):
+        mimg = np.zeros((10, 10, 5), dtype=bool)
+        mimg[5, :, 3] = True
+        mimg[:, 7, 2] = True
+        path = find_path(mimg, (0, 5, 3), [(7, 9, 2)])
+        self.assertIsNotNone(path)
 
 # vim: expandtab sw=4 ts=4
 

--- a/subt/octomap.py
+++ b/subt/octomap.py
@@ -27,6 +27,8 @@ def seq2xyz(seq_arr):
     :return: list of XYZ boxes with their "size category" (shorted the sequence bigger the voxel)
     """
     xyz = []
+    if len(seq_arr) == 0:
+        return xyz
     max_len = max([len(s) for s in seq_arr])
     for seq in seq_arr:
         d = 2 ** (max_len - 1)

--- a/subt/octomap.py
+++ b/subt/octomap.py
@@ -194,7 +194,6 @@ def frontiers(img, start, draw=False):
 
     # the path planner currently expects goals as tuple (x, y) and operation "in"
     goals = set(map(tuple, goals))
-    print('LEN', len(goals))
     path = find_path(drivable, start, goals, verbose=False)
 
     img[mask] = STATE_FRONTIER

--- a/subt/ros/robot/launch/x4.launch
+++ b/subt/ros/robot/launch/x4.launch
@@ -146,7 +146,7 @@
 
   <!-- Run a passthrough filter to remove drone propellers -->
   <node name="filter_pointcloud" pkg="robot" type="filter_pointcloud.py">
-    <remap from="/A100LXM/rgbd_camera/depth/points" to="/$(arg robot_name)/rgbd_camera/depth/points"/>
+    <remap from="/points" to="/$(arg robot_name)/rgbd_camera/depth/points"/>
     <remap from="/points_cleaned" to="/$(arg robot_name)/rgbd_camera/depth/points_cleaned"/>
   </node>
 

--- a/subt/ros/robot/launch/x4.launch
+++ b/subt/ros/robot/launch/x4.launch
@@ -150,22 +150,14 @@
     <remap from="/passthrough/output" to="/$(arg robot_name)/rgbd_camera/depth/points_cleaned" />
     <rosparam>
       filter_field_name: z
-      filter_limit_min: 0.31
-      filter_limit_max: 100.0
-      filter_limit_negative: False
+      filter_limit_min: 0
+      filter_limit_max: 0.31
+      filter_limit_negative: True
     </rosparam>
   </node>
 
-  <node name="scan360pts" pkg="robot" type="laserscan_to_pointcloud.py">
-    <remap from="scan" to="/$(arg robot_name)/front_scan"/>
-    <remap from="points" to="/$(arg robot_name)/front_scan/points"/>
-  </node>
-
-  <node pkg="topic_tools" type="relay" name="points_merge_front" args="$(arg robot_name)/rgbd_camera/depth/points_cleaned $(arg robot_name)/all_points"/>
-  <node pkg="topic_tools" type="relay" name="points_merge_lidar360" args="$(arg robot_name)/front_scan/points $(arg robot_name)/all_points"/>
-
   <node if="$(eval arg('robot_name').endswith('XM'))" ns="mapping" pkg="octomap_server" type="octomap_server_node" name="octomap">
-    <remap from="cloud_in" to="/$(arg robot_name)/all_points"/>
+    <remap from="cloud_in" to="/$(arg robot_name)/rgbd_camera/depth/points_cleaned"/>
     <param name="frame_id" value="odom"/>
     <!-- resolution in meters per voxel -->
     <param name="resolution" value="0.5" />
@@ -175,5 +167,7 @@
     <!-- We trust the simulated sensor a lot more than what default parameters expect. -->
     <param name="sensor_model/hit" value="0.95"/>
     <param name="sensor_model/miss" value="0.05"/>
+    <!-- RGBD camera has range only 10 meters -->
+    <param name="sensor_model/max_range" value="10"/>
   </node>
 </launch>

--- a/subt/ros/robot/launch/x4.launch
+++ b/subt/ros/robot/launch/x4.launch
@@ -145,15 +145,9 @@
   <node pkg="nodelet" type="nodelet" name="pcl_manager" args="manager" output="screen" />
 
   <!-- Run a passthrough filter to remove drone propellers -->
-  <node pkg="nodelet" type="nodelet" name="passthrough" args="load pcl/PassThrough pcl_manager" output="screen">
-    <remap from="~input" to="/$(arg robot_name)/rgbd_camera/depth/points" />
-    <remap from="/passthrough/output" to="/$(arg robot_name)/rgbd_camera/depth/points_cleaned" />
-    <rosparam>
-      filter_field_name: z
-      filter_limit_min: 0
-      filter_limit_max: 0.31
-      filter_limit_negative: True
-    </rosparam>
+  <node name="filter_pointcloud" pkg="robot" type="filter_pointcloud.py">
+    <remap from="/A100LXM/rgbd_camera/depth/points" to="/$(arg robot_name)/rgbd_camera/depth/points"/>
+    <remap from="/points_cleaned" to="/$(arg robot_name)/rgbd_camera/depth/points_cleaned"/>
   </node>
 
   <node if="$(eval arg('robot_name').endswith('XM'))" ns="mapping" pkg="octomap_server" type="octomap_server_node" name="octomap">

--- a/subt/ros/robot/launch/x4.launch
+++ b/subt/ros/robot/launch/x4.launch
@@ -156,8 +156,16 @@
     </rosparam>
   </node>
 
+  <node name="scan360pts" pkg="robot" type="laserscan_to_pointcloud.py">
+    <remap from="scan" to="/$(arg robot_name)/front_scan"/>
+    <remap from="points" to="/$(arg robot_name)/front_scan/points"/>
+  </node>
+
+  <node pkg="topic_tools" type="relay" name="points_merge_front" args="$(arg robot_name)/rgbd_camera/depth/points_cleaned $(arg robot_name)/all_points"/>
+  <node pkg="topic_tools" type="relay" name="points_merge_lidar360" args="$(arg robot_name)/front_scan/points $(arg robot_name)/all_points"/>
+
   <node if="$(eval arg('robot_name').endswith('XM'))" ns="mapping" pkg="octomap_server" type="octomap_server_node" name="octomap">
-    <remap from="cloud_in" to="/$(arg robot_name)/rgbd_camera/depth/points_cleaned"/>
+    <remap from="cloud_in" to="/$(arg robot_name)/all_points"/>
     <param name="frame_id" value="odom"/>
     <!-- resolution in meters per voxel -->
     <param name="resolution" value="0.5" />

--- a/subt/ros/robot/src/filter_pointcloud.py
+++ b/subt/ros/robot/src/filter_pointcloud.py
@@ -17,9 +17,7 @@ import numpy as np
 
 class FilterPointCloud:
     def __init__(self):
-#        self.points_subscriber = rospy.Subscriber("/input_points", PointCloud2, self.points_callback)
-        self.points_subscriber = rospy.Subscriber("/A100LXM/rgbd_camera/depth/points", PointCloud2, self.points_callback)
-#        self.points_publisher = rospy.Publisher("/output_points", PointCloud2, queue_size = 1)
+        self.points_subscriber = rospy.Subscriber("/points", PointCloud2, self.points_callback)
         self.points_publisher = rospy.Publisher("/points_cleaned", PointCloud2, queue_size=1)
 
         # create flat "infinity" background

--- a/subt/ros/robot/src/filter_pointcloud.py
+++ b/subt/ros/robot/src/filter_pointcloud.py
@@ -28,13 +28,13 @@ class FilterPointCloud:
         self.inf_y = np.zeros(size, dtype=np.float32)
         self.inf_z = np.zeros(size, dtype=np.float32)
         fx = 554.25469
-        Z_VALUE = 11.0
+        MAX_VALUE = 11.0
         for x in range(640):
             for y in range(480):
-                pos = y * 640
-                self.inf_x[pos] = Z_VALUE * (x - 320.5)/fx
-                self.inf_y[pos] = Z_VALUE * (240.5 - y)/fx
-                self.inf_z[pos] = Z_VALUE
+                pos = y * 640 + x
+                self.inf_x[pos] = MAX_VALUE
+                self.inf_y[pos] = MAX_VALUE * (320.5 - x)/fx
+                self.inf_z[pos] = MAX_VALUE * (240.5 - y)/fx
 
     def points_callback(self, msg):
         assert msg.height == 480, msg.height
@@ -52,7 +52,7 @@ class FilterPointCloud:
         y[mask] = self.inf_y[mask]
         z[mask] = self.inf_z[mask]
 
-        mask = z < 0.31  # propellers
+        mask = x < 0.31  # propellers
         x[mask] = float('-inf')
         y[mask] = float('-inf')
         z[mask] = float('-inf')

--- a/subt/ros/robot/src/filter_pointcloud.py
+++ b/subt/ros/robot/src/filter_pointcloud.py
@@ -53,8 +53,8 @@ class FilterPointCloud:
         data = np.frombuffer(msg.data, dtype=np.float32).reshape((480, 640, 6))
         xyz = data[:, :, :3]
         # convert +inf to real number outside sensor range
-        mask = np.isposinf(xyz[:, :, 0])
-        xyz[:, :, :] = np.where(mask, background, xyz)
+        mask = np.isposinf(xyz)
+        xyz[:, :, :] = np.where(mask, self.background, xyz)
 
         # replace close reading (propellers) by -inf (blind zone)
         mask = (xyz[:, :, 0] < 0.32)

--- a/subt/ros/robot/src/filter_pointcloud.py
+++ b/subt/ros/robot/src/filter_pointcloud.py
@@ -1,0 +1,66 @@
+#!/usr/bin/python
+"""
+  Filter PointCloud2 received from X4 drone for Octomap server
+  - remove nearby propellers (up to 31cm) in the RGBD camera view
+  - replace xyz = (inf, inf, inf) to range larger than 10m
+"""
+# http://docs.ros.org/en/melodic/api/sensor_msgs/html/msg/PointCloud2.html
+# http://docs.ros.org/en/api/sensor_msgs/html/point__cloud2_8py_source.html
+import ctypes
+import struct
+
+import rospy
+from sensor_msgs.msg import PointCloud2, PointField
+
+import numpy as np
+
+
+class FilterPointCloud:
+    def __init__(self):
+#        self.points_subscriber = rospy.Subscriber("/input_points", PointCloud2, self.points_callback)
+        self.points_subscriber = rospy.Subscriber("/A100LXM/rgbd_camera/depth/points", PointCloud2, self.points_callback)
+#        self.points_publisher = rospy.Publisher("/output_points", PointCloud2, queue_size = 1)
+        self.points_publisher = rospy.Publisher("/points_cleaned", PointCloud2, queue_size=1)
+
+    def points_callback(self, msg):
+        assert msg.height == 480, msg.height
+        assert msg.width == 640, msg.width
+        assert msg.point_step == 24, msg.point_step
+        assert msg.row_step == 640 * 24, msg.row_step
+        arr = np.frombuffer(msg.data, dtype=np.float32)
+        x = arr[::6]
+        y = arr[1::6]
+        z = arr[2::6]
+        mask = x == float('inf')
+        print('num inf', sum(mask))
+
+        fields = [PointField('x', 0, PointField.FLOAT32, 1),
+                  PointField('y', 4, PointField.FLOAT32, 1),
+                  PointField('z', 8, PointField.FLOAT32, 1)]
+
+        cloud_struct = struct.Struct('<fff')
+        buff = ctypes.create_string_buffer(cloud_struct.size * len(x))
+
+        # TODO faster conversion
+        bytes_arr = np.vstack([x, y, z]).flatten('f').tobytes()
+        for i in range(len(bytes_arr)):
+            buff[i] = bytes_arr[i]
+
+        new_msg = PointCloud2(header=msg.header,
+                              height=msg.height,
+                              width=msg.width,
+                              is_dense=False,
+                              is_bigendian=False,
+                              fields=fields,
+                              point_step=cloud_struct.size,
+                              row_step=cloud_struct.size * msg.width,
+                              data=buff.raw)
+
+        self.points_publisher.publish(new_msg)
+
+
+if __name__ == "__main__":
+    rospy.init_node("FilterPointCloud")
+    filter = FilterPointCloud()
+    rospy.spin()
+

--- a/subt/ros/robot/src/filter_pointcloud.py
+++ b/subt/ros/robot/src/filter_pointcloud.py
@@ -51,7 +51,7 @@ class FilterPointCloud:
         assert msg.row_step == 640 * 24, msg.row_step
 
         data = np.frombuffer(msg.data, dtype=np.float32).reshape((480, 640, 6))
-        xyz = data[:, :, :3]
+        xyz = data[:, :, :3].copy()
         # convert +inf to real number outside sensor range
         mask = np.isposinf(xyz)
         xyz[:, :, :] = np.where(mask, self.background, xyz)

--- a/subt/ros/robot/src/filter_pointcloud.py
+++ b/subt/ros/robot/src/filter_pointcloud.py
@@ -58,6 +58,7 @@ class FilterPointCloud:
 
         # replace close reading (propellers) by -inf (blind zone)
         mask = (xyz[:, :, 0] < 0.32)
+        mask = np.repeat(mask[:, :, np.newaxis], 3, axis=2)
         xyz[:, :, :] = np.where(mask, float('-inf'), xyz)
         new_data = data.tobytes()
 

--- a/subt/test_octomap.py
+++ b/subt/test_octomap.py
@@ -19,8 +19,8 @@ class OctomapTest(unittest.TestCase):
 
     def test_frontiers(self):
         # no frontiers in totally unknown world
-        img = np.zeros((1024, 1024), dtype=np.uint8)
-        __, path = frontiers(img, start=(512, 512))
+        img = np.zeros((1024, 1024, 1), dtype=np.uint8)
+        __, path = frontiers(img, start=(512, 512, 0))
         self.assertIsNone(path)
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_octomap.py
+++ b/subt/test_octomap.py
@@ -3,8 +3,9 @@ from unittest.mock import MagicMock
 import os
 
 import cv2
+import numpy as np
 
-from subt.octomap import Octomap, data2maplevel
+from subt.octomap import Octomap, data2maplevel, frontiers
 
 
 class OctomapTest(unittest.TestCase):
@@ -15,6 +16,12 @@ class OctomapTest(unittest.TestCase):
         self.assertEqual(len(data), 57278)
         img = data2maplevel(data, level=2)
         cv2.imwrite('octo.png', img)
+
+    def test_frontiers(self):
+        # no frontiers in totally unknown world
+        img = np.zeros((1024, 1024), dtype=np.uint8)
+        __, path = frontiers(img, start=(512, 512))
+        self.assertIsNone(path)
 
 # vim: expandtab sw=4 ts=4
 

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -137,7 +137,8 @@
       "octomap": {
         "driver": "subt.octomap:Octomap",
           "init": {
-            "zlevel": 2.0
+            "min_z": 2.0,
+            "max_z": 2.0
           }
       }
     },


### PR DESCRIPTION
This is "draft" of current state of Octomap exploration with robots with XM suffix. This version still plans path in single 2D raster, which is cut for Freyja at 0.5m above the ground and for X4 at 2m. The 3D frontiers are "too dense" and they will require another revision never the less there are already useful bits:
* `subt/octomap.py` used as script allow interactive analysis of recorded octomap in 10 levels
* RGBD camera for drone filters out properly propellers (depth is X axis) and inserts out of range rays (10m for RGBD).
* when tested in FP2 it explored parts so far not reachable by left/right wall following (and scored 4 points for X4 + Freyja)
* the map slices are `uint8` grayscale and numpy optimized "drawing"/cutting