### PR TITLE
steering angle in gym simulator

### DIFF
--- a/examples/gym/gym_simulator.py
+++ b/examples/gym/gym_simulator.py
@@ -34,6 +34,11 @@ class GymSimulator(Node):
         else:
             self.steer = 0
 
+    def on_move(self, data):
+        speed, steering_angle_100deg = data
+        self.speed = speed / 1000
+        self.steer = math.radians(steering_angle_100deg / 100.0)
+
     def on_tick(self, data):
         # step simulation
         pass

--- a/examples/gym/test-gym_simulation.json
+++ b/examples/gym/test-gym_simulation.json
@@ -28,7 +28,7 @@
           }
       }
     },
-    "links": [["app.desired_speed", "gym.desired_speed"],
+    "links": [["app.desired_speed", "gym.move"],
               ["tick.tick", "gym.tick"],
               ["gym.pose2d", "app.pose2d"]]
   }


### PR DESCRIPTION
This PR enables use steering angle beside angular speed in the Gym simulator. The simulator robot uses Ackerman steering. The name of the channel is "move" as well as for Spider.