### PR TITLE
Add fprX (finals preliminary round worlds) to submit tool

### DIFF
--- a/subt/tools/run.py
+++ b/subt/tools/run.py
@@ -61,9 +61,9 @@ WORLDS = dict(
     fp2="finals_practice_02",
     fp3="finals_practice_03",
 
-    fpr1="Finals Preliminary Round World 1",
-    fpr2="Finals Preliminary Round World 2",
-    fpr3="Finals Preliminary Round World 3",
+    fpr1="final_prelim_01",
+    fpr2="final_prelim_02",
+    fpr3="final_prelim_03",
 )
 
 ROBOTS=dict(

--- a/subt/tools/run.py
+++ b/subt/tools/run.py
@@ -60,6 +60,10 @@ WORLDS = dict(
     fp1="finals_practice_01",
     fp2="finals_practice_02",
     fp3="finals_practice_03",
+
+    fpr1="Finals Preliminary Round World 1",
+    fpr2="Finals Preliminary Round World 2",
+    fpr3="Finals Preliminary Round World 3",
 )
 
 ROBOTS=dict(

--- a/subt/tools/submit.py
+++ b/subt/tools/submit.py
@@ -64,6 +64,10 @@ WORLDS = dict(
     fp2 = "Finals Practice 2",
     fp3 = "Finals Practice 3",
     fpr = "Finals Preliminary Round",
+
+    fpr1 = "Finals Preliminary Round World 1",
+    fpr2 = "Finals Preliminary Round World 2",
+    fpr3 = "Finals Preliminary Round World 3",
 )
 
 ROBOTS=dict(


### PR DESCRIPTION
WIP - waiting for fix on CloudSim side, see osrf/subt issue 1000 from Meryl
```
{
    "errcode": 3013,
    "msg": "Invalid value in field.",
    "extra": [
        "Circuit:Finals Preliminary Round World 1"
    ],
    "errid": "5c17e6ad-113e-47c5-81a3-2800b1125ed9",
    "route": "POST /1.0/simulations",
    "user-agent": "",
    "remote-address": "109.164.32.171"
}
```
@jisa I suppose that you would like to have it also for local run, but for that I need to update my sim images to test it