### PR TITLE
Filter false DRILL detection mismatched with breadcrumbs

### DIFF
--- a/subt/test_artf_filter.py
+++ b/subt/test_artf_filter.py
@@ -26,7 +26,7 @@ class ArtifactFilterTest(unittest.TestCase):
         # 2nd report should be ignored
         self.assertEqual(filter.maybe_remember_artifact(artf_data, artf_xyz), False)
 
-    def test_usage(self):
+    def test_staging_area(self):
         bus = MagicMock()
         filter = ArtifactFilter(bus=bus, config={})
         filter.on_robot_name(b'A100L')

--- a/subt/test_artf_filter.py
+++ b/subt/test_artf_filter.py
@@ -33,5 +33,17 @@ class ArtifactFilterTest(unittest.TestCase):
         filter.on_localized_artf(['TYPE_DRILL', [-10.0, 0.0, 0.0]])
         bus.publish.assert_not_called()  # inside staging area
 
+    def test_false_drill(self):
+        # the breadcrumbs are sometimes wrongly classified as drill
+        bus = MagicMock()
+        filter = ArtifactFilter(bus=bus, config={})
+        filter.on_robot_name(b'A100L')
+        filter.on_breadcrumb([100.0, 20.0, -30.0])
+        filter.on_localized_artf(['TYPE_DRILL', [100.0, 20.0, -30.0]])
+        bus.publish.assert_not_called()  # inside staging area
+
+        filter.on_localized_artf(['TYPE_DRILL', [105.0, 20.0, -30.0]])
+        bus.publish.assert_called_with('artf_xyz', [['TYPE_DRILL', [105000, 20000, -30000], 'A100L', None]])
+
 
 # vim: expandtab sw=4 ts=4

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -179,6 +179,7 @@
               ["breadcrumbs.deploy", "torospy.deploy"],
               ["breadcrumbs.location", "radio.breadcrumb"],
               ["radio.breadcrumb", "breadcrumbs.external"],
+              ["radio.breadcrumb", "artifact_filter.breadcrumb"],
 
               ["detector.localized_artf", "artifact_filter.localized_artf"],
               ["detector.stdout", "rosmsg.stdout"],

--- a/subt/zmq-subt-x4.json
+++ b/subt/zmq-subt-x4.json
@@ -192,6 +192,7 @@
               ["radio.radio", "rosmsg.broadcast"],
               ["rosmsg.radio", "radio.radio"],
               ["rosmsg.sim_time_sec", "radio.sim_time_sec"],
+              ["radio.breadcrumb", "artifact_filter.breadcrumb"],
 
               ["radio.robot_xyz", "mtm.robot_xyz"],
               ["radio.trace_info", "mtm.trace_info"],


### PR DESCRIPTION
This is the first step to filter 1:1 matching drills and breadcrumbs. There is still danger that Freyja will drop breadcrumb next to the real drill and tolerance 4m could be too long, but due to localization uncertainty the position is sometimes 3m off (to be investigated independently).

![fq-6pts](https://user-images.githubusercontent.com/5664353/117345486-e255a580-aea6-11eb-85a8-0d915ccca553.jpg)
(loosing 2 extra artifacts)

Note, that this PR is based on traversibility map branch.