### PR TITLE
Increase score for rope.

### DIFF
--- a/subt/tf_detector.py
+++ b/subt/tf_detector.py
@@ -13,7 +13,7 @@ PATH_TO_CV_GRAPH = "subt/tf_models/cv_graph.pbtxt"
 NAMES_AND_SCORES = {'backpack': 0.36,
                     'survivor': 0.25,
                     'phone': 0.1,
-                    'rope': 0.1,
+                    'rope': 0.25,
                     'helmet': 0.4,
                     'fire_extinguisher': 0.1,
                     'drill': 0.1,


### PR DESCRIPTION
Fixing too benevolent threshold for Rope artefact (causing problems with Finals Qualification world).
![err-rope-1](https://user-images.githubusercontent.com/5664353/114877643-bee78f80-9dff-11eb-8f51-2bbdf2f0327a.png)
![err-rope-2](https://user-images.githubusercontent.com/5664353/114877651-c149e980-9dff-11eb-974c-8f793b4ca37a.png)
![err-rope-3](https://user-images.githubusercontent.com/5664353/114877660-c4dd7080-9dff-11eb-8cbb-80de279de783.png)
