### PR TITLE
Use confidence borders for check detections

### DIFF
--- a/subt/artf_node.py
+++ b/subt/artf_node.py
@@ -140,7 +140,7 @@ class ArtifactDetectorDNN(Node):
             'helmet': 0.5,
             'rope': 0.5,
             'fire_extinguisher': 0.5,
-            'drill': 0.5,
+            'drill': 0.75,
             'vent': 0.5,
             'cube': 0.5
         }

--- a/subt/artf_node.py
+++ b/subt/artf_node.py
@@ -34,6 +34,18 @@ NAME2IGN = {
 }
 
 
+def check_borders(result, borders):
+    for ii, (name, points, r_cv) in enumerate(result.copy()):
+        points.sort(key=lambda item: item[2], reverse=True)
+        x = points[1][2]  # mdnet score
+        y = r_cv[1]  # cv_detector score
+        a1, b1, a2, b2 = borders[name]  # coefficients of lines equations - borders
+        if y < min(a1 * x + b1, a2 * x + b2):  # the value is below the borders
+            result.pop(ii)
+
+        return result
+
+
 def check_results(result_mdnet, result_cv):
     result = result_mdnet.copy()
     ret = []
@@ -91,6 +103,19 @@ def result2report(result, depth, fx, robot_pose, camera_pose, max_depth):
     return [NAME2IGN[result[0][0]], world_xyz]
 
 
+def get_border_lines(border_points):
+    ret = {}
+    for name, points in border_points.items():
+        A, B, C = points
+        a1 = (B[1] - A[1]) / (B[0] - A[0])  # slope of the first line
+        a2 = (C[1] - B[1]) / (C[0] - B[0])  # slope of the second line
+        b1 = B[1] - a1 * B[0]  # the first intercept
+        b2 = B[1] - a2 * B[0]  # the second intercept
+        ret[name] = [a1, b1, a2, b2]
+
+    return ret
+
+
 def create_detector(confidence_thresholds):
     model = os.path.join(os.path.dirname(__file__), '../../../mdnet5.128.128.13.4.elu.pth')
     max_gap = 16
@@ -108,17 +133,31 @@ class ArtifactDetectorDNN(Node):
         super().__init__(config, bus)
         bus.register("localized_artf", "dropped", "debug_rgbd", "stdout",
                      "debug_result", "debug_cv_result")
-        confidence_thresholds = {
-            'survivor': 0.8,
-            'backpack': 0.8,
+        confidence_thresholds = {  # used for mdnet
+            'survivor': 0.5,
+            'backpack': 0.5,
             'phone': 0.5,
             'helmet': 0.5,
-            'rope': 0.6,
+            'rope': 0.5,
             'fire_extinguisher': 0.5,
             'drill': 0.5,
             'vent': 0.5,
             'cube': 0.5
         }
+        # Confidence borders points
+        # There are tree border points for each artifact, point coordinates: x - mdnet, y - cv_detector
+        confidence_borders = {
+            'survivor': [[0.6, 1],[0.9, 0.65],[0.95, 0.2]],
+            'backpack': [[0.5, 0.6],[0.96, 0.55],[0.99, 0.2]],
+            'phone': [[0.5, 0.4],[0.87, 0.65],[1, 0.2]],
+            'helmet': [[0.5, 0.6],[0.9, 0.4],[1, 0.1]],
+            'rope': [[0.6, 0.5],[0.95, 0.35],[1, 0.2]],
+            'fire_extinguisher': [[0.5, 0.75],[0.95, 0.7],[1, 0.65]],
+            'drill': [[0.75, 1],[0.9, 0.8],[0.91, 0.1]],
+            'vent': [[0.5, 0.98],[0.9, 0.9],[1, 0.1]],
+            'cube': [[0.5, 0.4],[0.9, 0.4],[1, 0.4]]
+        }
+        self.border_lines = get_border_lines(confidence_borders)
         self.time = None
         self.width = None  # not sure if we will need it
         self.depth = None  # more precise artifact position from depth image
@@ -175,11 +214,13 @@ class ArtifactDetectorDNN(Node):
             self.publish('debug_cv_result', result_cv)
             checked_result = check_results(result, result_cv)
             if checked_result:
-                report = result2report(checked_result, depth, self.fx,
-                        robot_pose, camera_pose, self.max_depth)
-                if report is not None:
-                    self.publish('localized_artf', report)
-                    self.publish('debug_rgbd', rgbd)
+                checked_result = check_borders(checked_result, self.border_lines)
+                if checked_result:
+                    report = result2report(checked_result, depth, self.fx,
+                            robot_pose, camera_pose, self.max_depth)
+                    if report is not None:
+                        self.publish('localized_artf', report)
+                        self.publish('debug_rgbd', rgbd)
 
 
 if __name__ == "__main__":

--- a/subt/artf_node.py
+++ b/subt/artf_node.py
@@ -148,8 +148,8 @@ class ArtifactDetectorDNN(Node):
         # There are tree border points for each artifact, point coordinates: x - mdnet, y - cv_detector
         confidence_borders = {
             'survivor': [[0.6, 1],[0.9, 0.65],[0.95, 0.2]],
-            'backpack': [[0.5, 0.6],[0.96, 0.55],[0.99, 0.2]],
-            'phone': [[0.5, 0.4],[0.87, 0.65],[1, 0.2]],
+            'backpack': [[0.5, 0.55],[0.97, 0.4],[0.99, 0.2]],
+            'phone': [[0.5, 0.4],[0.82, 0.37],[1, 0.2]],
             'helmet': [[0.5, 0.6],[0.9, 0.4],[1, 0.1]],
             'rope': [[0.6, 0.5],[0.95, 0.35],[1, 0.2]],
             'fire_extinguisher': [[0.5, 0.75],[0.95, 0.7],[1, 0.65]],

--- a/subt/test_artf_node.py
+++ b/subt/test_artf_node.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 
-from subt.artf_node import result2report, check_results
+from subt.artf_node import result2report, check_results, check_borders, get_border_lines
 
 
 DRONE_FX = 554.25469
@@ -10,7 +10,8 @@ DRONE_FX = 554.25469
 class ArtifactDetectorDNNTest(unittest.TestCase):
 
     def test_result2report(self):
-        result = [('backpack', [(60, 180, 0.9785775), (72, 180, 0.9795098), (60, 184, 0.97716093), (72, 184, 0.9782014)])]
+        result = [('backpack', [(60, 180, 0.9785775), (72, 180, 0.9795098), (60, 184, 0.97716093), (72, 184, 0.9782014)]),
+                  ['backpack', 0.99990773, [50, 150, 200, 250]]]
         row = [5000]*640
         depth = np.array([row]*360, dtype=np.uint16)
         robot_pose = [0, 0, 0], [0, 0, 0, 1]
@@ -82,5 +83,18 @@ class ArtifactDetectorDNNTest(unittest.TestCase):
         robot_pose, camera_pose, max_depth = None, None, 10.0
         self.assertIsNone(result2report(result, depth=None, fx=100, robot_pose=robot_pose,
                                        camera_pose=camera_pose, max_depth=max_depth))
+
+    def test_above_border(self):
+        borders_points = {'backpack': [[0.5, 0.6],[0.96, 0.55],[0.99, 0.2]]}
+        borders = get_border_lines(borders_points)
+        result = [('backpack', [(100, 200, 0.99), (101, 200, 0.995)], ['backpack', 0.21, [50, 150, 200, 250]])]
+        self.assertEqual(check_borders(result, borders), result)
+
+    def test_below_border(self):
+        borders_points = {'backpack': [[0.5, 0.6],[0.96, 0.55],[0.99, 0.2]]}
+        borders = get_border_lines(borders_points)
+        result = [('backpack', [(100, 200, 0.5), (101, 200, 0.9)], ['backpack', 0.59, [50, 150, 200, 250]])]
+        self.assertEqual(check_borders(result, borders), [])
+
 
 # vim: expandtab sw=4 ts=4

--- a/subt/tf_detector.py
+++ b/subt/tf_detector.py
@@ -10,15 +10,15 @@ MODEL_DIR = "subt/tf_models"
 PATH_TO_PB_GRAPH = "subt/tf_models/frozen_inference_graph.pb"
 PATH_TO_CV_GRAPH = "subt/tf_models/cv_graph.pbtxt"
 
-NAMES_AND_SCORES = {'backpack': 0.36,
-                    'survivor': 0.25,
-                    'phone': 0.1,
-                    'rope': 0.25,
-                    'helmet': 0.4,
-                    'fire_extinguisher': 0.1,
+NAMES_AND_SCORES = {'backpack': 0.1,
+                    'survivor': 0.1,
+                    'phone': 0.2,
+                    'rope': 0.2,
+                    'helmet': 0.1,
+                    'fire_extinguisher': 0.65,
                     'drill': 0.1,
                     'vent': 0.1,
-                    'cube': 0.1,
+                    'cube': 0.4,
                     'robot': 1.0,
                     'breadcrumb': 1.0,
                     'nothing': 1.0


### PR DESCRIPTION
This is an attempt to use a more advanced verification of detections. The detections are verified via border between false and true areas. The borders are defined by three points.
The disadvantage is higher amount of detections that needed to be sort out. 