### PR TITLE
Collect data for "time to signal"

### DIFF
--- a/subt/config/coro_pam.json
+++ b/subt/config/coro_pam.json
@@ -232,6 +232,8 @@
               ["radio.robot_trace", "mtm.robot_trace"],
               ["radio.robot_xyz", "app.whereabouts"],
               ["radio.teambase_sec", "mtm.teambase_sec"],
+              ["fromrospy.robot_name", "mtm.robot_name"],
+              ["rosmsg.sim_time_sec", "mtm.sim_time_sec"],
               ["mtm.trace_info", "radio.trace_info"],
               ["mtm.robot_trace", "radio.robot_trace"],
 

--- a/subt/config/coro_pam.json
+++ b/subt/config/coro_pam.json
@@ -231,6 +231,7 @@
               ["radio.trace_info", "mtm.trace_info"],
               ["radio.robot_trace", "mtm.robot_trace"],
               ["radio.robot_xyz", "app.whereabouts"],
+              ["radio.teambase_sec", "mtm.teambase_sec"],
               ["mtm.trace_info", "radio.trace_info"],
               ["mtm.robot_trace", "radio.robot_trace"],
 

--- a/subt/multitrace.py
+++ b/subt/multitrace.py
@@ -85,6 +85,9 @@ class MultiTraceManager(Node):
                 for name in update:
                     self.publish('robot_trace', {name : update[name][:CUT_NUM]})
 
+    def on_teambase_sec(self, data):
+        pass
+
     def update(self):
         channel = super().update()  # define self.time
         handler = getattr(self, "on_" + channel, None)

--- a/subt/radio.py
+++ b/subt/radio.py
@@ -36,7 +36,7 @@ def draw_positions(arr):
 class Radio(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
-        bus.register('radio', 'artf_xyz', 'breadcrumb', 'robot_xyz', 'trace_info', 'robot_trace')
+        bus.register('radio', 'artf_xyz', 'breadcrumb', 'robot_xyz', 'trace_info', 'robot_trace', 'teambase_sec')
         self.min_transmit_dt = 0  # i.e. every sim_time_sec -> every simulated second
         self.last_transmit = None
         self.sim_time_sec = None
@@ -62,6 +62,8 @@ class Radio(Node):
             self.publish('robot_xyz', [name, msg_data])
             if self.verbose:
                 self.debug_robot_poses.append((self.time, name, msg_data))
+        elif channel == 'sim_time_sec' and name.startswith('T'):
+            self.publish('teambase_sec', msg_data)
 
     def on_breadcrumb(self, data):
         self.send_data('breadcrumb', data)

--- a/subt/test_multitrace.py
+++ b/subt/test_multitrace.py
@@ -73,4 +73,15 @@ class MultiTraceManagerTest(unittest.TestCase):
         # AssertionError: 20362 not less than 1000
         self.assertLess(len(str(bus.method_calls[-1][1])), 1000)
 
+    def test_time_to_signal(self):
+        bus = MagicMock()
+        mtm = MultiTraceManager(bus=bus, config={})
+
+        mtm.on_sim_time_sec(42)
+        bus.publish.assert_called_with('time_to_signal', 0)
+
+        mtm.on_teambase_sec(42)
+        mtm.on_sim_time_sec(43)
+        bus.publish.assert_called_with('time_to_signal', 1)
+
 # vim: expandtab sw=4 ts=4

--- a/subt/zmq-subt-x2.json
+++ b/subt/zmq-subt-x2.json
@@ -185,6 +185,7 @@
               ["radio.robot_xyz", "mtm.robot_xyz"],
               ["radio.trace_info", "mtm.trace_info"],
               ["radio.robot_trace", "mtm.robot_trace"],
+              ["radio.teambase_sec", "mtm.teambase_sec"],
               ["mtm.trace_info", "radio.trace_info"],
               ["mtm.robot_trace", "radio.robot_trace"],
 


### PR DESCRIPTION
This is preliminary step for "time to signal" feature. It collects data from teambase in `mtm` and publishes `mtm.time_to_signal` which is for version 0 simply time difference between last teambase packet and current time. The next step would be implementation of codes `T` and `Q` for timeout and query, which would conflict with another PR #853 (actually there will be some conflicts already now).

I am currently running simulation just to check that `tts` varies between 0 and 1 on start, then it grows and on return it drops to 0/1 again (in TS2).

Robot name is not used but it will be necessary to choose from correct trajectory on Query.