### PR TITLE
Implement confirmation threshold for artifact filtering

### DIFF
--- a/subt/artf_filter.py
+++ b/subt/artf_filter.py
@@ -5,7 +5,7 @@
 from osgar.node import Node
 from osgar.bus import BusShutdownException
 from subt.trace import distance3D
-from subt.artifacts import DRILL
+from subt.artifacts import DRILL, GAS
 
 
 class ArtifactFilter(Node):
@@ -41,10 +41,13 @@ class ArtifactFilter(Node):
                     # return true only when confirmation threshold was reached
                     if self.verbose:
                         print('Confirmed:', artifact_data, self.confirmations[i])
+                    if artifact_data == GAS:
+                        return False  # ignore confirmation - virtual detector is perfect
                     return self.confirmations[i] == self.num_confirm
         self.artifacts.append((artifact_data, artifact_xyz))
         self.confirmations.append(0)
-        if self.num_confirm > 0:
+        if self.num_confirm > 0 and artifact_data != GAS:
+            # new GAS should be reported independently on confirmation level
             return False
         return True
 

--- a/subt/artf_filter.py
+++ b/subt/artf_filter.py
@@ -12,10 +12,10 @@ class ArtifactFilter(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
         bus.register("artf_xyz")
-        self.num_confirm = config.get('num_confirm', 1)
+        self.min_observations = config.get('min_observations', 2)
         self.robot_name = None  # for "signature" who discovered the artifact
         self.artifacts = []
-        self.confirmations = []
+        self.num_observations = []
         self.breadcrumbs = []
         self.verbose = False
 
@@ -37,16 +37,16 @@ class ArtifactFilter(Node):
             if distance3D((x, y, z), artifact_xyz) < 4.0:
                 # in case of uncertain type, rather report both
                 if stored_data == artifact_data:
-                    self.confirmations[i] += 1
+                    self.num_observations[i] += 1
                     # return true only when confirmation threshold was reached
                     if self.verbose:
-                        print('Confirmed:', artifact_data, self.confirmations[i])
+                        print('Confirmed:', artifact_data, self.num_observations[i])
                     if artifact_data == GAS:
                         return False  # ignore confirmation - virtual detector is perfect
-                    return self.confirmations[i] == self.num_confirm
+                    return self.num_observations[i] == self.min_observations  # report only once
         self.artifacts.append((artifact_data, artifact_xyz))
-        self.confirmations.append(0)
-        if self.num_confirm > 0 and artifact_data != GAS:
+        self.num_observations.append(1)
+        if self.min_observations > 1 and artifact_data != GAS:
             # new GAS should be reported independently on confirmation level
             return False
         return True

--- a/subt/artf_filter.py
+++ b/subt/artf_filter.py
@@ -12,7 +12,7 @@ class ArtifactFilter(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
         bus.register("artf_xyz")
-        self.num_confirm = config.get('num_confirm', 0)
+        self.num_confirm = config.get('num_confirm', 1)
         self.robot_name = None  # for "signature" who discovered the artifact
         self.artifacts = []
         self.confirmations = []

--- a/subt/artf_filter.py
+++ b/subt/artf_filter.py
@@ -24,7 +24,13 @@ class ArtifactFilter(Node):
         self.bus.publish('artf_xyz', [
             [artifact_data, [round(ax * 1000), round(ay * 1000), round(az * 1000)], self.robot_name, None]])
 
-    def maybe_remember_artifact(self, artifact_data, artifact_xyz):
+    def register_new_artifact(self, artifact_data, artifact_xyz):
+        """
+        Register newly detected artifact and update internal structures
+        :param artifact_data: type of artifact
+        :param artifact_xyz: artifact 3D position
+        :return: True if artifact should be new published
+        """
         # the breadcrumbs are sometimes wrongly classified as DRILL
         if artifact_data == DRILL:
             for x, y, z in self.breadcrumbs:
@@ -60,7 +66,7 @@ class ArtifactFilter(Node):
             if self.verbose:
                 print(self.time, 'Robot at staging area:', (ax, ay, az))
         else:
-            if self.maybe_remember_artifact(artifact_data, (ax, ay, az)):
+            if self.register_new_artifact(artifact_data, (ax, ay, az)):
                 self.publish_single_artf_xyz(artifact_data, (ax, ay, az))
 
     def on_robot_name(self, data):

--- a/subt/test_artf_filter.py
+++ b/subt/test_artf_filter.py
@@ -21,10 +21,10 @@ class ArtifactFilterTest(unittest.TestCase):
 
         artf_data = ['TYPE_BACKPACK', -1614, 1886]
         artf_xyz = (0, 0, 0)
-        self.assertTrue(filter.maybe_remember_artifact(artf_data, artf_xyz))
+        self.assertTrue(filter.register_new_artifact(artf_data, artf_xyz))
 
         # 2nd report should be ignored
-        self.assertEqual(filter.maybe_remember_artifact(artf_data, artf_xyz), False)
+        self.assertEqual(filter.register_new_artifact(artf_data, artf_xyz), False)
 
     def test_staging_area(self):
         bus = MagicMock()
@@ -48,9 +48,9 @@ class ArtifactFilterTest(unittest.TestCase):
     def test_artf_confirmation(self):
         bus = MagicMock()
         filter = ArtifactFilter(bus=bus, config={})
-        self.assertFalse(filter.maybe_remember_artifact('TYPE_BACKPACK', [10, 20, 3]))
-        self.assertTrue(filter.maybe_remember_artifact('TYPE_BACKPACK', [10.1, 20, 3]))  # confirmed
-        self.assertFalse(filter.maybe_remember_artifact('TYPE_BACKPACK', [10.1, 20.1, 3]))  # already reported
+        self.assertFalse(filter.register_new_artifact('TYPE_BACKPACK', [10, 20, 3]))
+        self.assertTrue(filter.register_new_artifact('TYPE_BACKPACK', [10.1, 20, 3]))  # confirmed
+        self.assertFalse(filter.register_new_artifact('TYPE_BACKPACK', [10.1, 20.1, 3]))  # already reported
 
     def test_gas_without_confirmation(self):
         bus = MagicMock()

--- a/subt/test_artf_filter.py
+++ b/subt/test_artf_filter.py
@@ -10,14 +10,14 @@ class ArtifactFilterTest(unittest.TestCase):
 
     def test_usage(self):
         bus = MagicMock()
-        filter = ArtifactFilter(bus=bus, config={})
+        filter = ArtifactFilter(bus=bus, config={'num_confirm': 0})
         filter.on_robot_name(b'A100L')
         filter.on_localized_artf([GAS, [100.0, 0.0, 0.0]])
         bus.publish.assert_called_with('artf_xyz', [[GAS, [100000, 0, 0], 'A100L', None]])
 
     def test_maybe_remember_artifact(self):
         bus = MagicMock()
-        filter = ArtifactFilter(bus=bus, config={})
+        filter = ArtifactFilter(bus=bus, config={'num_confirm': 0})
 
         artf_data = ['TYPE_BACKPACK', -1614, 1886]
         artf_xyz = (0, 0, 0)
@@ -28,7 +28,7 @@ class ArtifactFilterTest(unittest.TestCase):
 
     def test_staging_area(self):
         bus = MagicMock()
-        filter = ArtifactFilter(bus=bus, config={})
+        filter = ArtifactFilter(bus=bus, config={'num_confirm': 0})
         filter.on_robot_name(b'A100L')
         filter.on_localized_artf(['TYPE_DRILL', [-10.0, 0.0, 0.0]])
         bus.publish.assert_not_called()  # inside staging area
@@ -36,7 +36,7 @@ class ArtifactFilterTest(unittest.TestCase):
     def test_false_drill(self):
         # the breadcrumbs are sometimes wrongly classified as drill
         bus = MagicMock()
-        filter = ArtifactFilter(bus=bus, config={})
+        filter = ArtifactFilter(bus=bus, config={'num_confirm': 0})
         filter.on_robot_name(b'A100L')
         filter.on_breadcrumb([100.0, 20.0, -30.0])
         filter.on_localized_artf(['TYPE_DRILL', [100.0, 20.0, -30.0]])
@@ -47,7 +47,7 @@ class ArtifactFilterTest(unittest.TestCase):
 
     def test_artf_confirmation(self):
         bus = MagicMock()
-        filter = ArtifactFilter(bus=bus, config={'num_confirm': 1})
+        filter = ArtifactFilter(bus=bus, config={})
         self.assertFalse(filter.maybe_remember_artifact('TYPE_BACKPACK', [10, 20, 3]))
         self.assertTrue(filter.maybe_remember_artifact('TYPE_BACKPACK', [10.1, 20, 3]))  # confirmed
         self.assertFalse(filter.maybe_remember_artifact('TYPE_BACKPACK', [10.1, 20.1, 3]))  # already reported

--- a/subt/test_artf_filter.py
+++ b/subt/test_artf_filter.py
@@ -52,4 +52,11 @@ class ArtifactFilterTest(unittest.TestCase):
         self.assertTrue(filter.maybe_remember_artifact('TYPE_BACKPACK', [10.1, 20, 3]))  # confirmed
         self.assertFalse(filter.maybe_remember_artifact('TYPE_BACKPACK', [10.1, 20.1, 3]))  # already reported
 
+    def test_gas_without_confirmation(self):
+        bus = MagicMock()
+        filter = ArtifactFilter(bus=bus, config={'num_confirm': 3})
+        filter.on_robot_name(b'A100L')
+        filter.on_localized_artf([GAS, [100.0, 0.0, 0.0]])
+        bus.publish.assert_called_with('artf_xyz', [[GAS, [100000, 0, 0], 'A100L', None]])
+
 # vim: expandtab sw=4 ts=4

--- a/subt/test_artf_filter.py
+++ b/subt/test_artf_filter.py
@@ -10,14 +10,14 @@ class ArtifactFilterTest(unittest.TestCase):
 
     def test_usage(self):
         bus = MagicMock()
-        filter = ArtifactFilter(bus=bus, config={'num_confirm': 0})
+        filter = ArtifactFilter(bus=bus, config={'min_observations': 1})
         filter.on_robot_name(b'A100L')
         filter.on_localized_artf([GAS, [100.0, 0.0, 0.0]])
         bus.publish.assert_called_with('artf_xyz', [[GAS, [100000, 0, 0], 'A100L', None]])
 
     def test_maybe_remember_artifact(self):
         bus = MagicMock()
-        filter = ArtifactFilter(bus=bus, config={'num_confirm': 0})
+        filter = ArtifactFilter(bus=bus, config={'min_observations': 1})
 
         artf_data = ['TYPE_BACKPACK', -1614, 1886]
         artf_xyz = (0, 0, 0)
@@ -28,7 +28,7 @@ class ArtifactFilterTest(unittest.TestCase):
 
     def test_staging_area(self):
         bus = MagicMock()
-        filter = ArtifactFilter(bus=bus, config={'num_confirm': 0})
+        filter = ArtifactFilter(bus=bus, config={'min_observations': 1})
         filter.on_robot_name(b'A100L')
         filter.on_localized_artf(['TYPE_DRILL', [-10.0, 0.0, 0.0]])
         bus.publish.assert_not_called()  # inside staging area
@@ -36,7 +36,7 @@ class ArtifactFilterTest(unittest.TestCase):
     def test_false_drill(self):
         # the breadcrumbs are sometimes wrongly classified as drill
         bus = MagicMock()
-        filter = ArtifactFilter(bus=bus, config={'num_confirm': 0})
+        filter = ArtifactFilter(bus=bus, config={'min_observations': 1})
         filter.on_robot_name(b'A100L')
         filter.on_breadcrumb([100.0, 20.0, -30.0])
         filter.on_localized_artf(['TYPE_DRILL', [100.0, 20.0, -30.0]])
@@ -54,7 +54,7 @@ class ArtifactFilterTest(unittest.TestCase):
 
     def test_gas_without_confirmation(self):
         bus = MagicMock()
-        filter = ArtifactFilter(bus=bus, config={'num_confirm': 3})
+        filter = ArtifactFilter(bus=bus, config={'min_observations': 4})
         filter.on_robot_name(b'A100L')
         filter.on_localized_artf([GAS, [100.0, 0.0, 0.0]])
         bus.publish.assert_called_with('artf_xyz', [[GAS, [100000, 0, 0], 'A100L', None]])

--- a/subt/test_artf_filter.py
+++ b/subt/test_artf_filter.py
@@ -45,5 +45,11 @@ class ArtifactFilterTest(unittest.TestCase):
         filter.on_localized_artf(['TYPE_DRILL', [105.0, 20.0, -30.0]])
         bus.publish.assert_called_with('artf_xyz', [['TYPE_DRILL', [105000, 20000, -30000], 'A100L', None]])
 
+    def test_artf_confirmation(self):
+        bus = MagicMock()
+        filter = ArtifactFilter(bus=bus, config={'num_confirm': 1})
+        self.assertFalse(filter.maybe_remember_artifact('TYPE_BACKPACK', [10, 20, 3]))
+        self.assertTrue(filter.maybe_remember_artifact('TYPE_BACKPACK', [10.1, 20, 3]))  # confirmed
+        self.assertFalse(filter.maybe_remember_artifact('TYPE_BACKPACK', [10.1, 20.1, 3]))  # already reported
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
This is simple artifact filtering. Based on the last Freyja run in FP2 I have seen for properly detected artifacts:
```
0:02:04.584665 ['TYPE_BACKPACK', [12.404765528524946, 7.341454907572785, 0.25001002175853737]]
Confirmed: TYPE_BACKPACK 38
0:06:06.583681 ['TYPE_VENT', [19.190128880089453, -17.86577439674212, 1.9636593698621922]]
Confirmed: TYPE_VENT 12
0:07:14.534541 ['TYPE_CUBE', [20.05912215692238, -34.87304921571129, 0.15473397959270255]]
Confirmed: TYPE_CUBE 25
0:20:40.407697 ['TYPE_PHONE', [-6.7927368090999405, -95.57470150990535, -5.88281186353819]]
Confirmed: TYPE_PHONE 118
...
```
:) so even the phone can be sometimes seen for many frames.
I plan to add now commit increasing the default for `num_confirm` to 1.
