### PR TITLE
Add artifact filter

### DIFF
--- a/subt/artf_filter.py
+++ b/subt/artf_filter.py
@@ -1,0 +1,16 @@
+"""
+  Filter of detector outputs to unique reports
+"""
+
+from osgar.node import Node
+from osgar.bus import BusShutdownException
+
+
+class ArtifactFilter(Node):
+    def __init__(self, config, bus):
+        super().__init__(config, bus)
+        bus.register("localized_artf")
+
+
+
+# vim: expandtab sw=4 ts=4

--- a/subt/artf_filter.py
+++ b/subt/artf_filter.py
@@ -38,7 +38,7 @@ class ArtifactFilter(Node):
             if self.maybe_remember_artifact(artifact_data, (ax, ay, az)):
                 self.publish_single_artf_xyz(artifact_data, (ax, ay, az))
 
-    def on_robot_name(self, timestamp, data):
+    def on_robot_name(self, data):
         self.robot_name = data.decode('ascii')
 
     def on_localized_artf(self, data):

--- a/subt/artf_filter.py
+++ b/subt/artf_filter.py
@@ -12,6 +12,7 @@ class ArtifactFilter(Node):
         super().__init__(config, bus)
         bus.register("artf_xyz")
         self.robot_name = None  # for "signature" who discovered the artifact
+        self.artifacts = []
 
     def publish_single_artf_xyz(self, artifact_data, pos):
         ax, ay, az = pos

--- a/subt/artf_filter.py
+++ b/subt/artf_filter.py
@@ -4,13 +4,52 @@
 
 from osgar.node import Node
 from osgar.bus import BusShutdownException
+from subt.trace import distance3D
 
 
 class ArtifactFilter(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
-        bus.register("localized_artf")
+        bus.register("artf_xyz")
+        self.robot_name = None  # for "signature" who discovered the artifact
 
+    def publish_single_artf_xyz(self, artifact_data, pos):
+        ax, ay, az = pos
+        self.bus.publish('artf_xyz', [
+            [artifact_data, [round(ax * 1000), round(ay * 1000), round(az * 1000)], self.robot_name, None]])
 
+    def maybe_remember_artifact(self, artifact_data, artifact_xyz):
+        for stored_data, (x, y, z) in self.artifacts:
+            if distance3D((x, y, z), artifact_xyz) < 4.0:
+                # in case of uncertain type, rather report both
+                if stored_data == artifact_data:
+                    return False
+        self.artifacts.append((artifact_data, artifact_xyz))
+        return True
+
+    def handle_artf(self, artifact_data, world_xyz):
+        ax, ay, az = world_xyz
+        if -20 < ax < 0 and -10 < ay < 10:  # AND of currently available staging areas
+            # Urban (-20 < ax < 0 and -10 < ay < 10)
+            # Cave  (-50 < ax < 0 and -25 < ay < 25)
+            # filter out elements on staging area
+            self.stdout(self.time, 'Robot at:', (ax, ay, az))
+        else:
+            if self.maybe_remember_artifact(artifact_data, (ax, ay, az)):
+                self.publish_single_artf_xyz(artifact_data, (ax, ay, az))
+
+    def on_robot_name(self, timestamp, data):
+        self.robot_name = data.decode('ascii')
+
+    def on_localized_artf(self, data):
+        self.handle_artf(*data)
+
+    def update(self):
+        channel = super().update()
+        handler = getattr(self, "on_" + channel, None)
+        if handler is not None:
+            handler(getattr(self, channel))
+        else:
+            assert False, channel  # unknown channel
 
 # vim: expandtab sw=4 ts=4

--- a/subt/artf_filter.py
+++ b/subt/artf_filter.py
@@ -13,6 +13,7 @@ class ArtifactFilter(Node):
         bus.register("artf_xyz")
         self.robot_name = None  # for "signature" who discovered the artifact
         self.artifacts = []
+        self.verbose = False
 
     def publish_single_artf_xyz(self, artifact_data, pos):
         ax, ay, az = pos
@@ -34,7 +35,8 @@ class ArtifactFilter(Node):
             # Urban (-20 < ax < 0 and -10 < ay < 10)
             # Cave  (-50 < ax < 0 and -25 < ay < 25)
             # filter out elements on staging area
-            self.stdout(self.time, 'Robot at:', (ax, ay, az))
+            if self.verbose:
+                print(self.time, 'Robot at staging area:', (ax, ay, az))
         else:
             if self.maybe_remember_artifact(artifact_data, (ax, ay, az)):
                 self.publish_single_artf_xyz(artifact_data, (ax, ay, az))

--- a/subt/artf_gas.py
+++ b/subt/artf_gas.py
@@ -12,12 +12,16 @@ from subt.artifacts import GAS
 class ArtifactGasDetector(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
-        bus.register("artf")
+        bus.register("localized_artf")
+        self.xyz = None
 
     def on_gas_detected(self, data):
         # [type, [rel_x, rel_y, rel_z]]
         if data:
-            self.publish('artf', [GAS, [0, 0, 0]])
+            self.publish('localized_artf', [GAS, self.xyz])
+
+    def on_pose3d(self, data):
+        self.xyz = data[0]  # ignore orientation
 
     def update(self):
         channel = super().update()

--- a/subt/artf_gas.py
+++ b/subt/artf_gas.py
@@ -16,7 +16,6 @@ class ArtifactGasDetector(Node):
         self.xyz = None
 
     def on_gas_detected(self, data):
-        # [type, [rel_x, rel_y, rel_z]]
         if data:
             self.publish('localized_artf', [GAS, self.xyz])
 

--- a/subt/main.py
+++ b/subt/main.py
@@ -139,7 +139,6 @@ class SubTChallenge:
         self.joint_angle_rad = []  # optinal angles, needed for articulated robots flip
         self.stat = defaultdict(int)
         self.voltage = []
-        self.artifacts = []
         self.trace = Trace()
         self.waypoints = None  # external waypoints for navigation
         self.loop_detector = LoopDetector()

--- a/subt/test_artf_filter.py
+++ b/subt/test_artf_filter.py
@@ -26,5 +26,12 @@ class ArtifactFilterTest(unittest.TestCase):
         # 2nd report should be ignored
         self.assertEqual(filter.maybe_remember_artifact(artf_data, artf_xyz), False)
 
+    def test_usage(self):
+        bus = MagicMock()
+        filter = ArtifactFilter(bus=bus, config={})
+        filter.on_robot_name(b'A100L')
+        filter.on_localized_artf(['TYPE_DRILL', [-10.0, 0.0, 0.0]])
+        bus.publish.assert_not_called()  # inside staging area
+
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_artf_filter.py
+++ b/subt/test_artf_filter.py
@@ -2,6 +2,8 @@ import unittest
 from unittest.mock import MagicMock
 
 from subt.artf_filter import ArtifactFilter
+from subt.artifacts import GAS
+
 
 
 class ArtifactFilterTest(unittest.TestCase):
@@ -10,8 +12,8 @@ class ArtifactFilterTest(unittest.TestCase):
         bus = MagicMock()
         filter = ArtifactFilter(bus=bus, config={})
         filter.on_robot_name(b'A100L')
-        filter.on_localized_artf(['GAS', [100.0, 0.0, 0.0]])
-        bus.publish.assert_called_with('artf_xyz', [['GAS', [100000, 0, 0], 'A100L', None]])
+        filter.on_localized_artf([GAS, [100.0, 0.0, 0.0]])
+        bus.publish.assert_called_with('artf_xyz', [[GAS, [100000, 0, 0], 'A100L', None]])
 
     def test_maybe_remember_artifact(self):
         bus = MagicMock()

--- a/subt/test_artf_filter.py
+++ b/subt/test_artf_filter.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest.mock import MagicMock
 
 from subt.artf_filter import ArtifactFilter
 
@@ -6,7 +7,22 @@ from subt.artf_filter import ArtifactFilter
 class ArtifactFilterTest(unittest.TestCase):
 
     def test_usage(self):
-        pass
+        bus = MagicMock()
+        filter = ArtifactFilter(bus=bus, config={})
+        filter.on_robot_name(b'A100L')
+        filter.on_localized_artf(['GAS', [100.0, 0.0, 0.0]])
+        bus.publish.assert_called_with('artf_xyz', [['GAS', [100000, 0, 0], 'A100L', None]])
+
+    def test_maybe_remember_artifact(self):
+        bus = MagicMock()
+        filter = ArtifactFilter(bus=bus, config={})
+
+        artf_data = ['TYPE_BACKPACK', -1614, 1886]
+        artf_xyz = (0, 0, 0)
+        self.assertTrue(filter.maybe_remember_artifact(artf_data, artf_xyz))
+
+        # 2nd report should be ignored
+        self.assertEqual(filter.maybe_remember_artifact(artf_data, artf_xyz), False)
 
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_artf_filter.py
+++ b/subt/test_artf_filter.py
@@ -1,0 +1,12 @@
+import unittest
+
+from subt.artf_filter import ArtifactFilter
+
+
+class ArtifactFilterTest(unittest.TestCase):
+
+    def test_usage(self):
+        pass
+
+
+# vim: expandtab sw=4 ts=4

--- a/subt/test_artf_gas.py
+++ b/subt/test_artf_gas.py
@@ -10,11 +10,13 @@ class ArtifactGasDetectorTest(unittest.TestCase):
     def test_report(self):
         bus = bus=MagicMock()
         detector = ArtifactGasDetector(bus=bus, config={})
+        detector.on_pose3d([[1, 2, 3], [0, 0, 0, 1]])
         detector.on_gas_detected(False)
         bus.publish.assert_not_called()
 
+        detector.on_pose3d([[1, 0, 1], [0, 0, 0, 1]])
         detector.on_gas_detected(True)
         bus.publish.assert_called()
-        bus.publish.assert_has_calls([call('artf', [GAS, [0, 0, 0]])])
+        bus.publish.assert_has_calls([call('localized_artf', [GAS, [1.0, 0, 1.0]])])
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_subt.py
+++ b/subt/test_subt.py
@@ -24,19 +24,6 @@ def entrance_reached(sim):
 
 class SubTChallengeTest(unittest.TestCase):
 
-    def test_maybe_remember_artifact(self):
-        config = {'max_speed': 0.5, 'walldist': 0.9, 'timeout': 600, 'symmetric': True,
-                  'right_wall': True}
-        bus = MagicMock()
-        game = SubTChallenge(config, bus)
-
-        artf_data = ['TYPE_BACKPACK', -1614, 1886]
-        artf_xyz = (0, 0, 0)
-        self.assertTrue(game.maybe_remember_artifact(artf_data, artf_xyz))
-
-        # 2nd report should be ignored
-        self.assertEqual(game.maybe_remember_artifact(artf_data, artf_xyz), False)
-
     def test_go_to_entrance(self):
         config = {'virtual_world': True, 'max_speed': 1.0, 'walldist': 0.8, 'timeout': 600, 'symmetric': False, 'right_wall': 'auto'}
         bus = Bus(simulation.SimLogger())
@@ -58,25 +45,6 @@ class SubTChallengeTest(unittest.TestCase):
         app.request_stop()
         app.join()
         self.assertTrue(entrance_reached(sim))
-
-    def test_on_artf_xyz(self):
-        config = {'virtual_world': True, 'max_speed': 1.0, 'walldist': 0.8, 'timeout': 600, 'symmetric': False, 'right_wall': 'auto'}
-        bus = MagicMock()
-        app = SubTChallenge(config, bus)
-        data = ['TYPE_BACKPACK', [5000, -2359, 2222]]
-        app.xyz = 100.0, 2.0, 3.0
-        app.orientation = quaternion.identity()
-        bus.publish.reset_mock()
-        app.on_artf(None, data)
-        bus.publish.assert_called()
-        self.assertEqual(bus.method_calls[-1],
-                         call.publish('artf_xyz', [['TYPE_BACKPACK', [105000, -359, 5222], None, None]]))
-        app.orientation = quaternion.euler_to_quaternion(math.pi/2, 0, 0)
-        bus.publish.reset_mock()
-        app.on_artf(None, data)
-        bus.publish.assert_called()
-        self.assertEqual(bus.method_calls[-1],
-                         call.publish('artf_xyz', [['TYPE_BACKPACK', [102359, 7000, 5222], None, None]]))
 
 
 if __name__ == "__main__":

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -33,11 +33,11 @@
       },
       "gas_detector": {
           "driver": "subt.artf_gas:ArtifactGasDetector",
-          "in": ["gas_detected"],
-          "out": ["artf"],
+          "in": ["pose3d", "gas_detected"],
+          "out": ["localized_artf"],
           "init": {}
       },
-      "filter": {
+      "artifact_filter": {
           "driver": "subt.artf_filter:ArtifactFilter",
           "in": ["robot_name", "localized_artf"],
           "out": ["artf_xyz"],
@@ -166,7 +166,7 @@
               ["twister.cmd_vel", "torospy.cmd_vel"],
               ["app.stdout", "rosmsg.stdout"],
               ["fromrospy.robot_name", "app.robot_name"],
-              ["fromrospy.robot_name", "filter.robot_name"],
+              ["fromrospy.robot_name", "artifact_filter.robot_name"],
 
               ["receiver.raw", "rosmsg.raw"],
               ["rosmsg.cmd", "transmitter.raw"],
@@ -194,7 +194,7 @@
 
               ["fromrospy.pose3d", "gas_detector.pose3d"],
               ["fromrospy.gas_detected", "gas_detector.gas_detected"],
-              ["gas_detector.localized_artf", "filter.localized_artf"],
+              ["gas_detector.localized_artf", "artifact_filter.localized_artf"],
 
               ["fromrospy.pose3d", "radio.pose3d"],
               ["reporter.artf_all", "radio.artf"],
@@ -215,11 +215,11 @@
               ["breadcrumbs.location", "radio.breadcrumb"],
               ["radio.breadcrumb", "breadcrumbs.external"],
 
-              ["detector.localized_artf", "filter.localized_artf"],
+              ["detector.localized_artf", "artifact_filter.localized_artf"],
               ["detector.stdout", "rosmsg.stdout"],
-              ["detector_rear.localized_artf", "filter.localized_artf"],
+              ["detector_rear.localized_artf", "artifact_filter.localized_artf"],
               ["detector_rear.stdout", "rosmsg.stdout"],
-              ["filter.artf_xyz", "reporter.artf_xyz"],
+              ["artifact_filter.artf_xyz", "reporter.artf_xyz"],
               ["rosmsg.base_station", "reporter.base_station"],
               ["reporter.artf_cmd", "transmitter.raw"],
 

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -42,7 +42,6 @@
           "in": ["robot_name", "localized_artf"],
           "out": ["artf_xyz"],
           "init": {
-            "confirmation_level": 3
           }
       },
       "reporter": {

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -4,8 +4,8 @@
     "modules": {
       "app": {
           "driver": "application",
-          "in": ["emergency_stop", "scan", "scan_back", "artf", "sim_time_sec", "acc", "robot_name"],
-          "out": ["desired_speed", "pose2d", "artf_xyz", "pose3d", "stdout"],
+          "in": ["emergency_stop", "scan", "scan_back", "sim_time_sec", "acc", "robot_name"],
+          "out": ["desired_speed", "pose2d", "pose3d", "stdout"],
           "init": {
             "max_speed": 0.5,
             "symmetric": true,
@@ -36,6 +36,14 @@
           "in": ["gas_detected"],
           "out": ["artf"],
           "init": {}
+      },
+      "filter": {
+          "driver": "subt.artf_filter:ArtifactFilter",
+          "in": ["robot_name", "localized_artf"],
+          "out": ["artf_xyz"],
+          "init": {
+            "confirmation_level": 3
+          }
       },
       "reporter": {
           "driver": "subt.artf_reporter:ArtifactReporter",
@@ -159,6 +167,7 @@
               ["twister.cmd_vel", "torospy.cmd_vel"],
               ["app.stdout", "rosmsg.stdout"],
               ["fromrospy.robot_name", "app.robot_name"],
+              ["fromrospy.robot_name", "filter.robot_name"],
 
               ["receiver.raw", "rosmsg.raw"],
               ["rosmsg.cmd", "transmitter.raw"],
@@ -185,7 +194,7 @@
               ["rosmsg.sim_time_sec", "octomap.sim_time_sec"],
 
               ["fromrospy.gas_detected", "gas_detector.gas_detected"],
-              ["gas_detector.artf", "app.artf"],
+              ["gas_detector.localized_artf", "filter.localized_artf"],
 
               ["fromrospy.pose3d", "radio.pose3d"],
               ["reporter.artf_all", "radio.artf"],
@@ -206,11 +215,11 @@
               ["breadcrumbs.location", "radio.breadcrumb"],
               ["radio.breadcrumb", "breadcrumbs.external"],
 
-              ["detector.localized_artf", "app.localized_artf"],
+              ["detector.localized_artf", "filter.localized_artf"],
               ["detector.stdout", "rosmsg.stdout"],
-              ["detector_rear.localized_artf", "app.localized_artf"],
+              ["detector_rear.localized_artf", "filter.localized_artf"],
               ["detector_rear.stdout", "rosmsg.stdout"],
-              ["app.artf_xyz", "reporter.artf_xyz"],
+              ["filter.artf_xyz", "reporter.artf_xyz"],
               ["rosmsg.base_station", "reporter.base_station"],
               ["reporter.artf_cmd", "transmitter.raw"],
 

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -193,6 +193,7 @@
               ["rosmsg.sim_time_sec", "torospy.sim_time_sec"],
               ["rosmsg.sim_time_sec", "octomap.sim_time_sec"],
 
+              ["fromrospy.pose3d", "gas_detector.pose3d"],
               ["fromrospy.gas_detected", "gas_detector.gas_detected"],
               ["gas_detector.localized_artf", "filter.localized_artf"],
 

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -44,6 +44,14 @@
           "out": ["artf"],
           "init": {}
       },
+      "filter": {
+          "driver": "subt.artf_filter:ArtifactFilter",
+          "in": ["robot_name", "localized_artf"],
+          "out": ["artf_xyz"],
+          "init": {
+            "confirmation_level": 3
+          }
+      },
       "reporter": {
           "driver": "subt.artf_reporter:ArtifactReporter",
           "in": ["artf_xyz"],
@@ -155,6 +163,7 @@
               ["drone.desired_speed_3d", "torospy.cmd_vel"],
               ["app.stdout", "rosmsg.stdout"],
               ["fromrospy.robot_name", "app.robot_name"],
+              ["fromrospy.robot_name", "filter.robot_name"],
 
               ["receiver.raw", "rosmsg.raw"],
               ["rosmsg.cmd", "transmitter.raw"],
@@ -175,7 +184,7 @@
               ["rosmsg.sim_time_sec", "octomap.sim_time_sec"],
 
               ["fromrospy.gas_detected", "gas_detector.gas_detected"],
-              ["gas_detector.artf", "app.artf"],
+              ["gas_detector.localized_artf", "filter.localized_artf"],
 
               ["fromrospy.pose3d", "radio.pose3d"],
               ["reporter.artf_all", "radio.artf"],
@@ -194,9 +203,9 @@
               ["fromrospy.robot_name", "marsupial.robot_name"],
               ["marsupial.detach", "torospy.detach"],
 
-              ["detector.localized_artf", "app.localized_artf"],
+              ["detector.localized_artf", "filter.localized_artf"],
               ["detector.stdout", "rosmsg.stdout"],
-              ["app.artf_xyz", "reporter.artf_xyz"],
+              ["filter.artf_xyz", "reporter.artf_xyz"],
               ["rosmsg.base_station", "reporter.base_station"],
               ["reporter.artf_cmd", "transmitter.raw"],
 

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -40,11 +40,11 @@
       },
       "gas_detector": {
           "driver": "subt.artf_gas:ArtifactGasDetector",
-          "in": ["gas_detected"],
-          "out": ["artf"],
+          "in": ["pose3d", "gas_detected"],
+          "out": ["localized_artf"],
           "init": {}
       },
-      "filter": {
+      "artifact_filter": {
           "driver": "subt.artf_filter:ArtifactFilter",
           "in": ["robot_name", "localized_artf"],
           "out": ["artf_xyz"],
@@ -162,7 +162,7 @@
               ["drone.desired_speed_3d", "torospy.cmd_vel"],
               ["app.stdout", "rosmsg.stdout"],
               ["fromrospy.robot_name", "app.robot_name"],
-              ["fromrospy.robot_name", "filter.robot_name"],
+              ["fromrospy.robot_name", "artifact_filter.robot_name"],
 
               ["receiver.raw", "rosmsg.raw"],
               ["rosmsg.cmd", "transmitter.raw"],
@@ -184,7 +184,7 @@
 
               ["fromrospy.pose3d", "gas_detector.pose3d"],
               ["fromrospy.gas_detected", "gas_detector.gas_detected"],
-              ["gas_detector.localized_artf", "filter.localized_artf"],
+              ["gas_detector.localized_artf", "artifact_filter.localized_artf"],
 
               ["fromrospy.pose3d", "radio.pose3d"],
               ["reporter.artf_all", "radio.artf"],
@@ -203,9 +203,9 @@
               ["fromrospy.robot_name", "marsupial.robot_name"],
               ["marsupial.detach", "torospy.detach"],
 
-              ["detector.localized_artf", "filter.localized_artf"],
+              ["detector.localized_artf", "artifact_filter.localized_artf"],
               ["detector.stdout", "rosmsg.stdout"],
-              ["filter.artf_xyz", "reporter.artf_xyz"],
+              ["artifact_filter.artf_xyz", "reporter.artf_xyz"],
               ["rosmsg.base_station", "reporter.base_station"],
               ["reporter.artf_cmd", "transmitter.raw"],
 

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -49,7 +49,6 @@
           "in": ["robot_name", "localized_artf"],
           "out": ["artf_xyz"],
           "init": {
-            "confirmation_level": 3
           }
       },
       "reporter": {

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -183,6 +183,7 @@
               ["rosmsg.sim_time_sec", "reporter.sim_time_sec"],
               ["rosmsg.sim_time_sec", "octomap.sim_time_sec"],
 
+              ["fromrospy.pose3d", "gas_detector.pose3d"],
               ["fromrospy.gas_detected", "gas_detector.gas_detected"],
               ["gas_detector.localized_artf", "filter.localized_artf"],
 


### PR DESCRIPTION
This is refactoring of artifact processing in `subt/main.py` to separate module `artf_filter.py`. My main motivation was to run post-processing on already detected artifact and delay the report until verified. And there is also filtering of breadcrumbs as false reports and maybe more :). At the end this is this first step although I will have to review it again in the morning with fresh head.

Note also needed change of gas detector, which is now publishing `localized_artf`. Finally there is no longer "terminated" report of all artifacts after return to home - the robot should broadcast them permanently. If you spot some weakness, please let me know.