### PR TITLE
Add radio follow option for Pam drone

### DIFF
--- a/subt/config/coro_pam.json
+++ b/subt/config/coro_pam.json
@@ -245,6 +245,7 @@
               ["follower.query_trace", "mtm.query"],
               ["mtm.response", "follower.trace"],
               ["follower.waypoints", "app.waypoints"],
+              ["app.follow_status", "follower.follow_status"],
 
               ["rosmsg.sim_time_sec", "marsupial.sim_time_sec"],
               ["fromrospy.robot_name", "marsupial.robot_name"],

--- a/subt/config/coro_pam.json
+++ b/subt/config/coro_pam.json
@@ -183,6 +183,11 @@
             "size": 100,
             "threshold": 30.0
           }
+      },
+      "follower": {
+        "driver": "subt.follower:RadioFollower",
+          "init": {
+          }
       }
     },
     "links": [["app.desired_speed", "drone.desired_speed"],
@@ -232,6 +237,14 @@
               ["radio.robot_xyz", "app.whereabouts"],
               ["mtm.trace_info", "radio.trace_info"],
               ["mtm.robot_trace", "radio.robot_trace"],
+
+              ["fromrospy.robot_name", "follower.robot_name"],
+              ["rosmsg.sim_time_sec", "follower.sim_time_sec"],
+              ["radio.robot_xyz", "follower.robot_xyz"],
+              ["fromrospy.pose3d", "follower.pose3d"],
+              ["follower.query_trace", "mtm.query"],
+              ["mtm.response", "follower.trace"],
+              ["follower.waypoints", "app.waypoints"],
 
               ["rosmsg.sim_time_sec", "marsupial.sim_time_sec"],
               ["fromrospy.robot_name", "marsupial.robot_name"],

--- a/subt/follower.py
+++ b/subt/follower.py
@@ -39,6 +39,12 @@ class RadioFollower(Node):
         if name not in self.robot_names:
             self.robot_names.append(name)
 
+    def on_pose3d(self, data):
+        pass
+
+    def on_trace(self, data):
+        pass
+
     def update(self):
         channel = super().update()  # define self.time
         handler = getattr(self, "on_" + channel, None)

--- a/subt/follower.py
+++ b/subt/follower.py
@@ -58,6 +58,14 @@ class RadioFollower(Node):
         assert leader_name in data, (leader_name, data.keys())
         self.leader_trace = data[leader_name]  # TODO smarter merge
 
+    def on_follow_status(self, data):
+        # begin, end, following, completed, aborted
+        if self.verbose:
+            print(f'follow status: {data}')
+        if data == 'completed':
+            # reset last "anchor pose"
+            self.last_sent_xyz = None
+
     def update(self):
         channel = super().update()  # define self.time
         handler = getattr(self, "on_" + channel, None)

--- a/subt/follower.py
+++ b/subt/follower.py
@@ -1,0 +1,35 @@
+"""
+  SubT radio follower
+
+Follow trace of already running robot (with shortcuts)
+"""
+
+from osgar.node import Node
+
+
+class RadioFollower(Node):
+    def __init__(self, config, bus):
+        super().__init__(config, bus)
+        bus.register('waypoints')
+        self.robot_name_prefix = None
+
+    def on_robot_name(self, data):
+        name = data.decode('ascii')
+        if 'X' in name and 'XM' not in name:  # not mapping
+            self.robot_name_prefix = name.split('X')[1]
+
+    def on_robot_xyz(self, data):
+        name, position = data
+
+
+    def update(self):
+        channel = super().update()  # define self.time
+        handler = getattr(self, "on_" + channel, None)
+        if handler is not None:
+            handler(getattr(self, channel))
+        else:
+            assert False, channel  # not supported
+        return channel
+
+
+# vim: expandtab sw=4 ts=4

--- a/subt/follower.py
+++ b/subt/follower.py
@@ -32,7 +32,7 @@ class RadioFollower(Node):
         leader_name = self.get_leader_robot_name()
         if leader_name is not None:
             # query the whole trace from the very beginning
-            self.publish('query_trace', (leader_name, 0, data))
+            self.publish('query_trace', [leader_name, 0, data])
 
     def on_robot_xyz(self, data):
         name, position_with_time = data

--- a/subt/follower.py
+++ b/subt/follower.py
@@ -47,10 +47,10 @@ class RadioFollower(Node):
         if (len(self.leader_trace) > 0 and
                 (self.last_sent_xyz is None or distance3D(self.last_sent_xyz, data[0]) > self.min_update_step)):
             waypoints = [xyz for t, xyz in self.leader_trace]
-#            self.publish('waypoints', waypoints)
+            self.publish('waypoints', waypoints)
             self.last_sent_xyz = data[0]
             if self.verbose:
-                print(self.last_sent_xyz)
+                print(self.last_sent_xyz, waypoints)
 
     def on_trace(self, data):
         leader_name = self.get_leader_robot_name()

--- a/subt/main.py
+++ b/subt/main.py
@@ -938,7 +938,7 @@ class SubTChallenge:
 
         self.stdout(self.time, "Explore phase finished %.3f" % dist, reason)
 
-    def play_virtual_part_map_and_explore_frontiers(self):
+    def play_virtual_part_map_and_explore_frontiers(self, details=None):
         start_time = self.sim_time_sec
         self.bus.publish('follow_status', 'begin')
         while self.sim_time_sec - start_time < self.timeout.total_seconds():
@@ -999,9 +999,9 @@ class SubTChallenge:
                 self.use_center = (action == 'center')
                 self.play_virtual_part_explore()
 
-            elif action == 'explore':
+            elif action.startswith('explore'):
                 self.timeout = timedelta(seconds=duration)
-                self.play_virtual_part_map_and_explore_frontiers()
+                self.play_virtual_part_map_and_explore_frontiers(details=action)
 
             elif action == 'home':
                 self.play_virtual_part_return(timedelta(seconds=duration))

--- a/subt/main.py
+++ b/subt/main.py
@@ -957,7 +957,7 @@ class SubTChallenge:
                     with NewWaypointsMonitor(self) as wm:
                         termination_reason = self.follow_trace(tmp_trace, timeout=timedelta(seconds=10),
                                           max_target_distance=3.0, end_threshold=2.0, is_trace3d=True,
-                                          safety_limit=0.1)
+                                          safety_limit=None)  # TODO safety based on lidar in direction
                         if termination_reason == 'safety':
                             self.bus.publish('follow_status', 'aborted-safety')
                             break  # terminate exploration for now

--- a/subt/main.py
+++ b/subt/main.py
@@ -956,7 +956,7 @@ class SubTChallenge:
                 try:
                     with NewWaypointsMonitor(self) as wm:
                         termination_reason = self.follow_trace(tmp_trace, timeout=timedelta(seconds=10),
-                                          max_target_distance=1.0, end_threshold=0.5, is_trace3d=True,
+                                          max_target_distance=3.0, end_threshold=2.0, is_trace3d=True,
                                           safety_limit=0.1)
                         if termination_reason == 'safety':
                             self.bus.publish('follow_status', 'aborted-safety')

--- a/subt/multitrace.py
+++ b/subt/multitrace.py
@@ -36,7 +36,7 @@ def get_intervals(seq):
 class MultiTraceManager(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
-        bus.register('robot_trace', 'trace_info')
+        bus.register('robot_trace', 'trace_info', 'response')
         self.traces = {}
 
     def publish_trace_info(self):
@@ -83,7 +83,11 @@ class MultiTraceManager(Node):
             else:
                 # cut first part for now
                 for name in update:
-                    self.publish('robot_trace', {name : update[name][:CUT_NUM]})
+                    self.publish('robot_trace', {name: update[name][:CUT_NUM]})
+
+    def on_query(self, data):
+        name, from_sec, to_sec = data
+        self.publish('response', {name: self.traces.get(name, [])})
 
     def update(self):
         channel = super().update()  # define self.time

--- a/subt/name_decoder.py
+++ b/subt/name_decoder.py
@@ -30,10 +30,11 @@ def split_multi_simple(s, delimiters):
 def split_multi(s, delimiters):
     # small letters are prohibited so they can be used as alternative single letter
     multichar = [(k, chr(ord('a') + i)) for i, k in enumerate(delimiters) if len(k) > 1]
+    one_char_delimiters = [k for k in delimiters if len(k) == 1] + [v for k, v in multichar]
     for k, v in multichar:
         s = s.replace(k, v)
     ret = []
-    for word in split_multi_simple(s, delimiters):
+    for word in split_multi_simple(s, one_char_delimiters):
         for k, v in multichar:
             word = word.replace(v, k)  # inverse
         ret.append(word)

--- a/subt/name_decoder.py
+++ b/subt/name_decoder.py
@@ -77,6 +77,8 @@ def parse_robot_name(robot_name):
                 ret.append(('enter-' + action, None))
                 entered = True
             sum_t += t
+        if action.startswith('explore'):
+            sum_t += t  # explore may need also time to return home
         ret.append((action, t))
         if action == 'home':
             entered = False

--- a/subt/submission/two-freyjas.toml
+++ b/subt/submission/two-freyjas.toml
@@ -1,6 +1,6 @@
-world = "fp1"
+world = "fp2"
 timeout = 2000
-image = "ver101cuda"
+image = "ver118tri"
 
 [robots]
 A900L = "freyja"

--- a/subt/test_follower.py
+++ b/subt/test_follower.py
@@ -15,4 +15,37 @@ class RadioFollowerTest(unittest.TestCase):
         follower.on_robot_name(b'A100EXG')
         self.assertEqual(follower.robot_name_prefix, 'G')
 
+        follower.on_robot_xyz(['G10W900L', [52, [-3.499999464866466, 3.9999992320291566, 0.11749785807827295]]])
+
+        bus.reset_mock()
+        follower.on_sim_time_sec(13)
+        bus.publish.assert_called()
+
+    def test_get_leader_robot_name(self):
+        bus = MagicMock()
+        follower = RadioFollower(bus=bus, config={})
+        follower.robot_name_prefix = None
+        self.assertIsNone(follower.get_leader_robot_name())
+
+        follower.robot_name_prefix = 'A'
+        self.assertIsNone(follower.get_leader_robot_name())
+
+        follower.robot_name_prefix = 'A'
+        follower.robot_names = ['A100L', 'B10W300R']
+        self.assertEqual(follower.get_leader_robot_name(), 'A100L')
+
+    def test_robot_names_collection(self):
+        bus = MagicMock()
+        follower = RadioFollower(bus=bus, config={})
+        self.assertEqual(follower.robot_names, [])
+
+        follower.on_robot_xyz(['B900R', [52, [-3.499999938402841, 1.999999616027235, 0.11749921263375614]]])
+        self.assertEqual(follower.robot_names, ['B900R'])
+
+        follower.on_robot_xyz(['A900L', [52, [-3.499999464866466, 3.9999992320291566, 0.11749785807827295]]])
+        self.assertEqual(follower.robot_names, ['B900R', 'A900L'])
+
+        follower.on_robot_xyz(['B900R', [53, [-3.799999938402841, 1.999999616027235, 0.11749921263375614]]])
+        self.assertEqual(follower.robot_names, ['B900R', 'A900L'])
+
 # vim: expandtab sw=4 ts=4

--- a/subt/test_follower.py
+++ b/subt/test_follower.py
@@ -48,4 +48,27 @@ class RadioFollowerTest(unittest.TestCase):
         follower.on_robot_xyz(['B900R', [53, [-3.799999938402841, 1.999999616027235, 0.11749921263375614]]])
         self.assertEqual(follower.robot_names, ['B900R', 'A900L'])
 
+    def test_follow_status(self):
+        bus = MagicMock()
+        follower = RadioFollower(bus=bus, config={})
+        follower.robot_name_prefix = 'A'
+        follower.leader_trace = [[52, [-3.499999464866466, 3.9999992320291566, 0.11749785807827295]]]
+
+        bus.reset_mock()
+        pose3d = [[1, 2, 3], [0, 0, 0, 1]]
+        follower.on_pose3d(pose3d)
+        bus.publish.assert_called()
+
+        follower.on_follow_status('begin')
+
+        bus.reset_mock()
+        follower.on_pose3d(pose3d)
+        bus.publish.assert_not_called()
+
+        follower.on_follow_status('completed')
+
+        bus.reset_mock()
+        follower.on_pose3d(pose3d)
+        bus.publish.assert_called()
+
 # vim: expandtab sw=4 ts=4

--- a/subt/test_follower.py
+++ b/subt/test_follower.py
@@ -1,0 +1,18 @@
+
+import unittest
+from unittest.mock import MagicMock, patch, call
+
+from subt.follower import RadioFollower
+
+
+class RadioFollowerTest(unittest.TestCase):
+
+    def test_usage(self):
+        bus = MagicMock()
+        follower = RadioFollower(bus=bus, config={})
+        follower.on_robot_name(b'A100L')
+        self.assertIsNone(follower.robot_name_prefix)
+        follower.on_robot_name(b'A100EXG')
+        self.assertEqual(follower.robot_name_prefix, 'G')
+
+# vim: expandtab sw=4 ts=4

--- a/subt/test_multitrace.py
+++ b/subt/test_multitrace.py
@@ -73,4 +73,11 @@ class MultiTraceManagerTest(unittest.TestCase):
         # AssertionError: 20362 not less than 1000
         self.assertLess(len(str(bus.method_calls[-1][1])), 1000)
 
+    def test_query_response(self):
+        bus = MagicMock()
+        mtm = MultiTraceManager(bus=bus, config={})
+        mtm.on_query(['A500L', 0, 100])
+        bus.publish.assert_called_with('response', {'A500L': []})
+
+
 # vim: expandtab sw=4 ts=4

--- a/subt/test_name_decoder.py
+++ b/subt/test_name_decoder.py
@@ -49,5 +49,15 @@ class NameDecoderTest(unittest.TestCase):
         steps = parse_robot_name('X100L')
         self.assertEqual(steps, [('enter-left', None), ('left', 100), ('home', 200)])
 
+    def test_split_multi_2chars(self):
+        self.assertEqual(split_multi('100EL', ['E', 'L', 'EL']), ['100EL'])
+
+    def test_exploration_subparams(self):
+        steps = parse_robot_name('B10W1200EXA')
+        self.assertEqual(steps, [('wait', 10), ('explore', 1200), ('home', 0)])
+
+        steps = parse_robot_name('B10W1200ELXA')
+        self.assertEqual(steps, [('wait', 10), ('explore-left', 1200), ('home', 0)])
+
 # vim: expandtab sw=4 ts=4
 

--- a/subt/test_name_decoder.py
+++ b/subt/test_name_decoder.py
@@ -54,17 +54,21 @@ class NameDecoderTest(unittest.TestCase):
 
     def test_exploration_subparams(self):
         steps = parse_robot_name('B10W1200EXA')
-        self.assertEqual(steps, [('wait', 10), ('explore', 1200), ('home', 0)])
+        self.assertEqual(steps, [('wait', 10), ('explore', 1200), ('home', 2400)])
 
         steps = parse_robot_name('B10W1200ELXA')
-        self.assertEqual(steps, [('wait', 10), ('explore-left', 1200), ('home', 0)])
+        self.assertEqual(steps, [('wait', 10), ('explore-left', 1200), ('home', 2400)])
 
     def test_crash(self):
         steps = parse_robot_name('B300W900LHXA')
         self.assertEqual(steps, [('wait', 300), ('enter-left', None), ('left', 900), ('home', 1800)])
 
         steps = parse_robot_name('B300W900ELHXA')
-        self.assertEqual(steps, [('wait', 300), ('explore-left', 900), ('home', 0)])
+        self.assertEqual(steps, [('wait', 300), ('explore-left', 900), ('home', 1800)])
+
+    def test_home_after_explore(self):
+        steps = parse_robot_name('B300W900EH')
+        self.assertEqual(steps, [('wait', 300), ('explore', 900), ('home', 1800)])
 
 # vim: expandtab sw=4 ts=4
 

--- a/subt/test_name_decoder.py
+++ b/subt/test_name_decoder.py
@@ -59,5 +59,12 @@ class NameDecoderTest(unittest.TestCase):
         steps = parse_robot_name('B10W1200ELXA')
         self.assertEqual(steps, [('wait', 10), ('explore-left', 1200), ('home', 0)])
 
+    def test_crash(self):
+        steps = parse_robot_name('B300W900LHXA')
+        self.assertEqual(steps, [('wait', 300), ('enter-left', None), ('left', 900), ('home', 1800)])
+
+        steps = parse_robot_name('B300W900ELHXA')
+        self.assertEqual(steps, [('wait', 300), ('explore-left', 900), ('home', 0)])
+
 # vim: expandtab sw=4 ts=4
 


### PR DESCRIPTION
This is preparation step towards relay/stafeta optimization. It is rather backbone and this (draft) PR is for confirmation if I am going the right/wrong direction.

The basic naming scheme is as before, including `X` for "eXtended parameters", so letters and numbers after X are not parsed for basic strategy (`XM` is reserved for extended mapping). The robot, which should be followed is named (prefixed) after X, i.e. `B10W1200EXA` will wait 10s and then switch to "exploration" mode for 1200s while following robot `A`.

The new module `RadioFollower` queries MTM (multi-trace manager) for known trace of "leader robot" (`A` in our case) and once a while generates `waypoints` to main application to be followed (old functionality used in Octomap planning). There is new `app.follow_status` reporting current status of "following the trace" in particular when the application waits for new trace because the old one is finished.

And that is it. There is a lot to do, in particular speed optimization of following the trace, what to do in case the trace is no longer passable (blocked passage), etc.

Reference run:
https://subtchallenge.world/submission/2b4f87ba-3bb1-4d48-bcb4-46eda764c39f
(with blocked passage example ;)