### PR TITLE
imu.py: publish quaternion through "orientation"

### DIFF
--- a/osgar/drivers/imu.py
+++ b/osgar/drivers/imu.py
@@ -87,9 +87,9 @@ class IMU(Thread):
                         yaw += 360
                     if yaw > 180:
                         yaw -= 360
+                    yaw, pitch, roll = [a + b/100 for a, b in zip([yaw, pitch, roll], self.offset)]  # correct for offset
                     quat = euler_to_quaternion(math.radians(yaw), math.radians(pitch), math.radians(roll))
                     angles = [int(round(x * 100)) for x in [yaw, pitch, roll]]
-                    angles = [a + b for a, b in zip(angles, self.offset)]  # correct for offset
                     self.bus.publish('rotation', angles)
                     self.bus.publish('orientation', quat)
         except BusShutdownException:

--- a/osgar/drivers/imu.py
+++ b/osgar/drivers/imu.py
@@ -3,8 +3,10 @@
 """
 
 from threading import Thread
+import math
 
 from osgar.bus import BusShutdownException
+from osgar.lib.quaternion import euler_to_quaternion
 
 
 def parse_line(line):
@@ -33,7 +35,7 @@ def parse_line(line):
 
 class IMU(Thread):
     def __init__(self, config, bus):
-        bus.register('orientation', 'rotation')
+        bus.register('orientation', 'rotation', 'data')
         Thread.__init__(self)
         self.setDaemon(True)
 
@@ -75,7 +77,7 @@ class IMU(Thread):
                 dt, __, data = packet
                 for out in self.process_gen(data):
                     assert out is not None
-                    self.bus.publish('orientation', out)
+                    self.bus.publish('data', out)
                     # publish separately yaw, pitch and roll in 1/100th deg
                     yaw, pitch, roll = out[0]
                     # The  VN-100  uses a right-handed coordinate system. A positive yaw angle
@@ -85,9 +87,11 @@ class IMU(Thread):
                         yaw += 360
                     if yaw > 180:
                         yaw -= 360
+                    quat = euler_to_quaternion(math.radians(yaw), math.radians(pitch), math.radians(roll))
                     angles = [int(round(x * 100)) for x in [yaw, pitch, roll]]
                     angles = [a + b for a, b in zip(angles, self.offset)]  # correct for offset
                     self.bus.publish('rotation', angles)
+                    self.bus.publish('orientation', quat)
         except BusShutdownException:
             pass
 

--- a/osgar/drivers/test_imu.py
+++ b/osgar/drivers/test_imu.py
@@ -9,7 +9,7 @@ from osgar.bus import Bus
 class IMUTest(unittest.TestCase):
 
     nmea_line = b'$VNYMR,-095.878,+008.933,-009.419,+00.1785,+00.1474,+00.5479,+00.252,-03.706,-03.874,-01.012502,-00.234810,+00.247165*66'
-    orientation = [[-95.878, 8.933, -9.419], [0.1785, 0.1474, 0.5479], [0.252, -3.706, -3.874], [-1.012502, -0.23481, 0.247165]]
+    data = [[-95.878, 8.933, -9.419], [0.1785, 0.1474, 0.5479], [0.252, -3.706, -3.874], [-1.012502, -0.23481, 0.247165]]
 
     def test_parse_line(self):
         # (yaw, pitch, roll), (magx, y, z), (accx, y, z), (gyrox, y, z)
@@ -37,12 +37,12 @@ class IMUTest(unittest.TestCase):
         tester = bus.handle('tester')
         tester.register('raw')
         bus.connect('tester.raw', 'imu.raw')
-        bus.connect('imu.orientation', 'tester.orientation')
+        bus.connect('imu.data', 'tester.data')
         imu.start()
         tester.publish('raw', self.nmea_line)
         imu.request_stop()
         imu.join()
         tester.shutdown()
-        self.assertEqual(tester.listen(), (timedelta(135), 'orientation', self.orientation))
+        self.assertEqual(tester.listen(), (timedelta(135), 'data', self.data))
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
In original the "orientation" stream contained all data provided by IMU. Now, this stream is renamed to "data" and "orientation" contains quaternion.