### PR TITLE
Dummy record via drivers/replay

### DIFF
--- a/osgar/drivers/replay.py
+++ b/osgar/drivers/replay.py
@@ -15,8 +15,7 @@ class ReplayDriver:
 
         self.filename = config['filename']
         self.pins = config['pins']
-        for channel in self.pins.values():
-            self.bus.register(channel)
+        self.bus.register(*self.pins.values())
         self.sleep_channel = config.get('sleep_channel')  # e.g. ['scan', 0.05]
 
 
@@ -35,8 +34,7 @@ class ReplayDriver:
         print(ids)
         if self.sleep_channel:
             sleeping_channel, period = self.sleep_channel
-        for timestamp, channel_index, data_raw in LogReader(self.filename,
-                only_stream_id=ids):
+        for timestamp, channel_index, data_raw in LogReader(self.filename, only_stream_id=ids):
             if not self.bus.is_alive():
                 break
             channel = names[channel_index - 1]

--- a/osgar/drivers/replay.py
+++ b/osgar/drivers/replay.py
@@ -3,7 +3,6 @@
 """
 
 from threading import Thread
-import time
 
 from osgar.logger import LogReader, lookup_stream_names
 from osgar.lib.serialize import deserialize
@@ -47,7 +46,7 @@ class ReplayDriver:
             sub_channel = self.pins[channel]
             self.bus.publish(sub_channel, data)
             if sub_channel == sleeping_channel:
-                time.sleep(period)
+                self.bus.sleep(period)
         print('Replay completed!')
 
     def request_stop(self):


### PR DESCRIPTION
This PR fixes streams registration and  adds a sleep option to slow down recording.
I used it during testing of node for lidar processing. This tool may partially replace a real sensor if needed.