### PR TITLE
add to ogar.record option --without (list of modules)

### DIFF
--- a/config/test-dual-timer.json
+++ b/config/test-dual-timer.json
@@ -1,0 +1,24 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "timer1": {
+          "driver": "timer",
+          "in": [],
+          "out": ["tick"],
+          "init": {
+            "sleep": 0.1
+          }
+      },
+      "timer2": {
+          "driver": "timer",
+          "in": [],
+          "out": ["tick"],
+          "init": {
+            "sleep": 0.2
+          }
+      }
+    },
+    "links": []
+  }
+}

--- a/osgar/lib/config.py
+++ b/osgar/lib/config.py
@@ -36,7 +36,7 @@ def _application2import(application):
     return f"{s.name}:{application.__qualname__}"
 
 
-def config_load(*filenames, application=None, params=None):
+def config_load(*filenames, application=None, params=None, without=None):
     ret = {}
     for filename in filenames:
         with open(filename) as f:
@@ -51,6 +51,17 @@ def config_load(*filenames, application=None, params=None):
             key = key_path.split('.')
             assert len(key) == 2, key
             ret['robot']['modules'][key[0]]['init'][key[1]] = literal_eval(str_value)
+    if without is not None:
+        for module in without:
+            assert module in ret['robot']['modules'], f"Module {module} not in {ret['robot']['modules'].keys()}"
+            del ret['robot']['modules'][module]
+            new_links = []
+            key = module + '.'
+            for link_from, link_to in ret['robot']['links']:
+                if link_from.startswith(key) or link_to.startswith(key):
+                    continue
+                new_links.append([link_from, link_to])
+            ret['robot']['links'] = new_links
     if application is None:
         return ret
     if not isinstance(application, str):

--- a/osgar/lib/test_config.py
+++ b/osgar/lib/test_config.py
@@ -72,6 +72,22 @@ class ConfigTest(unittest.TestCase):
         conf = config_load(filename, params=['app.max_speed=0.1'])
         self.assertAlmostEqual(conf['robot']['modules']['app']['init']['max_speed'], 0.1)
 
+    def test_without(self):
+        conf_dir = '../../config'
+        filename = test_data('test-dual-timer.json', conf_dir)
+        with self.assertRaises(AssertionError):
+            config_load(filename, without=['non_existing_timer'])
+
+        conf = config_load(filename, without=['timer1'])
+        self.assertNotIn('timer1', conf['robot']['modules'])
+        self.assertIn('timer2', conf['robot']['modules'])
+
+    def test_without_links(self):
+        conf_dir = '../../config'
+        filename = test_data('eduro.json', conf_dir)
+        conf = config_load(filename, without=['lidar_tcp'])
+        self.assertNotIn(["lidar_tcp.raw", "lidar.raw"], conf['robot']['links'])
+
 
 # vim: expandtab sw=4 ts=4
 

--- a/osgar/record.py
+++ b/osgar/record.py
@@ -90,11 +90,13 @@ def main(record=record):
     parser.add_argument('--application', help='import string to application', default=None)
     parser.add_argument('--params', nargs='+',
                         help='optional list of configuration parameters like app.max_speed=0.1 app.dist=-2.0')
+    parser.add_argument('--without', nargs='+',
+                        help='list of modules which should not be loaded/initialized/started')
     args = parser.parse_args()
 
 
     prefix = os.path.basename(args.config[0]).split('.')[0] + '-'
-    cfg = config_load(*args.config, application=args.application, params=args.params)
+    cfg = config_load(*args.config, application=args.application, params=args.params, without=args.without)
     record(cfg, log_prefix=prefix, duration_sec=args.duration, log_filename=args.log)
 
 


### PR DESCRIPTION
I would like to minimize the number of needed configuration JSON files. This is proposal for `--without` option to `osgar.record` which removes given module (or list of modules) from config and all its dependent links. Inspiration is from `poetry.lock`:
https://python-poetry.org/docs/cli/#install
where the original `poetry.lock` is already consistent with versions, but you may want to install only some packages. Later we may add also `--with` and "optional modules" ... but "later may never come".

Example:
```
(osgar) md@md-ThinkPad-P50:~/git/osgar$ python -m osgar.record --duration 10 config/test-dual-timer.json
2024-01-14 21:55:06,225 root             WARNING  Environment variable OSGAR_LOGS is not set - using working directory
2024-01-14 21:55:06,226 __main__         INFO     /home/md/git/osgar/test-dual-timer-240114_205506.log
2024-01-14 21:55:06,233 __main__         INFO     SIGINT handler installed
(osgar) md@md-ThinkPad-P50:~/git/osgar$ python -m osgar.logger /home/md/git/osgar/test-dual-timer-240114_205506.log
 k        name bytes | count | freq Hz
--------------------------------------
 0         sys 396 |   4 |   0.4Hz
 1 timer1.tick 900 | 100 |  10.1Hz
 2 timer2.tick 450 |  50 |   5.0Hz

Total time 0:00:09.937925
```
and with new option `--without`
```
osgar) md@md-ThinkPad-P50:~/git/osgar$ python -m osgar.record --duration 10 config/test-dual-timer.json  --without timer1
2024-01-14 22:10:46,318 root             WARNING  Environment variable OSGAR_LOGS is not set - using working directory
2024-01-14 22:10:46,319 __main__         INFO     /home/md/git/osgar/test-dual-timer-240114_211046.log
2024-01-14 22:10:46,319 __main__         INFO     SIGINT handler installed
(osgar) md@md-ThinkPad-P50:~/git/osgar$ python -m osgar.logger /home/md/git/osgar/test-dual-timer-240114_211046.log
 k        name bytes | count | freq Hz
--------------------------------------
 0         sys 296 |  3 |   0.3Hz
 1 timer2.tick 450 | 50 |   5.1Hz

Total time 0:00:09.816342
```