### PR TITLE
Use global coordinates for X4 octomap

### DIFF
--- a/subt/cloudsim2osgar.py
+++ b/subt/cloudsim2osgar.py
@@ -187,7 +187,7 @@ class main:
                             (origin_orientation.x, origin_orientation.y, origin_orientation.z,
                                 origin_orientation.w))
             except rospy.ServiceException:
-                rospy.logerror("Failed to get origin. Trying again.")
+                rospy.logerr("Failed to get origin. Trying again.")
                 time.sleep(origin_retry_delay)
                 origin_retry_delay = min(
                         MAX_ORIGIN_RETRY_DELAY,

--- a/subt/main.py
+++ b/subt/main.py
@@ -907,7 +907,7 @@ class SubTChallenge:
                 tmp_trace.trace = self.waypoints
                 self.waypoints = None
                 tmp_trace.reverse()
-                self.follow_trace(tmp_trace, timeout=timedelta(seconds=10), max_target_distance=2, is_trace3d=True)
+                self.follow_trace(tmp_trace, timeout=timedelta(seconds=10), max_target_distance=0.5, is_trace3d=True)
                 self.send_speed_cmd(0, 0)
 
     def play_virtual_part_return(self, timeout):

--- a/subt/main.py
+++ b/subt/main.py
@@ -889,6 +889,18 @@ class SubTChallenge:
 
         self.stdout(self.time, "Explore phase finished %.3f" % dist, reason)
 
+    def play_virtual_part_map_and_explore_frontiers(self):
+        start_time = self.sim_time_sec
+        while self.sim_time_sec - start_time < self.timeout.total_seconds():
+            channel = self.update()
+            if channel == 'waypoints':
+                tmp_trace = Trace()
+                tmp_trace.trace = self.waypoints
+                self.waypoints = None
+                tmp_trace.reverse()
+                self.follow_trace(tmp_trace, timeout=timedelta(seconds=10), max_target_distance=2)
+                self.send_speed_cmd(0, 0)
+
     def play_virtual_part_return(self, timeout):
         self.return_home(timeout)
         self.send_speed_cmd(0, 0)
@@ -931,6 +943,10 @@ class SubTChallenge:
                 self.use_right_wall = (action == 'right')
                 self.use_center = (action == 'center')
                 self.play_virtual_part_explore()
+
+            elif action == 'explore':
+                self.timeout = timedelta(seconds=duration)
+                self.play_virtual_part_map_and_explore_frontiers()
 
             elif action == 'home':
                 self.play_virtual_part_return(timedelta(seconds=duration))

--- a/subt/main.py
+++ b/subt/main.py
@@ -466,9 +466,12 @@ class SubTChallenge:
         print('return_home: dist', distance3D(self.xyz, home_position), 'time(sec)', self.sim_time_sec - start_time)
         self.bus.publish('desired_z_speed', None)
 
-    def follow_trace(self, trace, timeout, max_target_distance=5.0, safety_limit=None, is_trace3d=False):
+    def follow_trace(self, trace, timeout, max_target_distance=5.0, end_threshold=None, safety_limit=None, is_trace3d=False):
         print('Follow trace')
-        END_THRESHOLD = 2.0
+        if end_threshold is None:
+            END_THRESHOLD = 2.0
+        else:
+            END_THRESHOLD = end_threshold
         start_time = self.sim_time_sec
         print('MD', self.xyz, distance3D(self.xyz, trace.trace[0]), trace.trace)
         while distance3D(self.xyz, trace.trace[0]) > END_THRESHOLD and self.sim_time_sec - start_time < timeout.total_seconds():
@@ -907,7 +910,8 @@ class SubTChallenge:
                 tmp_trace.trace = self.waypoints
                 self.waypoints = None
                 tmp_trace.reverse()
-                self.follow_trace(tmp_trace, timeout=timedelta(seconds=10), max_target_distance=0.5, is_trace3d=True)
+                self.follow_trace(tmp_trace, timeout=timedelta(seconds=10),
+                                  max_target_distance=1.0, end_threshold=0.5, is_trace3d=True)
                 self.send_speed_cmd(0, 0)
 
     def play_virtual_part_return(self, timeout):

--- a/subt/main.py
+++ b/subt/main.py
@@ -921,7 +921,7 @@ class SubTChallenge:
         self.stdout('Final xyz (DARPA coord system):', self.xyz)
 
     def play_virtual_track(self):
-        self.stdout("SubT Challenge Ver105!")
+        self.stdout("SubT Challenge Ver106!")
         self.stdout("Waiting for robot_name ...")
         while self.robot_name is None:
             self.update()

--- a/subt/name_decoder.py
+++ b/subt/name_decoder.py
@@ -32,6 +32,7 @@ def parse_robot_name(robot_name):
         'L': 'left',
         'R': 'right',
         'C': 'center',
+        'E': 'explore',  # map & explore frontiers
         'W': 'wait',
         'H': 'home'
     }

--- a/subt/octomap.py
+++ b/subt/octomap.py
@@ -312,6 +312,7 @@ if __name__ == "__main__":
     parser.add_argument('logfile', help='path to logfile with octomap data')
     parser.add_argument('--out', help='output path to PNG image', default='out.png')
     parser.add_argument('--draw', action='store_true', help='draw pyplot frontiers')
+    parser.add_argument('--open3d', action='store_true', help='use Open3D for visualization')
     args = parser.parse_args()
 
     octomap_stream_id = lookup_stream_id(args.logfile, 'fromrospy.octomap')
@@ -350,6 +351,19 @@ if __name__ == "__main__":
                     paused = not paused
                 if ord('0') <= key <= ord('9'):
                     level = key - ord('0')
+                if args.open3d and key == ord('d'):
+                    import open3d as o3d
+                    all = []
+                    for lev in range(-3, 10):
+                        img = data2maplevel(data, level=lev)
+                        xy = np.where(img == STATE_OCCUPIED)
+                        xyz = np.array([xy[0], xy[1], np.full(len(xy[0]), lev)]).T
+                        all.extend(xyz.tolist())
+                    pcd = o3d.geometry.PointCloud()
+                    xyz = np.array(all)
+                    pcd.points = o3d.utility.Vector3dVector(xyz)
+                    voxel_grid = o3d.geometry.VoxelGrid.create_from_point_cloud(pcd, voxel_size=0.5)
+                    o3d.visualization.draw_geometries([voxel_grid])
                 if not paused:
                     break
             if key == KEY_Q:

--- a/subt/octomap.py
+++ b/subt/octomap.py
@@ -215,7 +215,6 @@ class Octomap(Node):
         self.time_limit_sec = None  # initialized with the first sim_time_sec
         self.debug_arr = []
         self.waypoints = None  # experimental trigger of navigation
-        self.start_xyz = None
         self.sim_time_sec = None
         self.pose3d = None
         self.video_writer = None
@@ -230,9 +229,6 @@ class Octomap(Node):
             self.time_limit_sec = data
 
     def on_pose3d(self, data):
-        if self.start_xyz is None:
-            # the octomap starts with robot position at (0, 0, 0) - correction offset is needed
-            self.start_xyz = data[0]
         if self.waypoints is not None:
             print('Waypoints', data[0], self.waypoints[0], self.waypoints[-1])
             self.publish('waypoints', self.waypoints)
@@ -247,9 +243,7 @@ class Octomap(Node):
         assert len(data) % 2 == 0, len(data)
         data = bytes([(d + 256) % 256 for d in data])
 
-        x = self.pose3d[0][0] - self.start_xyz[0]
-        y = self.pose3d[0][1] - self.start_xyz[1]
-        z = self.pose3d[0][2] - self.start_xyz[2]
+        x, y, z = self.pose3d[0]
         start = int(SLICE_OCTOMAP_SIZE//2 + x/self.resolution), int(SLICE_OCTOMAP_SIZE//2 - y/self.resolution), int((z - self.min_z)/self.resolution)
         num_z_levels = int(round((self.max_z - self.min_z)/self.resolution)) + 1
         img3d = np.zeros((SLICE_OCTOMAP_SIZE, SLICE_OCTOMAP_SIZE, num_z_levels), dtype=np.uint8)
@@ -289,8 +283,8 @@ class Octomap(Node):
                 self.video_writer.write(img2)
 
         if path is not None:
-            self.waypoints = [[(x - SLICE_OCTOMAP_SIZE//2)/2 + self.start_xyz[0],
-                               (SLICE_OCTOMAP_SIZE//2 - y)/2 + self.start_xyz[1],
+            self.waypoints = [[(x - SLICE_OCTOMAP_SIZE//2)/2,
+                               (SLICE_OCTOMAP_SIZE//2 - y)/2,
                                z * self.resolution + self.min_z]
                               for x, y, z in path]
 

--- a/subt/ros/robot/launch/x4.launch
+++ b/subt/ros/robot/launch/x4.launch
@@ -150,9 +150,12 @@
     <remap from="/points_cleaned" to="/$(arg robot_name)/rgbd_camera/depth/points_cleaned"/>
   </node>
 
+  <node name="map_tf_broadcaster" pkg="robot" type="map_tf_broadcaster.py" args="$(arg robot_name)">
+  </node>
+
   <node if="$(eval arg('robot_name').endswith('XM'))" ns="mapping" pkg="octomap_server" type="octomap_server_node" name="octomap">
     <remap from="cloud_in" to="/$(arg robot_name)/rgbd_camera/depth/points_cleaned"/>
-    <param name="frame_id" value="odom"/>
+    <param name="frame_id" value="map"/>
     <!-- resolution in meters per voxel -->
     <param name="resolution" value="0.5" />
     <!-- In case we want to filter out ceilings.

--- a/subt/ros/robot/src/map_tf_broadcaster.py
+++ b/subt/ros/robot/src/map_tf_broadcaster.py
@@ -64,7 +64,7 @@ if __name__ == '__main__':
         rospy.logerr('Invalid number of parameters\nusage: '
                      './map_tf_broadcaster.py '
                      'robot_name')
-        sys.exit(0)
+        sys.exit(-1)
 
     origin = get_origin(myargv[1])
     rospy.loginfo(origin)

--- a/subt/ros/robot/src/map_tf_broadcaster.py
+++ b/subt/ros/robot/src/map_tf_broadcaster.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python2
+"""
+  Create ROS frame_id "map", which is global world position in DARPA coordinate system
+  (shifted and rotated so that (0, 0, 0) is in the middle of the entrance)
+"""
+from __future__ import print_function
+import time
+import sys
+
+import rospy
+#import tf
+import tf2_ros
+import geometry_msgs.msg
+
+from std_msgs.msg import String
+
+from subt_msgs.srv import PoseFromArtifact
+
+
+def get_origin(robot_name):
+    rospy.loginfo('get_origin for ' + robot_name)
+    origin = None
+    origin_retry_delay = 0.2
+    ORIGIN_RETRY_EXPONENTIAL_BACKOFF = 1.3
+    MAX_ORIGIN_RETRY_DELAY = 2.0
+    ORIGIN_SERVICE_NAME = "/subt/pose_from_artifact_origin"
+    rospy.wait_for_service(ORIGIN_SERVICE_NAME)
+    origin_service = rospy.ServiceProxy(ORIGIN_SERVICE_NAME, PoseFromArtifact)
+    origin_request = String()
+    origin_request.data = robot_name
+    while origin is None:
+        try:
+            origin_response = origin_service(origin_request)
+            if origin_response.success:
+                origin_pose = origin_response.pose.pose
+                origin_position = origin_response.pose.pose.position
+                origin_orientation = origin_response.pose.pose.orientation
+                origin = (
+                    (origin_position.x, origin_position.y, origin_position.z),
+                    (origin_orientation.x, origin_orientation.y, origin_orientation.z,
+                     origin_orientation.w))
+        except rospy.ServiceException:
+            rospy.logerr("Failed to get origin. Trying again.")
+            time.sleep(origin_retry_delay)
+            origin_retry_delay = min(
+                MAX_ORIGIN_RETRY_DELAY,
+                ORIGIN_RETRY_EXPONENTIAL_BACKOFF * origin_retry_delay)
+    return origin
+
+
+def publish_odom_to_map_tf(origin):
+    broadcaster = tf2_ros.StaticTransformBroadcaster()
+    static_transformStamped = geometry_msgs.msg.TransformStamped()
+
+    static_transformStamped.header.stamp = rospy.Time.now()
+    static_transformStamped.header.frame_id = 'map'
+    static_transformStamped.child_frame_id = 'odom'
+
+    static_transformStamped.transform.translation.x = origin[0][0]
+    static_transformStamped.transform.translation.y = origin[0][1]
+    static_transformStamped.transform.translation.z = origin[0][2]
+
+    static_transformStamped.transform.rotation.x = origin[1][0]
+    static_transformStamped.transform.rotation.y = origin[1][1]
+    static_transformStamped.transform.rotation.z = origin[1][2]
+    static_transformStamped.transform.rotation.w = origin[1][3]
+
+    broadcaster.sendTransform(static_transformStamped)
+
+
+if __name__ == '__main__':
+
+    rospy.init_node('map_tf_broadcaster')
+    myargv = rospy.myargv(argv=sys.argv)
+
+    if len(myargv) < 2:
+        rospy.logerr('Invalid number of parameters\nusage: '
+                     './map_tf_broadcaster.py '
+                     'robot_name')
+        sys.exit(0)
+
+    origin = get_origin(myargv[1])
+    print(origin)
+    publish_odom_to_map_tf(origin)
+    rospy.spin()

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -146,8 +146,8 @@
       "octomap": {
         "driver": "subt.octomap:Octomap",
           "init": {
-            "min_z": 2.0,
-            "max_z": 2.0
+            "min_z": 0.0,
+            "max_z": 4.0
           }
       }
     },


### PR DESCRIPTION
This PR is with with small but for next steps important "prelude":
* introduced letter 'E' in name as "exploration" (not to be confused with "explosion") with time, when the robot accepts only external waypoints
* experiments with Open3D for visualization of collected 3D octomap data
* uses `map` frame_id for octomap with small wrapper `map_tf_broadcaster` which handles static TF conversion

OTOH there bits I do not like - one is still duplicate `follow_trace` which is used by robots to enter the gate and by default ignoring Z coordinate (i.e. extra param). The "explore" mode is rather for testing - there is need of cooperation between generation of trajectories and its execution. Also 2m limit is too much. Launch file for Freyja with Octomap was not changed yet.

In general comments if to proceed, cut parts of this PR or add more functionality are also welcomed.