### PR TITLE
Add option --use-old-record for legacy System code in subt/main.py

### DIFF
--- a/subt/main.py
+++ b/subt/main.py
@@ -1153,7 +1153,7 @@ def main():
     parser_run.add_argument('--log', nargs='?', help='record log filename')
     parser_run.add_argument('--init-path', help='inital path to be followed from (0, 0). 2D coordinates are separated by ;')
     parser_run.add_argument('--start-paused', dest='start_paused', action='store_true',
-                            help='start robota Paused and wait for LoRa Contine command')
+                            help='start robot Paused and wait for LoRa Continue command')
     parser_run.add_argument('--use-old-record', help="use old osgar.record instead of zmqrouter", action='store_true')
 
     parser_replay = subparsers.add_parser('replay', help='replay from logfile')

--- a/subt/main.py
+++ b/subt/main.py
@@ -1137,8 +1137,6 @@ class SubTChallenge:
 def main():
     import argparse
     from osgar.lib.config import config_load
-    #from osgar.record import record
-    from osgar.zmqrouter import record
 
     parser = argparse.ArgumentParser(description='SubT Challenge')
     subparsers = parser.add_subparsers(help='sub-command help', dest='command')
@@ -1156,6 +1154,7 @@ def main():
     parser_run.add_argument('--init-path', help='inital path to be followed from (0, 0). 2D coordinates are separated by ;')
     parser_run.add_argument('--start-paused', dest='start_paused', action='store_true',
                             help='start robota Paused and wait for LoRa Contine command')
+    parser_run.add_argument('--use-old-record', help="use old osgar.record instead of zmqrouter", action='store_true')
 
     parser_replay = subparsers.add_parser('replay', help='replay from logfile')
     parser_replay.add_argument('logfile', help='recorded log file')
@@ -1163,6 +1162,11 @@ def main():
     parser_replay.add_argument('--config', nargs='+', help='force alternative configuration file')
     parser_replay.add_argument('--debug', help="print debug info about I/O streams", action='store_true')
     args = parser.parse_args()
+
+    if args.use_old_record:
+        from osgar.record import record
+    else:
+        from osgar.zmqrouter import record
 
     if args.command == 'replay':
         from osgar.replay import replay


### PR DESCRIPTION
just that we do not have to comment and uncomment imports