### PR TITLE
driver.replay - register channels

### DIFF
--- a/osgar/drivers/replay.py
+++ b/osgar/drivers/replay.py
@@ -42,6 +42,8 @@ class ReplayDriver:
             data = deserialize(data_raw)
             # TODO reuse timestamp
             sub_channel = self.pins[channel]
+            if ":" in sub_channel:
+                sub_channel = sub_channel.split(":")[0]
             self.bus.publish(sub_channel, data)
             if sub_channel == sleeping_channel:
                 self.bus.sleep(period)

--- a/osgar/lib/config.py
+++ b/osgar/lib/config.py
@@ -50,7 +50,11 @@ def config_load(*filenames, application=None, params=None, without=None):
             key_path, str_value = param.split('=')
             key = key_path.split('.')
             assert len(key) == 2, key
-            ret['robot']['modules'][key[0]]['init'][key[1]] = literal_eval(str_value)
+            try:
+                value_to_set = literal_eval(str_value)
+            except:
+                value_to_set = str_value
+            ret['robot']['modules'][key[0]]['init'][key[1]] = value_to_set
     if without is not None:
         for module in without:
             assert module in ret['robot']['modules'], f"Module {module} not in {ret['robot']['modules'].keys()}"

--- a/osgar/lib/config.py
+++ b/osgar/lib/config.py
@@ -50,11 +50,7 @@ def config_load(*filenames, application=None, params=None, without=None):
             key_path, str_value = param.split('=')
             key = key_path.split('.')
             assert len(key) == 2, key
-            try:
-                value_to_set = literal_eval(str_value)
-            except:
-                value_to_set = str_value
-            ret['robot']['modules'][key[0]]['init'][key[1]] = value_to_set
+            ret['robot']['modules'][key[0]]['init'][key[1]] = literal_eval(str_value)
     if without is not None:
         for module in without:
             assert module in ret['robot']['modules'], f"Module {module} not in {ret['robot']['modules'].keys()}"

--- a/osgar/record.py
+++ b/osgar/record.py
@@ -89,7 +89,8 @@ def main(record=record):
     parser.add_argument('--log', help='force record log filename')
     parser.add_argument('--application', help='import string to application', default=None)
     parser.add_argument('--params', nargs='+',
-                        help='optional list of configuration parameters like app.max_speed=0.1 app.dist=-2.0')
+                        help='optional list of configuration parameters like app.max_speed=0.1 app.dist=-2.0. '
+                             'For string parameters use double quotes e.g.: app.logfile=\'"name.log"\'')
     parser.add_argument('--without', nargs='+',
                         help='list of modules which should not be loaded/initialized/started')
     args = parser.parse_args()


### PR DESCRIPTION
It allow add channels with ":" in configs for replay driver. E.g.: 
```
"driver": "replay",
        "init": {
          "filename": null,
          "pins":{
            "oak_d.depth": "depth:null"
          }
```
Moreover, there is improved `--parrams` flag from `osgar.record`. It is easier to set string value now. E.g.:
`--params app.filename=data/logy_23/some.log`