### PR TITLE
Add optional configuration parameters for osgar.record

### DIFF
--- a/config/eduro-go.json
+++ b/config/eduro-go.json
@@ -1,0 +1,66 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "app": {
+          "driver": "osgar.go:Go",
+          "in": ["emergency_stop", "pose2d"],
+          "out": ["desired_speed"],
+          "init": {
+            "max_speed": 0.5,
+            "laser_pose2d": [0.13, 0.055, 0]
+          }
+      },
+      "eduro": {
+          "driver": "eduro",
+          "in": ["can", "desired_speed"],
+          "out": ["can", "encoders", "emergency_stop", "pose2d", "buttons"],
+          "init": {}
+      },
+      "can": {
+          "driver": "can",
+          "in": ["raw", "can"],
+          "out": ["can", "raw"],
+          "init": {"speed": "250k", "canopen":true}
+      },
+      "serial": {
+          "driver": "serial",
+          "in": ["raw"],
+          "out": ["raw"],
+          "init": {"port": "/dev/ttyS0", "speed": 115200,
+                   "rtscts":true, "reset":true}
+      },
+      "lidar": {
+          "driver": "lidar",
+          "in": ["raw"],
+          "out": ["raw", "scan"],
+          "init": {"sleep": 0.1}
+      },
+      "lidar_tcp": {
+          "driver": "tcp",
+          "in": ["raw"],
+          "out": ["raw"],
+          "init": {"host": "192.168.1.52", "port": 2111, "timeout": 3.0}
+      },
+      "camera": {
+          "driver": "http",
+          "in": [],
+          "out": ["raw"],
+          "init": {
+              "url": "http://192.168.0.99/img.jpg",
+              "sleep": 0.1,
+              "timeout": 1.0
+          }
+      }
+    },
+    "links": [["serial.raw", "can.raw"], 
+              ["can.raw", "serial.raw"],
+              ["eduro.can", "can.can"],
+              ["can.can", "eduro.can"],
+              ["app.desired_speed", "eduro.desired_speed"],
+              ["lidar_tcp.raw", "lidar.raw"], 
+              ["lidar.raw", "lidar_tcp.raw"],
+              ["eduro.emergency_stop", "app.emergency_stop"],
+              ["eduro.pose2d", "app.pose2d"]]
+  }
+}

--- a/config/eduro-go.json
+++ b/config/eduro-go.json
@@ -8,7 +8,8 @@
           "out": ["desired_speed"],
           "init": {
             "max_speed": 0.5,
-            "laser_pose2d": [0.13, 0.055, 0]
+            "dist": 1.0,
+            "timeout": 10
           }
       },
       "eduro": {

--- a/osgar/lib/config.py
+++ b/osgar/lib/config.py
@@ -5,6 +5,7 @@ import json
 import numbers
 import sys
 from importlib import import_module
+from ast import literal_eval
 
 from osgar.drivers import all_drivers
 
@@ -35,7 +36,7 @@ def _application2import(application):
     return f"{s.name}:{application.__qualname__}"
 
 
-def config_load(*filenames, application=None):
+def config_load(*filenames, application=None, params=None):
     ret = {}
     for filename in filenames:
         with open(filename) as f:
@@ -43,6 +44,13 @@ def config_load(*filenames, application=None):
             assert 'version' in data, data
             assert data['version'] in SUPPORTED_VERSIONS, data['version']
             ret = merge_dict(ret, data)
+    if params is not None:
+        for param in params:
+            assert '=' in param, param
+            key_path, str_value = param.split('=')
+            key = key_path.split('.')
+            assert len(key) == 2, key
+            ret['robot']['modules'][key[0]]['init'][key[1]] = literal_eval(str_value)
     if application is None:
         return ret
     if not isinstance(application, str):

--- a/osgar/lib/test_config.py
+++ b/osgar/lib/test_config.py
@@ -63,5 +63,15 @@ class ConfigTest(unittest.TestCase):
         conf = config_load(filename, application='osgar.lib.test_config:MyTestRobot')
         self.assertTrue(conf['robot']['modules']['app']['driver'].endswith('lib.test_config:MyTestRobot'))
 
+    def test_extra_params(self):
+        conf_dir = '../../config'
+        filename = test_data('eduro.json', conf_dir)
+        conf = config_load(filename)
+        self.assertAlmostEqual(conf['robot']['modules']['app']['init']['max_speed'], 0.5)
+
+        conf = config_load(filename, params=['app.max_speed=0.1'])
+        self.assertAlmostEqual(conf['robot']['modules']['app']['init']['max_speed'], 0.1)
+
+
 # vim: expandtab sw=4 ts=4
 

--- a/osgar/record.py
+++ b/osgar/record.py
@@ -88,11 +88,15 @@ def main(record=record):
     parser.add_argument('--duration', help='recording duration (sec), default infinite', type=float)
     parser.add_argument('--log', help='force record log filename')
     parser.add_argument('--application', help='import string to application', default=None)
+    parser.add_argument('--param', action='append',
+                        help='optional configuration parameters like go.max_speed=0.1')
     args = parser.parse_args()
 
+
     prefix = os.path.basename(args.config[0]).split('.')[0] + '-'
-    cfg = config_load(*args.config, application=args.application)
+    cfg = config_load(*args.config, application=args.application, params=args.param)
     record(cfg, log_prefix=prefix, duration_sec=args.duration, log_filename=args.log)
+
 
 if __name__ == "__main__":
     main()

--- a/osgar/record.py
+++ b/osgar/record.py
@@ -88,13 +88,13 @@ def main(record=record):
     parser.add_argument('--duration', help='recording duration (sec), default infinite', type=float)
     parser.add_argument('--log', help='force record log filename')
     parser.add_argument('--application', help='import string to application', default=None)
-    parser.add_argument('--param', action='append',
-                        help='optional configuration parameters like go.max_speed=0.1')
+    parser.add_argument('--params', nargs='+',
+                        help='optional list of configuration parameters like app.max_speed=0.1 app.dist=-2.0')
     args = parser.parse_args()
 
 
     prefix = os.path.basename(args.config[0]).split('.')[0] + '-'
-    cfg = config_load(*args.config, application=args.application, params=args.param)
+    cfg = config_load(*args.config, application=args.application, params=args.params)
     record(cfg, log_prefix=prefix, duration_sec=args.duration, log_filename=args.log)
 
 


### PR DESCRIPTION
The variable application for config file is deprecated so there is a need to pass variable configuration parameters via `osgar.record`. This PR provides new way using `--param key=value` for example `--param app.max_speed=0.1`. This was experimentally tested on robot Eduro.