### PR TITLE
Increase Freyja acc crash threshold from 30 to 100

### DIFF
--- a/subt/crash_report.py
+++ b/subt/crash_report.py
@@ -14,6 +14,7 @@ class CrashReport(Node):
         size = config.get('size', 100)  # keep N last records
         self.threshold = config.get('threshold', 100.0)  # i.e. 10g
         self.buf = collections.deque(maxlen=size)
+        self.verbose = False
 
     def on_rgbd(self, data):
         self.buf.append(data)
@@ -22,6 +23,8 @@ class CrashReport(Node):
         vec = [x/1000.0 for x in data]
         value = abs(distance3D(vec, [0, 0, 0]) - 9.81)
         if value >= self.threshold:
+            if self.verbose:
+                print(f'acc trigger: {value} (buf size = {len(self.buf)})')
             for rec in self.buf:
                 self.publish('crash_rgbd', rec)
             self.buf.clear()

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -136,7 +136,7 @@
         "driver": "subt.crash_report:CrashReport",
           "init": {
             "size": 100,
-            "threshold": 30.0
+            "threshold": 100.0
           }
       }
     },


### PR DESCRIPTION
In FP2 the log was mostly filled by passing door steps, which were not real crash. There were even values acc = 142, which was still
not collision. 100 seems to be reasonable limit until true crashes appear.

Old values (FP2, 5 points, `d9f13a84-d472-4529-95fd-744e493e72a0`)
```
acc trigger: 89.39034034719842 (buf size = 100)
acc trigger: 65.35707224576463 (buf size = 19)
acc trigger: 36.41460221570327 (buf size = 69)
acc trigger: 31.28264106868771 (buf size = 39)
acc trigger: 35.44149196435406 (buf size = 100)
acc trigger: 31.983370287642508 (buf size = 100)
acc trigger: 30.153607507330968 (buf size = 100)
acc trigger: 30.487644161911 (buf size = 100)
acc trigger: 76.04633363357651 (buf size = 100)
acc trigger: 92.14781603192566 (buf size = 100)
acc trigger: 33.18709088996603 (buf size = 100)
acc trigger: 47.00258091303369 (buf size = 100)
acc trigger: 54.69263269820853 (buf size = 18)
acc trigger: 56.64815393915181 (buf size = 100)
acc trigger: 33.52770702286866 (buf size = 100)
acc trigger: 124.3570501650834 (buf size = 16)
acc trigger: 142.57323841551602 (buf size = 100)
acc trigger: 124.27481448322177 (buf size = 12)
acc trigger: 32.1731838359122 (buf size = 7)
acc trigger: 67.57608224351456 (buf size = 100)
acc trigger: 59.135300601273755 (buf size = 100)
```

and the size is:
```
57        black_box.crash_rgbd 1020549891 |   1580 |   0.1Hz
```