### PR TITLE
Parsing new directory structure of SubT Finals logs

### DIFF
--- a/subt/main.py
+++ b/subt/main.py
@@ -910,7 +910,7 @@ class SubTChallenge:
         self.stdout('Final xyz (DARPA coord system):', self.xyz)
 
     def play_virtual_track(self):
-        self.stdout("SubT Challenge Ver108!")
+        self.stdout("SubT Challenge Ver109!")
         self.stdout("Waiting for robot_name ...")
         while self.robot_name is None:
             self.update()

--- a/subt/rosbag2log.py
+++ b/subt/rosbag2log.py
@@ -206,13 +206,14 @@ def process_tar(filepath, all, verbose):
                 elif member.name.endswith('rosout.log'):
                     rosout_name = letter + '-rosout.log'
                     print(member.name, "->", rosout_name)
-                    with open(os.path.join(os.path.dirname(filepath), rosout_name), 'wb') as f:
+                    with open(os.path.join(os.path.dirname(filepath), os.path.basename(rosout_name)), 'wb') as f:
                         f.write(tar.extractfile(member).read())
                 elif (member.name in ['server_console.log'] or member.name.endswith('.yml') or
                       member.name.startswith('subt_urban_') or member.name.startswith('subt_cave_') or
-                      (member.name.startswith('state.tlog') and all)):
+                      'subt_finals_' in member.name or member.name.endswith('-pos.data') or
+                      ('state.tlog' in member.name and all)):
                     print(member.name)
-                    with open(os.path.join(os.path.dirname(filepath), member.name.replace(':', '_')), 'wb') as f:
+                    with open(os.path.join(os.path.dirname(filepath), os.path.basename(member.name).replace(':', '_')), 'wb') as f:
                         f.write(tar.extractfile(member).read())
 
 

--- a/subt/tools/ignstate.py
+++ b/subt/tools/ignstate.py
@@ -122,7 +122,7 @@ def read_artifacts(filename):
 
 
 def _read_world(cursor):
-    cursor.execute(f"SELECT id FROM topics WHERE name == '/logs/sdf'")
+    cursor.execute(f"SELECT id FROM topics WHERE name == '/gazebo/sdf'")
     result = cursor.fetchone()
     sdf_id = result[0]
     cursor.execute(r"SELECT message, topic_id FROM messages")


### PR DESCRIPTION
This is rather "misc" branch, where I originally wanted to increase version to `Ver109` to run from master with new thresholds. The result was not good (6 points FQ), so I wanted to check older single Freyja run with 9 points ... but there is slightly different format of `.tar.gz` files with `gazebo` sub-folder. This workaround works for me with outputs:
```
gazebo/subt_finals_2021-05-26T20:44:04.899394422.log
gazebo/events.yml
gazebo/summary.yml
gazebo/score.yml
gazebo/pos-data/A5C2700L-pos.data
gazebo/run.yml
gazebo/state.tlog
gazebo/state.tlog-journal
```

Note, that `A5C2700L-pos.data` is new and we may use it later instead to huge `state.tlog` file (just to validate data received by Teambase, one day).