### PR TITLE
ICP - slightly faster, unified matrix calculations

### DIFF
--- a/osgar/lib/icp.py
+++ b/osgar/lib/icp.py
@@ -67,6 +67,9 @@ def transform(pairs):
     U, S, V = np.linalg.svd(m)
     rot = np.matmul(U, V)
     trans = np.array([xc1, yc1]) - np.matmul(rot, np.array([xc2, yc2]).T)
+
+    # combine rotation and translation into one matrix
+    # https://lavalle.pl/planning/node99.html
     ret = np.identity(3)
     ret[:2, :2] = rot
     ret[:2, 2] = trans

--- a/osgar/lib/icp.py
+++ b/osgar/lib/icp.py
@@ -99,9 +99,9 @@ def my_icp(scan1, scan2, debug_path_prefix=None, num_iter=10, offset=0, draw_it=
         if draw_it:
             draw_scans(scan1, scan2, pairs, filename=filename)
         mat = transform(pairs)
-        scan2b = np.matmul(np.array([[x, y, 1] for x, y, in scan2]), mat.T)
-        scan2 = [(x, y) for x, y, one in scan2b]
-        total_mat = np.matmul(total_mat, mat)
+        scan2b = mat @ np.array([[x, y, 1] for x, y, in scan2]).T
+        scan2 = [(x, y) for x, y, one in scan2b.T]
+        total_mat = mat @ total_mat
 
     if draw_it:
         draw_scans(scan1, scan2)
@@ -113,22 +113,22 @@ def run_icp(filename, debug_path_prefix=None, num_iter=10):
     offset = 0
     acc_mat = np.identity(3)
     acc_scan = []
+    draw_it = debug_path_prefix is not None
     for i, scan in enumerate(scan_gen(filename)):
         if i % 10 != 0:
             continue
         if prev is not None:
             mat = my_icp(prev, scan, debug_path_prefix=debug_path_prefix,
-                                  num_iter=num_iter, offset=offset)
+                                  num_iter=num_iter, offset=offset, draw_it=draw_it)
             offset += num_iter
             acc_mat = np.matmul(acc_mat, mat)
             print(i, len(prev), acc_mat)
         prev = scan
         tmp = np.matmul(np.array([[x, y, 1] for x, y, in scan]), acc_mat.T)
         acc_scan.extend([(x, y) for x, y, one in tmp])
-        if i >= 20:
-            break
 
     draw_scans(acc_scan, [], show=True)
+
 
 def create_animation(path_prefix, num_iter=10):
     from PIL import Image

--- a/osgar/lib/icp.py
+++ b/osgar/lib/icp.py
@@ -28,16 +28,11 @@ def nearest(scan1, scan2):
     return pairs of nearest points from scan2 for each point in scan1
     """
     pairs = []
+    a = np.array(scan2)
     for pt1 in scan1:
-        min_d = None
-        candidate = None
-        for pt2 in scan2:
-            d = math.hypot(pt1[0]-pt2[0], pt1[1]-pt2[1])
-            if min_d is None or d < min_d:
-                min_d = d
-                candidate = pt2
-        assert candidate is not None
-        pairs.append((pt1, candidate))
+        pt = np.array(pt1)
+        index = np.argmin(np.linalg.norm(a - pt, axis=1))
+        pairs.append((pt1, scan2[index]))
     return pairs
 
 

--- a/osgar/lib/test_icp.py
+++ b/osgar/lib/test_icp.py
@@ -44,6 +44,6 @@ class ICPTest(unittest.TestCase):
         scan2 = []
         for x, y in scan1:
             scan2.append((x+dx, y+dy))
-        mat = my_icp(scan1, scan2)
-        scan2corrected = np.array([(x, y) for x, y, one in np.matmul(np.array([[x, y, 1] for x, y, in scan2]), mat.T)])
+        mat = my_icp(scan1, scan2, num_iter=3)
+        scan2corrected = np.array([(x, y) for x, y, one in np.matmul(mat, np.array([[x, y, 1] for x, y, in scan2]).T).T])
         np.testing.assert_almost_equal(np.array(scan1), scan2corrected)

--- a/osgar/lib/test_icp.py
+++ b/osgar/lib/test_icp.py
@@ -1,3 +1,4 @@
+import math
 import unittest
 
 import numpy as np
@@ -47,3 +48,18 @@ class ICPTest(unittest.TestCase):
         mat = my_icp(scan1, scan2, num_iter=3)
         scan2corrected = np.array([(x, y) for x, y, one in np.matmul(mat, np.array([[x, y, 1] for x, y, in scan2]).T).T])
         np.testing.assert_almost_equal(np.array(scan1), scan2corrected)
+
+    def test_rotation_with_translation(self):
+        angle = math.radians(10)
+        dx = 0.1
+        dy = -0.3
+        scan2 = [(0, 0), (10, 0), (10, 10), (2, 13)]
+
+        mat = np.array([
+            [math.cos(angle),  math.sin(angle), dx],
+            [-math.sin(angle), math.cos(angle), dy],
+            [0,                0,               1]
+        ])
+        scan1 = (mat @ np.array([[x, y, 1] for x, y in scan2]).T).T[:, :2].tolist()
+        mat2 = my_icp(scan1, scan2, num_iter=3)
+        np.testing.assert_almost_equal(mat, mat2)


### PR DESCRIPTION
This is a slightly improved version of ICP, verified matrix computations and yes, the next step is to drop outliers. Follow me breaks matching ("as expected), as well as not matching parts of environment.
![todo-outliers](https://github.com/robotika/osgar/assets/5664353/afc1f98c-7cec-4fee-9d8b-45d845eb6df6)
