### PR TITLE
Stop logging while standstill

### DIFF
--- a/subt/config/coro_pam.json
+++ b/subt/config/coro_pam.json
@@ -130,7 +130,7 @@
           "in": ["rgbd"],
           "out": ["image", "depth"],
           "init": {
-            "image_sampling": 2
+            "image_sampling": 4
           }
       },
       "logimage_left": {
@@ -138,7 +138,7 @@
           "in": ["rgbd"],
           "out": ["image", "depth"],
           "init": {
-            "image_sampling": 2
+            "image_sampling": 4
           }
       },
       "logimage_right": {
@@ -146,7 +146,7 @@
           "in": ["rgbd"],
           "out": ["image", "depth"],
           "init": {
-            "image_sampling": 2
+            "image_sampling": 4
           }
       },
       "radio": {

--- a/subt/image_extractor.py
+++ b/subt/image_extractor.py
@@ -7,11 +7,13 @@ import numpy as np
 
 from osgar.node import Node
 from osgar.lib.depth import decompress as decompress_depth
+from osgar.lib import quaternion
+
 from subt.trace import distance3D
 
 
 DEFAULT_MIN_DIST_STEP = 0.1  # meters
-DEFAULT_MIN_ANGLE_STEP = math.degrees(10)
+DEFAULT_MIN_ANGLE_STEP = math.radians(10)
 
 
 class ImageExtractor(Node):
@@ -30,7 +32,8 @@ class ImageExtractor(Node):
 
         if self.image_sampling > 0 and self.index % self.image_sampling == 0:
             if (self.last_anchor_pose is None or
-                distance3D(self.last_anchor_pose[0], robot_pose[0]) >= self.image_min_dist_step):
+                distance3D(self.last_anchor_pose[0], robot_pose[0]) >= self.image_min_dist_step or
+                quaternion.angle_between(self.last_anchor_pose[1], robot_pose[1]) >= self.image_min_angle_step):
                 self.publish('image', rgb_compressed)
                 self.last_anchor_pose = robot_pose
 

--- a/subt/image_extractor.py
+++ b/subt/image_extractor.py
@@ -3,12 +3,15 @@
 """
 import math
 
-import cv2
 import numpy as np
 
 from osgar.node import Node
-from osgar.bus import BusShutdownException
 from osgar.lib.depth import decompress as decompress_depth
+from subt.trace import distance3D
+
+
+DEFAULT_MIN_DIST_STEP = 0.1  # meters
+DEFAULT_MIN_ANGLE_STEP = math.degrees(10)
 
 
 class ImageExtractor(Node):
@@ -16,14 +19,20 @@ class ImageExtractor(Node):
         super().__init__(config, bus)
         bus.register("image", "depth:gz")
         self.image_sampling = config.get('image_sampling', 1)  # no drop
+        self.image_min_dist_step = config.get('min_dist', DEFAULT_MIN_DIST_STEP)
+        self.image_min_angle_step = config.get('min_angle', DEFAULT_MIN_ANGLE_STEP)
         self.depth_sampling = config.get('depth_sampling', -1)  # do not log depth
         self.index = 0
+        self.last_anchor_pose = None  # unknown
 
     def on_rgbd(self, data):
         robot_pose, camera_pose, rgb_compressed, depth_compressed = data
 
         if self.image_sampling > 0 and self.index % self.image_sampling == 0:
-            self.publish('image', rgb_compressed)
+            if (self.last_anchor_pose is None or
+                distance3D(self.last_anchor_pose[0], robot_pose[0]) >= self.image_min_dist_step):
+                self.publish('image', rgb_compressed)
+                self.last_anchor_pose = robot_pose
 
         if self.depth_sampling > 0 and self.index % self.depth_sampling == 0:
             arr = decompress_depth(depth_compressed) * 1000

--- a/subt/image_extractor.py
+++ b/subt/image_extractor.py
@@ -25,25 +25,30 @@ class ImageExtractor(Node):
         self.min_dist_step = config.get('min_dist', DEFAULT_MIN_DIST_STEP)
         self.min_angle_step = config.get('min_angle', DEFAULT_MIN_ANGLE_STEP)
         self.index = 0
-        self.last_anchor_pose = None  # unknown
+        self.last_image_anchor_pose = None  # unknown
+        self.last_depth_anchor_pose = None  # unknown
+
+    def sufficient_step(self, anchor_pose, robot_pose):
+        return (anchor_pose is None or
+            distance3D(anchor_pose[0], robot_pose[0]) >= self.min_dist_step or
+            quaternion.angle_between(anchor_pose[1], robot_pose[1]) >= self.min_angle_step)
 
     def on_rgbd(self, data):
         robot_pose, camera_pose, rgb_compressed, depth_compressed = data
 
-        sufficient_step = (self.last_anchor_pose is None or
-            distance3D(self.last_anchor_pose[0], robot_pose[0]) >= self.min_dist_step or
-            quaternion.angle_between(self.last_anchor_pose[1], robot_pose[1]) >= self.min_angle_step)
-        if self.image_sampling > 0 and self.index % self.image_sampling == 0 and sufficient_step:
+        if (self.image_sampling > 0 and self.index % self.image_sampling == 0 and
+                self.sufficient_step(self.last_image_anchor_pose, robot_pose)):
             self.publish('image', rgb_compressed)
-            self.last_anchor_pose = robot_pose
+            self.last_image_anchor_pose = robot_pose
 
-        if self.depth_sampling > 0 and self.index % self.depth_sampling == 0 and sufficient_step:
+        if (self.depth_sampling > 0 and self.index % self.depth_sampling == 0 and
+                self.sufficient_step(self.last_depth_anchor_pose, robot_pose)):
             arr = decompress_depth(depth_compressed) * 1000
             arr = np.clip(arr, 1, 0xFFFF)
             arr = np.ndarray.astype(arr, dtype=np.dtype('H'))
             self.publish('depth', arr)
-            self.last_anchor_pose = robot_pose  # note, that for proper operation the sampling should be the same or
-                                                # multiply of the other
+            self.last_depth_anchor_pose = robot_pose
+
         self.index += 1
 
     def update(self):

--- a/subt/test_image_extractor.py
+++ b/subt/test_image_extractor.py
@@ -1,5 +1,8 @@
+import math
 import unittest
 from unittest.mock import MagicMock
+
+from osgar.lib import quaternion
 
 from subt.image_extractor import ImageExtractor
 
@@ -35,6 +38,24 @@ class ImageExtractorTest(unittest.TestCase):
             logimage.on_rgbd(data)
 
         self.assertEqual(len(bus.method_calls), 1)
+
+    def test_min_dist(self):
+        bus = MagicMock()
+        logimage = ImageExtractor(bus=bus, config={})
+
+        robot_pose = [[0, 0, 0], [0, 0, 0, 1]]
+        angle = quaternion.euler_to_quaternion(yaw=math.radians(20), roll=0, pitch=0)
+        camera_pose = None
+        rgb_compressed = b'dummy image'
+        depth_compressed = None
+
+        bus.reset_mock()
+        for i in range(10):
+            data = robot_pose, camera_pose, rgb_compressed, depth_compressed
+            logimage.on_rgbd(data)
+            robot_pose = [robot_pose[0], quaternion.multiply(robot_pose[1], angle)]
+
+        self.assertEqual(len(bus.method_calls), 10)
 
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_image_extractor.py
+++ b/subt/test_image_extractor.py
@@ -6,7 +6,7 @@ from subt.image_extractor import ImageExtractor
 
 class ImageExtractorTest(unittest.TestCase):
 
-    def test_min_dist(self):
+    def test_usage(self):
         bus = MagicMock()
         logimage = ImageExtractor(bus=bus, config={})
 
@@ -19,6 +19,22 @@ class ImageExtractorTest(unittest.TestCase):
         logimage.on_rgbd(data)
 
         bus.publish.assert_called_with('image', b'dummy image')
+
+    def test_min_dist(self):
+        bus = MagicMock()
+        logimage = ImageExtractor(bus=bus, config={})
+
+        robot_pose = [[0, 0, 0], [0, 0, 0, 1]]
+        camera_pose = None
+        rgb_compressed = b'dummy image'
+        depth_compressed = None
+
+        bus.reset_mock()
+        for i in range(10):
+            data = robot_pose, camera_pose, rgb_compressed, depth_compressed
+            logimage.on_rgbd(data)
+
+        self.assertEqual(len(bus.method_calls), 1)
 
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_image_extractor.py
+++ b/subt/test_image_extractor.py
@@ -1,0 +1,24 @@
+import unittest
+from unittest.mock import MagicMock
+
+from subt.image_extractor import ImageExtractor
+
+
+class ImageExtractorTest(unittest.TestCase):
+
+    def test_min_dist(self):
+        bus = MagicMock()
+        logimage = ImageExtractor(bus=bus, config={})
+
+        robot_pose = None
+        camera_pose = None
+        rgb_compressed = b'dummy image'
+        depth_compressed = None
+
+        data = robot_pose, camera_pose, rgb_compressed, depth_compressed
+        logimage.on_rgbd(data)
+
+        bus.publish.assert_called_with('image', b'dummy image')
+
+
+# vim: expandtab sw=4 ts=4


### PR DESCRIPTION
This PR should help with logging more interesting images and also to keep the log file size within 2GB limit.

I am not sure about some details:
* external configuration which we do not use now
* parametrize only image with distance and angle (and ignore depth)
* the default 0.1m and 10deg

Reference run `ver116min` `2cfa987d-2c2e-4336-bea7-171d43391b26` - `A600W600L` in TC2