### PR TITLE
Convert crash report

### DIFF
--- a/subt/crash_report.py
+++ b/subt/crash_report.py
@@ -60,10 +60,9 @@ if __name__ == "__main__":
     stream_names = lookup_stream_names(args.logfile)
 
     def get_camera_name_id(camera_pose):
-        y = camera_pose[0][1]
+        x, y = camera_pose[0][:2]
         if y == 0:
-            camera_direction = 'front'
-            # TODO rear
+            camera_direction = 'front' if x > 0 else 'rear'
         elif y < 0:
             camera_direction = 'right'
         else:  # y > 0

--- a/subt/crash_report.py
+++ b/subt/crash_report.py
@@ -44,8 +44,15 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser("Analyze crash_rgbd data")
     parser.add_argument('logfile', help='path to logfile')
+    parser.add_argument('--out', help='custom output (default [logfile]-crash.log)')
     parser.add_argument('--verbose', '-v', help="verbose mode", action='store_true')
     args = parser.parse_args()
+
+    outfile = args.out
+    if outfile is None:
+        assert args.logfile.endswith('.log')
+        outfile = args.logfile[:-4] + '-crash.log'
+    print('Crash outfile:', outfile)
 
     crash_stream_id = lookup_stream_id(args.logfile, 'black_box.crash_rgbd')
     pose3d_stream_id = lookup_stream_id(args.logfile, 'fromrospy.pose3d')
@@ -73,7 +80,7 @@ if __name__ == "__main__":
     crash_time = None
     with LogReader(args.logfile,
                only_stream_id=[pose3d_stream_id, crash_stream_id]) as logreader, LogWriter(
-            filename='crash.log', start_time=logreader.start_time) as f:
+            filename=outfile, start_time=logreader.start_time) as f:
         for name in stream_names:
             f.register(name)
         for time, stream, raw_bytes in logreader:


### PR DESCRIPTION
This is the first (minimal) step to extract `black_box.crash_rgbd` data and sort it into `fromrospy.{left|front|right}` streams. There is also experimental pose3d lookup but it is available only in `--verbose` mode.

Note, that the crash on stairs we have seen so far is probably caused by drained battery ... so the drone was not able to climb the stairs and return home.

Run:
`python -m subt.crash_report /data/aws/finals/FP2/ver117crash/B600W600RH3600W.log` generates `crash.log` and then
```
(osgar) md@md-ThinkPad-P50:~/git/osgar$ python -m osgar.logger crash.log | grep fromrospy
 9                  fromrospy.acc        0 |   0 |   0.0Hz
10             fromrospy.top_scan        0 |   0 |   0.0Hz
11          fromrospy.bottom_scan        0 |   0 |   0.0Hz
12               fromrospy.pose3d        0 |   0 |   0.0Hz
13        fromrospy.battery_state        0 |   0 |   0.0Hz
14                fromrospy.score        0 |   0 |   0.0Hz
15         fromrospy.gas_detected        0 |   0 |   0.0Hz
16           fromrospy.rgbd_front 77929060 | 105 |   0.0Hz
17            fromrospy.rgbd_left 73826216 | 106 |   0.0Hz
18           fromrospy.rgbd_right 78951525 | 105 |   0.0Hz
19         fromrospy.air_pressure        0 |   0 |   0.0Hz
20              fromrospy.scan360        0 |   0 |   0.0Hz
21               fromrospy.slopes        0 |   0 |   0.0Hz
22              fromrospy.octomap        0 |   0 |   0.0Hz
23           fromrospy.robot_name        0 |   0 |   0.0Hz
```
