### PR TITLE
Generate crash report

### DIFF
--- a/subt/config/coro_pam.json
+++ b/subt/config/coro_pam.json
@@ -176,6 +176,13 @@
             "min_z": 0.0,
             "max_z": 4.0
           }
+      },
+      "black_box": {
+        "driver": "subt.crash_report:CrashReport",
+          "init": {
+            "size": 100,
+            "threshold": 30.0
+          }
       }
     },
     "links": [["app.desired_speed", "drone.desired_speed"],
@@ -197,6 +204,10 @@
               ["fromrospy.rgbd_left", "detector_left.rgbd"],
               ["fromrospy.rgbd_right", "detector_right.rgbd"],
 
+              ["fromrospy.acc", "black_box.acc"],
+              ["fromrospy.rgbd_front", "black_box.rgbd"],
+              ["fromrospy.rgbd_left", "black_box.rgbd"],
+              ["fromrospy.rgbd_right", "black_box.rgbd"],
 
               ["fromrospy.pose3d", "app.pose3d"],
               ["rosmsg.sim_time_sec", "app.sim_time_sec"],

--- a/subt/crash_report.py
+++ b/subt/crash_report.py
@@ -1,0 +1,38 @@
+"""
+  Keep given buffer of RGBD images until crash happens (detected in accelerometers)
+"""
+import collections
+
+from osgar.node import Node
+from subt.trace import distance3D
+
+
+class CrashReport(Node):
+    def __init__(self, config, bus):
+        super().__init__(config, bus)
+        bus.register("crash_rgbd")
+        size = config.get('size', 100)  # keep N last records
+        self.acc_limit = config.get('acc_limit', 100.0)  # i.e. 10g
+        self.buf = collections.deque(maxlen=size)
+
+    def on_rgbd(self, data):
+        self.buf.append(data)
+
+    def on_acc(self, data):
+        vec = [x/1000.0 for x in data]
+        value = abs(distance3D(vec, [0, 0, 0]) - 9.81)
+        if value >= self.acc_limit:
+            for rec in self.buf:
+                self.publish('crash_rgbd', rec)
+            self.buf.clear()
+
+    def update(self):
+        channel = super().update()
+        handler = getattr(self, "on_" + channel, None)
+        if handler is not None:
+            handler(getattr(self, channel))
+        else:
+            assert False, channel  # unsupported channel
+        return channel
+
+# vim: expandtab sw=4 ts=4

--- a/subt/crash_report.py
+++ b/subt/crash_report.py
@@ -12,7 +12,7 @@ class CrashReport(Node):
         super().__init__(config, bus)
         bus.register("crash_rgbd")
         size = config.get('size', 100)  # keep N last records
-        self.acc_limit = config.get('acc_limit', 100.0)  # i.e. 10g
+        self.threshold = config.get('threshold', 100.0)  # i.e. 10g
         self.buf = collections.deque(maxlen=size)
 
     def on_rgbd(self, data):
@@ -21,7 +21,7 @@ class CrashReport(Node):
     def on_acc(self, data):
         vec = [x/1000.0 for x in data]
         value = abs(distance3D(vec, [0, 0, 0]) - 9.81)
-        if value >= self.acc_limit:
+        if value >= self.threshold:
             for rec in self.buf:
                 self.publish('crash_rgbd', rec)
             self.buf.clear()

--- a/subt/test_crash_report.py
+++ b/subt/test_crash_report.py
@@ -1,0 +1,44 @@
+import math
+import unittest
+from unittest.mock import MagicMock
+
+from subt.crash_report import CrashReport
+
+
+class CrashReportTest(unittest.TestCase):
+
+    def test_usage(self):
+        bus = MagicMock()
+        black_box = CrashReport(bus=bus, config={})
+
+        data = b'data1'
+        black_box.on_rgbd(data)
+        bus.pubilsh.assert_not_called()
+        black_box.on_acc(([-60, 70, 9805]))
+        bus.publish.assert_not_called()
+
+        data = b'data2'
+        black_box.on_rgbd(data)
+        bus.publish.assert_not_called()
+
+        # example crash of drones in ver115tf2fp1r2-d53b93ce-64e7-43fc-9838-3ee59b6b77b6, A-drone
+        # 0:13:22.940140 9 [-144200, 3600, 3245]
+        # 0:13:23.024618 9 [-220, 125, 9880]
+        # 0:13:23.031486 9 [-55, 90, 55]
+        # 0:13:23.035212 9 [-10, 95, 85]
+        # 0:13:23.041146 9 [-20, 130, 55]
+        # 0:13:23.188065 9 [5, 90, 65]
+        # 0:13:23.190759 9 [5, 80, 95]
+        # 0:13:23.197192 9 [30, 95, 65]
+        # 0:13:23.203757 9 [-10, 65, 25]
+        # 0:13:23.275979 9 [-2250, 3700, 630]
+        # 0:13:23.513236 9 [-288580, -65640, -56455]
+
+        black_box.on_acc(([-144200, 3600, 3245]))
+        bus.publish.assert_called_with('crash_rgbd', b'data2')
+
+        bus.reset_mock()
+        black_box.on_acc(([-288580, -65640, -56455]))  # now new data were received in meantime
+        bus.publish.assert_not_called()
+
+# vim: expandtab sw=4 ts=4

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -131,6 +131,13 @@
       },
       "octomap": {
         "driver": "subt.octomap:Octomap"
+      },
+      "black_box": {
+        "driver": "subt.crash_report:CrashReport",
+          "init": {
+            "size": 100,
+            "threshold": 30.0
+          }
       }
     },
     "links": [["app.desired_speed", "twister.desired_speed"],
@@ -149,6 +156,10 @@
 
               ["fromrospy.rgbd_front", "detector.rgbd"],
               ["fromrospy.rgbd_rear", "detector_rear.rgbd"],
+
+              ["fromrospy.acc", "black_box.acc"],
+              ["fromrospy.rgbd_front", "black_box.rgbd"],
+              ["fromrospy.rgbd_rear", "black_box.rgbd"],
 
               ["fromrospy.scan360", "app.scan360"],
 


### PR DESCRIPTION
Whenever accelerometer value is above the `threshold` new module dumps `crash_rgbd` into log file. The buffer size is limited and on Pam drone it contains all 3 types of RGBD images (left, front, right).

p.s. at the moment I have troubles to crash the drone ;) ...