### PR TITLE
subt/tools/submit.py - support also Urban Simple worlds

### DIFF
--- a/subt/tools/submit.py
+++ b/subt/tools/submit.py
@@ -27,6 +27,9 @@ WORLDS = dict(
     tc8 = "Tunnel Circuit World 8",
 
     uq  = "Urban Qualification",
+    us1 = "Urban Simple 1",
+    us2 = "Urban Simple 2",
+    us3 = "Urban Simple 3",
     up1 = "Urban Practice 1",
     up2 = "Urban Practice 2",
     up3 = "Urban Practice 3",


### PR DESCRIPTION
The Urban Simple worlds were missing in `submit` script, so I added them. First testing run is US2 - `c15a6bb6-51c8-44a0-91a9-e522c2c3ce30` (expected failure due to negative Z for octomap, but it started). Also we have 0 points in all simple worlds ... ;)