### PR TITLE
Docker ignore subt/submission folder with configs and logs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,5 +18,6 @@ osgar.egg-info/
 
 # other
 _deprecated
+subt/submission
 
 ign-logs


### PR DESCRIPTION
`subt/submission` folder contains some configurations tracked in git + in my case also many local copies and experiments used for CloudSim. When the simulation is used locally it stores logs next to the original `*.toml` file, i.e. in my case `subt/submission` which is then becoming part of next docker image ...