### PR TITLE
Reduce multiple reports

### DIFF
--- a/subt/artf_filter.py
+++ b/subt/artf_filter.py
@@ -18,11 +18,15 @@ class ArtifactFilter(Node):
         self.num_observations = []
         self.breadcrumbs = []
         self.verbose = False
+        self.debug_artf = []
+        self.debug_reported = []
 
     def publish_single_artf_xyz(self, artifact_data, pos):
         ax, ay, az = pos
         self.bus.publish('artf_xyz', [
             [artifact_data, [round(ax * 1000), round(ay * 1000), round(az * 1000)], self.robot_name, None]])
+        if self.verbose:
+            self.debug_reported.append((artifact_data, pos))
 
     def register_new_artifact(self, artifact_data, artifact_xyz):
         """
@@ -38,6 +42,9 @@ class ArtifactFilter(Node):
                     if self.verbose:
                         print('False detection - dist:', distance3D((x, y, z), artifact_xyz))
                     return False
+
+        if self.verbose:
+            self.debug_artf.append((artifact_data, artifact_xyz))
 
         for i, (stored_data, (x, y, z)) in enumerate(self.artifacts):
             if distance3D((x, y, z), artifact_xyz) < 4.0:
@@ -89,5 +96,19 @@ class ArtifactFilter(Node):
             handler(getattr(self, channel))
         else:
             assert False, channel  # unknown channel
+
+    def draw(self):
+        import matplotlib.pyplot as plt
+
+        x = [xyz[0] for _, xyz in self.debug_artf]
+        y = [xyz[1] for _, xyz in self.debug_artf]
+        plt.plot(x, y, 'x')
+
+        x = [xyz[0] for _, xyz in self.debug_reported]
+        y = [xyz[1] for _, xyz in self.debug_reported]
+        plt.scatter([x], [y], s=100, color='r')
+
+        plt.axes().set_aspect('equal', 'datalim')
+        plt.show()
 
 # vim: expandtab sw=4 ts=4

--- a/subt/artf_reporter.py
+++ b/subt/artf_reporter.py
@@ -152,6 +152,8 @@ class ArtifactReporter(Node):
             # TODO? check type - we decided to ignore it for Cave Circuit
             if was_unknown:
                 self.publish('artf_all', self.artf_xyz_accumulated)  # broadcast new update
+                # trigger sending next artifact if there is any
+                self.publish_artf(self.artf_xyz_accumulated)
 
     def update(self):
         channel = super().update()  # define self.time

--- a/subt/artf_reporter.py
+++ b/subt/artf_reporter.py
@@ -65,7 +65,7 @@ class ArtifactReporter(Node):
         robots = []
         artifact_types = []
         positions = []
-        for artf_type, pos, src, scored in artf_xyz:
+        for artf_type, pos, src, scored in sorted(artf_xyz):
             if artf_type not in artifact_types:
                 artifact_types.append(artf_type)
             if src not in robots:
@@ -81,7 +81,7 @@ class ArtifactReporter(Node):
         ret = []
         for p in positions:
             selected = None
-            for artf_type, pos, src, scored in artf_xyz:
+            for artf_type, pos, src, scored in sorted(artf_xyz):
                 if distance3D(pos, p)/1000.0 >= RADIUS:
                     continue
                 if (selected is None or  # some result is better than no result

--- a/subt/radio.py
+++ b/subt/radio.py
@@ -22,8 +22,9 @@ def draw_positions(arr):
     print('Robot IDs', robot_ids)
 
     for robot_id in robot_ids:
-        x = [a[2][0]/1000.0 for a in arr if a[1] == robot_id]
-        y = [a[2][1]/1000.0 for a in arr if a[1] == robot_id]
+        # received time, robot name, [sim_time, robot xyz position]
+        x = [a[2][1][0] for a in arr if a[1] == robot_id]
+        y = [a[2][1][1] for a in arr if a[1] == robot_id]
         line = plt.plot(x, y, '-o', linewidth=2, label=f'Robot {robot_id}')
 
 #    plt.xlabel('time (s)')

--- a/subt/test_artf_reporter.py
+++ b/subt/test_artf_reporter.py
@@ -121,11 +121,11 @@ class ArtifactReporterTest(unittest.TestCase):
         reporter.on_artf_xyz([['TYPE_PHONE', [69758 + 2000, -5143, 533], 'A150L', None]])  # 2m offset
         self.assertEqual(len(reporter.artf_xyz_accumulated), 2)
 
-    def test_group_artf_for_report(self):
+    def test_select_artf_for_report(self):
         bus = MagicMock()
         reporter = ArtifactReporter(config={}, bus=bus)
 
-        to_report = reporter.group_artf_for_report([
+        to_report = reporter.select_artf_for_report([
                    ['TYPE_DRILL', [343506, 22288, -14938], 'B300W900ELXA', None],
                    ['TYPE_DRILL', [343174, 22338, -14727], 'A900L', None],
                    ['TYPE_RESCUE_RANDY', [252978, 106894, -18309], 'A900L', None],
@@ -137,7 +137,7 @@ class ArtifactReporterTest(unittest.TestCase):
         ])
 
         # now let's have already positive report from B-drone
-        to_report = reporter.group_artf_for_report([
+        to_report = reporter.select_artf_for_report([
                    ['TYPE_DRILL', [343506, 22288, -14938], 'B300W900ELXA', True],
                    ['TYPE_DRILL', [343174, 22338, -14727], 'A900L', None]])
 
@@ -145,7 +145,7 @@ class ArtifactReporterTest(unittest.TestCase):
         self.assertEqual(to_report, [])
 
         # now let's have negative result of different artifact type
-        to_report = reporter.group_artf_for_report([
+        to_report = reporter.select_artf_for_report([
                    ['TYPE_DRILL', [343506, 22288, -14938], 'B300W900ELXA', None],
                    ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', False]])
 
@@ -155,7 +155,7 @@ class ArtifactReporterTest(unittest.TestCase):
         ])
 
         # the same type of artifact but already received False for nearby location
-        to_report = reporter.group_artf_for_report([
+        to_report = reporter.select_artf_for_report([
                    ['TYPE_BACKPACK', [343506, 22288, -14938], 'B300W900ELXA', None],
                    ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', False]])
 
@@ -163,7 +163,7 @@ class ArtifactReporterTest(unittest.TestCase):
         self.assertEqual(to_report, [])
 
         # two different reports from the same robot
-        to_report = reporter.group_artf_for_report([
+        to_report = reporter.select_artf_for_report([
                    ['TYPE_ROPE', [343506, 22288, -14938], 'A900L', None],
                    ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', None]])
 
@@ -172,8 +172,15 @@ class ArtifactReporterTest(unittest.TestCase):
             ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', None]
         ])
 
+        # True artefact masks ALL other reports
+        to_report = reporter.select_artf_for_report([
+                   ['TYPE_ROPE', [343506, 22288, -14938], 'A900L', True],
+                   ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', None]])
 
-    def test_grouping_integration(self):
+        self.assertEqual(to_report, [])
+
+
+    def test_artf_select_integration(self):
         bus = MagicMock()
         reporter = ArtifactReporter(config={}, bus=bus)
 
@@ -195,7 +202,7 @@ class ArtifactReporterTest(unittest.TestCase):
                     ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', None]]
 
         # two different reports from the same robot
-        to_report = reporter.group_artf_for_report(artf_xyz)
+        to_report = reporter.select_artf_for_report(artf_xyz)
 
         self.assertEqual(to_report, [
             ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', None]
@@ -203,7 +210,7 @@ class ArtifactReporterTest(unittest.TestCase):
 
         artf_xyz.reverse()
 
-        to_report = reporter.group_artf_for_report(artf_xyz)
+        to_report = reporter.select_artf_for_report(artf_xyz)
 
         self.assertEqual(to_report, [
             ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', None]

--- a/subt/test_artf_reporter.py
+++ b/subt/test_artf_reporter.py
@@ -63,19 +63,19 @@ class ArtifactReporterTest(unittest.TestCase):
         sim_time_sec = 0
         bus.listen = MagicMock(return_value=(1, 'sim_time_sec', sim_time_sec))
         reporter.update()
-        bus.publish.assert_has_calls([call('artf_cmd', b'artf TYPE_BACKPACK 0.10 0.20 -0.00\n'),
-                                      call('artf_cmd', b'artf TYPE_ROPE 0.01 0.02 0.03\n')])
+        bus.publish.assert_has_calls([call('artf_cmd', b'artf TYPE_BACKPACK 0.10 0.20 -0.00\n')])
+        # this 2nd call is postponed - call('artf_cmd', b'artf TYPE_ROPE 0.01 0.02 0.03\n')])
 
         # keep list unique
-        bus.listen = MagicMock(return_value=(1, 'artf_xyz', [['TYPE_BACKPACK', 100, 200, -3]]))
+        bus.listen = MagicMock(return_value=(1, 'artf_xyz', [['TYPE_BACKPACK', [100, 200, -3], "RobotX", None]]))
         reporter.update()
         bus.reset_mock()
         sim_time_sec = 0
         bus.listen = MagicMock(return_value=(1, 'sim_time_sec', sim_time_sec))
         reporter.update()
         # the same issue, that I do not want subset, but 1:1 correspondence - TODO more strict assert
-        bus.publish.assert_has_calls([call('artf_cmd', b'artf TYPE_BACKPACK 0.10 0.20 -0.00\n'),
-                                      call('artf_cmd', b'artf TYPE_ROPE 0.01 0.02 0.03\n')])
+        bus.publish.assert_has_calls([call('artf_cmd', b'artf TYPE_BACKPACK 0.10 0.20 -0.00\n')])
+        # this 2nd call is postponed - call('artf_cmd', b'artf TYPE_ROPE 0.01 0.02 0.03\n')])
 
     def test_on_base_station(self):
         data = {'report_id': 1, 'artifact_type': 0, 'artifact_position': [69.84, -4.86, 0.4],
@@ -120,6 +120,77 @@ class ArtifactReporterTest(unittest.TestCase):
         # backpack is confirmed and phone is tested as different artifact
         reporter.on_artf_xyz([['TYPE_PHONE', [69758 + 2000, -5143, 533], 'A150L', None]])  # 2m offset
         self.assertEqual(len(reporter.artf_xyz_accumulated), 2)
+
+    def test_group_artf_for_report(self):
+        bus = MagicMock()
+        reporter = ArtifactReporter(config={}, bus=bus)
+
+        to_report = reporter.group_artf_for_report([
+                   ['TYPE_DRILL', [343506, 22288, -14938], 'B300W900ELXA', None],
+                   ['TYPE_DRILL', [343174, 22338, -14727], 'A900L', None],
+                   ['TYPE_RESCUE_RANDY', [252978, 106894, -18309], 'A900L', None],
+                   ['TYPE_RESCUE_RANDY', [252930, 106716, -19523], 'B300W900ELXA', None]])
+
+        # pick only one sample and give A preference
+        self.assertEqual(to_report, [
+            ['TYPE_DRILL', [343174, 22338, -14727], 'A900L', None],
+            ['TYPE_RESCUE_RANDY', [252978, 106894, -18309], 'A900L', None]
+        ])
+
+        # now let's have already positive report from B-drone
+        to_report = reporter.group_artf_for_report([
+                   ['TYPE_DRILL', [343506, 22288, -14938], 'B300W900ELXA', True],
+                   ['TYPE_DRILL', [343174, 22338, -14727], 'A900L', None]])
+
+        # keep only successful report
+        self.assertEqual(to_report, [
+            ['TYPE_DRILL', [343506, 22288, -14938], 'B300W900ELXA', True]
+        ])
+
+        # now let's have negative result of different artifact type
+        to_report = reporter.group_artf_for_report([
+                   ['TYPE_DRILL', [343506, 22288, -14938], 'B300W900ELXA', None],
+                   ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', False]])
+
+        # keep only promising report
+        self.assertEqual(to_report, [
+            ['TYPE_DRILL', [343506, 22288, -14938], 'B300W900ELXA', None]
+        ])
+
+        # the same type of artifact but already received False for nearby location
+        to_report = reporter.group_artf_for_report([
+                   ['TYPE_BACKPACK', [343506, 22288, -14938], 'B300W900ELXA', None],
+                   ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', False]])
+
+        # keep only promising report
+        self.assertEqual(to_report, [
+            ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', False]
+        ])
+
+        # two different reports from the same robot
+        to_report = reporter.group_artf_for_report([
+                   ['TYPE_ROPE', [343506, 22288, -14938], 'A900L', None],
+                   ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', None]])
+
+        # keep only one of the options, verify and then try the second
+        self.assertEqual(to_report, [
+            ['TYPE_ROPE', [343506, 22288, -14938], 'A900L', None]
+        ])
+
+
+    def test_grouping_integration(self):
+        bus = MagicMock()
+        reporter = ArtifactReporter(config={}, bus=bus)
+
+        reporter.on_artf_xyz([
+                   ['TYPE_DRILL', [343506, 22288, -14938], 'B300W900ELXA', None],
+                   ['TYPE_DRILL', [343174, 22338, -14727], 'A900L', None],
+                   ['TYPE_RESCUE_RANDY', [252978, 106894, -18309], 'A900L', None],
+                   ['TYPE_RESCUE_RANDY', [252930, 106716, -19523], 'B300W900ELXA', None]])
+
+        bus.publish.assert_has_calls([
+            call('artf_cmd', b'artf TYPE_DRILL 343.17 22.34 -14.73\n'),
+            call('artf_cmd', b'artf TYPE_RESCUE_RANDY 252.98 106.89 -18.31\n')])
 
 
 # vim: expandtab sw=4 ts=4

--- a/subt/test_artf_reporter.py
+++ b/subt/test_artf_reporter.py
@@ -174,7 +174,7 @@ class ArtifactReporterTest(unittest.TestCase):
 
         # keep only one of the options, verify and then try the second
         self.assertEqual(to_report, [
-            ['TYPE_ROPE', [343506, 22288, -14938], 'A900L', None]
+            ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', None]
         ])
 
 
@@ -192,6 +192,28 @@ class ArtifactReporterTest(unittest.TestCase):
             call('artf_cmd', b'artf TYPE_DRILL 343.17 22.34 -14.73\n'),
             call('artf_cmd', b'artf TYPE_RESCUE_RANDY 252.98 106.89 -18.31\n')])
 
+    def test_grouping_order(self):
+        # the order does matter in order to identically report artifacts
+        bus = MagicMock()
+        reporter = ArtifactReporter(config={}, bus=bus)
+
+        artf_xyz = [['TYPE_ROPE', [343506, 22288, -14938], 'A900L', None],
+                    ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', None]]
+
+        # two different reports from the same robot
+        to_report = reporter.group_artf_for_report(artf_xyz)
+
+        self.assertEqual(to_report, [
+            ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', None]
+        ])
+
+        artf_xyz.reverse()
+
+        to_report = reporter.group_artf_for_report(artf_xyz)
+
+        self.assertEqual(to_report, [
+            ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', None]
+        ])
 
 # vim: expandtab sw=4 ts=4
 

--- a/subt/test_artf_reporter.py
+++ b/subt/test_artf_reporter.py
@@ -131,10 +131,9 @@ class ArtifactReporterTest(unittest.TestCase):
                    ['TYPE_RESCUE_RANDY', [252978, 106894, -18309], 'A900L', None],
                    ['TYPE_RESCUE_RANDY', [252930, 106716, -19523], 'B300W900ELXA', None]])
 
-        # pick only one sample and give A preference
+        # pick only one sample (minimum)
         self.assertEqual(to_report, [
-            ['TYPE_DRILL', [343174, 22338, -14727], 'A900L', None],
-            ['TYPE_RESCUE_RANDY', [252978, 106894, -18309], 'A900L', None]
+            ['TYPE_DRILL', [343174, 22338, -14727], 'A900L', None]
         ])
 
         # now let's have already positive report from B-drone
@@ -143,9 +142,7 @@ class ArtifactReporterTest(unittest.TestCase):
                    ['TYPE_DRILL', [343174, 22338, -14727], 'A900L', None]])
 
         # keep only successful report
-        self.assertEqual(to_report, [
-            ['TYPE_DRILL', [343506, 22288, -14938], 'B300W900ELXA', True]
-        ])
+        self.assertEqual(to_report, [])
 
         # now let's have negative result of different artifact type
         to_report = reporter.group_artf_for_report([
@@ -162,10 +159,8 @@ class ArtifactReporterTest(unittest.TestCase):
                    ['TYPE_BACKPACK', [343506, 22288, -14938], 'B300W900ELXA', None],
                    ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', False]])
 
-        # keep only promising report
-        self.assertEqual(to_report, [
-            ['TYPE_BACKPACK', [343174, 22338, -14727], 'A900L', False]
-        ])
+        # the report already failed, no need to report it again
+        self.assertEqual(to_report, [])
 
         # two different reports from the same robot
         to_report = reporter.group_artf_for_report([
@@ -189,8 +184,7 @@ class ArtifactReporterTest(unittest.TestCase):
                    ['TYPE_RESCUE_RANDY', [252930, 106716, -19523], 'B300W900ELXA', None]])
 
         bus.publish.assert_has_calls([
-            call('artf_cmd', b'artf TYPE_DRILL 343.17 22.34 -14.73\n'),
-            call('artf_cmd', b'artf TYPE_RESCUE_RANDY 252.98 106.89 -18.31\n')])
+            call('artf_cmd', b'artf TYPE_DRILL 343.17 22.34 -14.73\n')])
 
     def test_grouping_order(self):
         # the order does matter in order to identically report artifacts


### PR DESCRIPTION
This is attempt to reduce reports from multiple robots when the base station is not available and thus the hypothesis cannot be directly evaluated. In particular please have a look at unittest and optionally suggest more cases. For example note, that nearby artifact will not be reported again if it was already classified as false (so localization errors could be fatal). Thanks in advance for comments. 