### PR TITLE
Draw overview of robot positions from *-pos.data files

### DIFF
--- a/subt/tools/draw_pos_data.py
+++ b/subt/tools/draw_pos_data.py
@@ -1,0 +1,50 @@
+"""
+  Draw *-pos.data files stored in simulation log
+"""
+
+from pathlib import Path
+
+from matplotlib import pyplot as plt
+
+
+def read_pos_data(filename):
+    """
+    Read data from file which looks like (sec, nsec, x, y, z)
+        0 8000000 -14 0 0.149843
+        1 12000000 -13.9997 -1.6e-05 0.117777
+        2 16000000 -13.9997 -1.9e-05 0.117841
+    """
+    arr = []
+    for line in open(filename):
+        sec, nsec, x, y, z = [float(a) for a in line.split()]
+        arr.append((sec + nsec/1_000_000_000, (x, y, z)))
+    return arr
+
+
+def read_all(folder):
+    ret = {}
+    for path in Path(folder).glob('*-pos.data'):
+        name = path.stem[:-4]  # cutoff "-pos"
+        print(name)
+        ret[name] = read_pos_data(path)
+    return ret
+
+
+def draw(robots):
+    for name, arr in robots.items():
+        x = [xyz[0] for t, xyz in arr]
+        y = [xyz[1] for t, xyz in arr]
+        plt.plot(x, y, '-', label=name)
+    plt.axes().set_aspect('equal', 'datalim')
+    plt.legend()
+    plt.show()
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('folder', help='folder with *-pos.data files')
+    args = parser.parse_args()
+    robots = read_all(args.folder
+                      )
+    draw(robots)

--- a/subt/tools/draw_pos_data.py
+++ b/subt/tools/draw_pos_data.py
@@ -45,6 +45,5 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('folder', help='folder with *-pos.data files')
     args = parser.parse_args()
-    robots = read_all(args.folder
-                      )
+    robots = read_all(args.folder)
     draw(robots)


### PR DESCRIPTION
Formerly used "state.tlog" has for FP1 simulation 8GB while sum of these small *-pos.data files
for 8 robots is 815kB. Also the sampling is only XYZ every simulated second, which is enough
for the run overview.

An example FP1:
![FP1-track](https://user-images.githubusercontent.com/5664353/128349314-46938889-2bae-4c58-8e2d-5db404c74023.png)
