### PR TITLE
Fix Gas detection for drones - move Z coordinate to the ground

### DIFF
--- a/subt/artf_gas.py
+++ b/subt/artf_gas.py
@@ -14,13 +14,18 @@ class ArtifactGasDetector(Node):
         super().__init__(config, bus)
         bus.register("localized_artf")
         self.xyz = None
+        self.last_bottom_scan = 0.0  # expected to never arrive for ground robots
 
     def on_gas_detected(self, data):
-        if data:
-            self.publish('localized_artf', [GAS, self.xyz])
+        if data and self.xyz is not None:
+            x, y, z = self.xyz
+            self.publish('localized_artf', [GAS, [x, y, z - self.last_bottom_scan]])
 
     def on_pose3d(self, data):
         self.xyz = data[0]  # ignore orientation
+
+    def on_bottom_scan(self, data):
+        self.last_bottom_scan = data[0]
 
     def update(self):
         channel = super().update()

--- a/subt/config/coro_pam.json
+++ b/subt/config/coro_pam.json
@@ -215,6 +215,7 @@
               ["rosmsg.sim_time_sec", "octomap.sim_time_sec"],
 
               ["fromrospy.pose3d", "gas_detector.pose3d"],
+              ["fromrospy.bottom_scan", "gas_detector.bottom_scan"],
               ["fromrospy.gas_detected", "gas_detector.gas_detected"],
               ["gas_detector.localized_artf", "artifact_filter.localized_artf"],
 

--- a/subt/test_artf_gas.py
+++ b/subt/test_artf_gas.py
@@ -19,4 +19,19 @@ class ArtifactGasDetectorTest(unittest.TestCase):
         bus.publish.assert_called()
         bus.publish.assert_has_calls([call('localized_artf', [GAS, [1.0, 0, 1.0]])])
 
+    def test_drone_z(self):
+        # the location point is on the ground level, which is OK for ground vehicles but not for drones
+        bus = bus=MagicMock()
+        detector = ArtifactGasDetector(bus=bus, config={})
+        detector.on_pose3d([[1, 2, 3], [0, 0, 0, 1]])
+        detector.on_gas_detected(False)
+        detector.on_pose3d([[1, 0, 1], [0, 0, 0, 1]])
+        detector.on_bottom_scan([1.0])  # top/bottom scans are in meters
+
+        bus.publish.reset_mock()
+        detector.on_gas_detected(True)
+        bus.publish.assert_called()
+        bus.publish.assert_has_calls([call('localized_artf', [GAS, [1.0, 0, 1.0 - 1.0]])])
+
+
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Reference run UP1 (`dcb87ea7-af18-4159-9f9f-4f25c60eef68`) ... not sure where is the closest gas :( ... and FPR1 is not available yet.