### PR TITLE
Add driver for VanJee Lidar

### DIFF
--- a/config/test-vanjee-lidar.json
+++ b/config/test-vanjee-lidar.json
@@ -1,0 +1,22 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "vanjee": {
+          "driver": "vanjee",
+          "in": ["raw"],
+          "out": ["raw", "xyz"],
+          "init": {}
+      },
+      "vanjee_udp": {
+          "driver": "udp",
+          "in": ["raw"],
+          "out": ["raw"],
+          "init": {"host": "192.168.0.2", "port": 58587, "timeout": 3.0, "bufsize": 100000}
+      }
+    },
+    "links": [["vanjee_udp.raw", "vanjee.raw"],
+              ["vanjee.raw", "vanjee_udp.raw"]
+      ]
+  }
+}

--- a/config/test-vanjee-lidar.json
+++ b/config/test-vanjee-lidar.json
@@ -12,7 +12,7 @@
           "driver": "udp",
           "in": ["raw"],
           "out": ["raw"],
-          "init": {"host": "192.168.0.2", "port": 58587, "timeout": 3.0, "bufsize": 100000}
+          "init": {"host": "192.168.0.2", "port": 6050, "timeout": 3.0, "bufsize": 100000}
       }
     },
     "links": [["vanjee_udp.raw", "vanjee.raw"],

--- a/osgar/drivers/__init__.py
+++ b/osgar/drivers/__init__.py
@@ -34,6 +34,7 @@ all_drivers = dict(
     resize="osgar.drivers.resize:Resize",
     pozyx="osgar.drivers.pozyx:Pozyx",
     rtk_filter="osgar.drivers.rtk_filter:RTKFilter",
+    vanjee="osgar.drivers.vanjee:VanJeeLidar",
 )
 
 

--- a/osgar/drivers/test_vanjee.py
+++ b/osgar/drivers/test_vanjee.py
@@ -1,0 +1,14 @@
+import unittest
+from unittest.mock import MagicMock
+from datetime import timedelta
+
+from osgar.drivers.vanjee import VanJeeLidar
+
+class VanJeeLidarTest(unittest.TestCase):
+
+    def test_usage(self):
+        config = {}
+        handler = MagicMock()
+        lidar = VanJeeLidar(config, bus=handler)
+
+# vim: expandtab sw=4 ts=4

--- a/osgar/drivers/vanjee.py
+++ b/osgar/drivers/vanjee.py
@@ -14,7 +14,25 @@ class VanJeeLidar(Node):
         super().__init__(config, bus)
 
     def on_raw(self, data):
-        pass
+        assert len(data) in [34, 1384], len(data)
+        if len(data) != 1384:
+            return
+        assert data[:2] == b'\xFF\xAA', data[:2].hex()
+        length = struct.unpack_from('>H', data, 2)[0]
+        assert length == 1380, length
+        frame = struct.unpack_from('>H', data, 4)[0]
+        assert data[6:8] == bytes.fromhex('0000'), data[6:10].hex()  # reserved
+        # reserved [8:10]  - variable
+        assert data[11:14] == bytes.fromhex('02 190C'), data[11:14].hex()
+        # reserved [14:16]
+        assert data[16:18] == bytes.fromhex('01 04'), data[16:18].hex()
+        bank, motor_speed = struct.unpack_from('>BH', data, 18)
+        assert 1 <= bank <= 16, bank
+        assert 38000 <= motor_speed <= 39300, motor_speed
+
+        assert data[-2:] == b'\xEE\xEE', data[-2:].hex()
+        points = struct.unpack_from('>' + 'BH' * 450, data, 21)
+#        assert 0, points[:20]
 
     def run(self):
         magic_packet = b'\xFF\xAA\x00\x1E\x00\x00\x00\x00\x00\x00\x01\x01\x19\x0C\x00\x00\x00\x00\x00\x00\x00\x00\x05\x03\x00\x00\x00\x00\x00\x00\x00\x0D\xEE\xEE'

--- a/osgar/drivers/vanjee.py
+++ b/osgar/drivers/vanjee.py
@@ -12,6 +12,8 @@ class VanJeeLidar(Node):
     def __init__(self, config, bus):
         bus.register('raw', 'xyz', 'scan')
         super().__init__(config, bus)
+        self.last_frame = None  # not defined
+        self.points = []
 
     def on_raw(self, data):
         assert len(data) in [34, 1384], len(data)
@@ -21,6 +23,9 @@ class VanJeeLidar(Node):
         length = struct.unpack_from('>H', data, 2)[0]
         assert length == 1380, length
         frame = struct.unpack_from('>H', data, 4)[0]
+        if self.last_frame is not None:
+            assert self.last_frame + 1 == frame, (self.last_frame, frame)
+        self.last_frame = frame
         assert data[6:8] == bytes.fromhex('0000'), data[6:10].hex()  # reserved
         # reserved [8:10]  - variable
         assert data[11:14] == bytes.fromhex('02 190C'), data[11:14].hex()
@@ -29,10 +34,17 @@ class VanJeeLidar(Node):
         bank, motor_speed = struct.unpack_from('>BH', data, 18)
         assert 1 <= bank <= 16, bank
         assert 38000 <= motor_speed <= 39300, motor_speed
+        if bank == 1:
+            self.points = []  # reset last scan
 
         assert data[-2:] == b'\xEE\xEE', data[-2:].hex()
-        points = struct.unpack_from('>' + 'BH' * 450, data, 21)
-#        assert 0, points[:20]
+        self.points.extend(struct.unpack_from('>' + 'BH' * 450, data, 21))
+        if bank == 16:
+            if len(self.points) == 2*7200:
+                scan = self.points[5::8]  # -10, -5, 0, 0.3
+                self.publish('scan', scan)
+            else:
+                print(self.time, f'Incomplete scan - only {len(self.points)//2} points out of 7200')  # intensity, dist in mm
 
     def run(self):
         magic_packet = b'\xFF\xAA\x00\x1E\x00\x00\x00\x00\x00\x00\x01\x01\x19\x0C\x00\x00\x00\x00\x00\x00\x00\x00\x05\x03\x00\x00\x00\x00\x00\x00\x00\x0D\xEE\xEE'

--- a/osgar/drivers/vanjee.py
+++ b/osgar/drivers/vanjee.py
@@ -1,0 +1,18 @@
+"""
+  Handle data from VanJee Lidar WLR-719C (4 lines)
+"""
+import struct
+import math
+
+from osgar.node import Node
+
+
+class VanJeeLidar(Node):
+    def __init__(self, config, bus):
+        bus.register('raw', 'xyz', 'scan')
+        super().__init__(config, bus)
+
+    def on_raw(self, data):
+        pass
+
+# vim: expandtab sw=4 ts=4

--- a/osgar/drivers/vanjee.py
+++ b/osgar/drivers/vanjee.py
@@ -5,6 +5,7 @@ import struct
 import math
 
 from osgar.node import Node
+from osgar.bus import BusShutdownException
 
 
 class VanJeeLidar(Node):
@@ -14,5 +15,15 @@ class VanJeeLidar(Node):
 
     def on_raw(self, data):
         pass
+
+    def run(self):
+        magic_packet = b'\xFF\xAA\x00\x1E\x00\x00\x00\x00\x00\x00\x01\x01\x19\x0C\x00\x00\x00\x00\x00\x00\x00\x00\x05\x03\x00\x00\x00\x00\x00\x00\x00\x0D\xEE\xEE'
+        self.publish('raw', magic_packet)
+        try:
+            while True:
+                self.update()
+        except BusShutdownException:
+            pass
+
 
 # vim: expandtab sw=4 ts=4

--- a/osgar/drivers/vanjee.py
+++ b/osgar/drivers/vanjee.py
@@ -10,7 +10,7 @@ from osgar.bus import BusShutdownException
 
 class VanJeeLidar(Node):
     def __init__(self, config, bus):
-        bus.register('raw', 'xyz', 'scan')
+        bus.register('raw', 'xyz', 'scan', 'scan10', 'scanup')
         super().__init__(config, bus)
         self.last_frame = None  # not defined
         self.points = []
@@ -43,6 +43,10 @@ class VanJeeLidar(Node):
             if len(self.points) == 2*7200:
                 scan = self.points[5::8]  # -10, -5, 0, 0.3
                 self.publish('scan', scan)
+                scan10 = self.points[1::8]  # -10, -5, 0, 0.3
+                self.publish('scan10', scan10)
+                scanup = self.points[7::8]  # -10, -5, 0, 0.3
+                self.publish('scanup', scanup)
             else:
                 print(self.time, f'Incomplete scan - only {len(self.points)//2} points out of 7200')  # intensity, dist in mm
 


### PR DESCRIPTION
This is the first attempt for VanJee 4-lines lidar integration. I expect changes (mainly test) once integrated on robot and used. In particular while scan for horizontal line is compatible with former SICK scan there is nothing similar for additional 3 layers. XYZ pointcloud from Velodyne is on the other hand overkill, I think. So for now "something in between". More info available on
https://robotika.cz/articles/vanjee-lidar/