### PR TITLE
Add followpath node

### DIFF
--- a/config/eduro-followpath.json
+++ b/config/eduro-followpath.json
@@ -52,6 +52,27 @@
               "sleep": 0.1,
               "timeout": 1.0
           }
+      },
+      "oak": {
+        "driver": "osgar.drivers.oak_camera:OakCamera",
+        "init": {
+          "fps": 10,
+          "is_color": true,
+          "is_depth": true,
+          "laser_projector_current": 1200,
+          "is_imu_enabled": true,
+          "number_imu_records": 10,
+          "disable_magnetometer_fusion": false,
+          "cam_ip": "169.254.1.222",
+          "mono_resolution": "THE_400_P",
+          "color_resolution": "THE_1080_P",
+          "color_manual_focus": 130,
+          "stereo_median_filter": "KERNEL_3x3",
+          "stereo_mode": "HIGH_ACCURACY",
+          "stereo_extended_disparity": false,
+          "stereo_subpixel": false,
+          "stereo_left_right_check": true
+        }
       }
     },
     "links": [["serial.raw", "can.raw"], 

--- a/config/eduro-followpath.json
+++ b/config/eduro-followpath.json
@@ -1,0 +1,67 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "app": {
+          "driver": "osgar.followpath:FollowPath",
+          "in": ["emergency_stop", "pose2d", "path"],
+          "out": ["desired_speed"],
+          "init": {
+            "max_speed": 0.5,
+            "path": [[0, 0], [1, 0], [1, 1]],
+            "timeout": 10
+          }
+      },
+      "eduro": {
+          "driver": "eduro",
+          "in": ["can", "desired_speed"],
+          "out": ["can", "encoders", "emergency_stop", "pose2d", "buttons"],
+          "init": {}
+      },
+      "can": {
+          "driver": "can",
+          "in": ["raw", "can"],
+          "out": ["can", "raw"],
+          "init": {"speed": "250k", "canopen":true}
+      },
+      "serial": {
+          "driver": "serial",
+          "in": ["raw"],
+          "out": ["raw"],
+          "init": {"port": "/dev/ttyS0", "speed": 115200,
+                   "rtscts":true, "reset":true}
+      },
+      "lidar": {
+          "driver": "lidar",
+          "in": ["raw"],
+          "out": ["raw", "scan"],
+          "init": {"sleep": 0.1}
+      },
+      "lidar_tcp": {
+          "driver": "tcp",
+          "in": ["raw"],
+          "out": ["raw"],
+          "init": {"host": "192.168.1.52", "port": 2111, "timeout": 3.0}
+      },
+      "camera": {
+          "driver": "http",
+          "in": [],
+          "out": ["raw"],
+          "init": {
+              "url": "http://192.168.0.99/img.jpg",
+              "sleep": 0.1,
+              "timeout": 1.0
+          }
+      }
+    },
+    "links": [["serial.raw", "can.raw"], 
+              ["can.raw", "serial.raw"],
+              ["eduro.can", "can.can"],
+              ["can.can", "eduro.can"],
+              ["app.desired_speed", "eduro.desired_speed"],
+              ["lidar_tcp.raw", "lidar.raw"], 
+              ["lidar.raw", "lidar_tcp.raw"],
+              ["eduro.emergency_stop", "app.emergency_stop"],
+              ["eduro.pose2d", "app.pose2d"]]
+  }
+}

--- a/osgar/followpath.py
+++ b/osgar/followpath.py
@@ -58,7 +58,7 @@ class FollowPath(Node):
             return 0, 0
         pt = Route(second).pointAtDist(dist=0.2)  # maybe speed dependent
         angle = Route(second).turnAngleAt(pt, radius=0.1)
-        return self.max_speed, pose[2] - angle
+        return self.max_speed, angle - pose[2]
 
     def on_pose2d(self, data):
         x, y, heading = data

--- a/osgar/followpath.py
+++ b/osgar/followpath.py
@@ -57,13 +57,15 @@ class FollowPath(Node):
         if len(second) <= 1:
             return 0, 0
         pt = Route(second).pointAtDist(dist=0.2)  # maybe speed dependent
-        angle = Route(second).turnAngleAt(pt)
+        angle = Route(second).turnAngleAt(pt, radius=0.1)
         return self.max_speed, pose[2] - angle
 
     def on_pose2d(self, data):
         x, y, heading = data
         self.last_position = [x / 1000.0, y / 1000.0, math.radians(heading / 100.0)]
         speed, angular_speed = self.control(self.last_position)
+        if self.verbose:
+            print(speed, angular_speed)
         self.send_speed_cmd(speed, angular_speed)
 
     def on_emergency_stop(self, data):

--- a/osgar/followpath.py
+++ b/osgar/followpath.py
@@ -33,9 +33,12 @@ class FollowPath(Node):
             return 0, 0
         pt = Route(second).pointAtDist(dist=0.2)  # maybe speed dependent
         pt2 = Route(second).pointAtDist(dist=0.2+0.1)
+        if math.hypot(pt2[1]-pt[1], pt2[0]-pt[0]) < 0.001:
+            # at the very end, or not defined angle
+            return 0, 0
         angle = math.atan2(pt2[1]-pt[1], pt2[0]-pt[0])
         if self.verbose:
-            print(second, pt, angle)
+            print(self.time, second, pt, angle)
         return self.max_speed, normalizeAnglePIPI(angle - pose[2])
 
     def on_pose2d(self, data):
@@ -49,17 +52,6 @@ class FollowPath(Node):
     def on_emergency_stop(self, data):
         if self.raise_exception_on_stop and data:
             raise EmergencyStopException()
-
-    def draw(self):
-        import matplotlib.pyplot as plt
-        t = [a[0] for a in self.debug_arr]
-        x = [a[1] for a in self.debug_arr]
-        line = plt.plot(t, x, '-o', linewidth=2, label=f'diff')
-
-        plt.xlabel('time (s)')
-        plt.ylabel('distance diff (m)')
-        plt.legend()
-        plt.show()
 
     def send_speed_cmd(self, speed, angular_speed):
         return self.bus.publish(

--- a/osgar/followpath.py
+++ b/osgar/followpath.py
@@ -1,0 +1,42 @@
+"""
+  Follow Path - ver0 static, ver1 dynamically updated via msg "path'
+"""
+import math
+
+from osgar.node import Node
+from osgar.followme import EmergencyStopException
+
+
+class FollowPath(Node):
+    def __init__(self, config, bus):
+        super().__init__(config, bus)
+        bus.register('desired_speed')
+        self.last_position = [0, 0, 0]  # proper should be None, but we really start from zero
+        self.raise_exception_on_stop = False
+        self.verbose = False
+
+    def on_pose2d(self, data):
+        pass  # ignore for now
+
+    def on_emergency_stop(self, data):
+        if self.raise_exception_on_stop and data:
+            raise EmergencyStopException()
+
+    def draw(self):
+        import matplotlib.pyplot as plt
+        t = [a[0] for a in self.debug_arr]
+        x = [a[1] for a in self.debug_arr]
+        line = plt.plot(t, x, '-o', linewidth=2, label=f'diff')
+
+        plt.xlabel('time (s)')
+        plt.ylabel('distance diff (m)')
+        plt.legend()
+        plt.show()
+
+    def send_speed_cmd(self, speed, angular_speed):
+        return self.bus.publish(
+            'desired_speed',
+            [round(speed*1000), round(math.degrees(angular_speed)*100)]
+        )
+
+# vim: expandtab sw=4 ts=4

--- a/osgar/followpath.py
+++ b/osgar/followpath.py
@@ -27,32 +27,6 @@ class FollowPath(Node):
         self.raise_exception_on_stop = False
         self.verbose = False
 
-    def nearest(self, pose, path):
-        if len(path) == 0:
-            return None, None
-        if len(path) == 1:
-            return path[0], None
-        # dense points? crossing lines?
-        min_dist = None
-        best = None, None
-        x, y, heading = pose
-        for i, p in enumerate(path):
-            dist = math.hypot(p[0] - x, p[1] - y)
-            if min_dist is None or dist < min_dist:
-                best = i
-                min_dist = dist
-        if best == 0:
-            return path[0], path[1]
-        if best == len(path) - 1:
-            return path[-1], None
-        # choose before or after
-        dist_before = math.hypot(path[best - 1][0] - x, path[best - 1][1] - y)
-        dist_after = math.hypot(path[best + 1][0] - x, path[best + 1][1] - y)
-        if dist_before < dist_after:
-            return path[best - 1], path[best]
-        else:
-            return path[best], path[best + 1]
-
     def control(self, pose):
         first, second = self.route.routeSplit(pose[:2])
         if len(second) <= 1:

--- a/osgar/followpath.py
+++ b/osgar/followpath.py
@@ -3,8 +3,17 @@
 """
 import math
 
+from osgar.lib.route import Route as GPSRoute, DummyConvertor
 from osgar.node import Node
 from osgar.followme import EmergencyStopException
+
+
+class Route(GPSRoute):
+    """
+    Override GPS defaults to normal planar case
+    """
+    def __init__(self, pts=[]):
+        super().__init__(pts, conv=DummyConvertor(), isLoop=False)
 
 
 class FollowPath(Node):
@@ -12,11 +21,50 @@ class FollowPath(Node):
         super().__init__(config, bus)
         bus.register('desired_speed')
         self.last_position = [0, 0, 0]  # proper should be None, but we really start from zero
+        self.route = Route(pts=config.get('path', []))
+        self.max_speed = config.get('max_speed', 0.2)
         self.raise_exception_on_stop = False
         self.verbose = False
 
+    def nearest(self, pose, path):
+        if len(path) == 0:
+            return None, None
+        if len(path) == 1:
+            return path[0], None
+        # dense points? crossing lines?
+        min_dist = None
+        best = None, None
+        x, y, heading = pose
+        for i, p in enumerate(path):
+            dist = math.hypot(p[0] - x, p[1] - y)
+            if min_dist is None or dist < min_dist:
+                best = i
+                min_dist = dist
+        if best == 0:
+            return path[0], path[1]
+        if best == len(path) - 1:
+            return path[-1], None
+        # choose before or after
+        dist_before = math.hypot(path[best - 1][0] - x, path[best - 1][1] - y)
+        dist_after = math.hypot(path[best + 1][0] - x, path[best + 1][1] - y)
+        if dist_before < dist_after:
+            return path[best - 1], path[best]
+        else:
+            return path[best], path[best + 1]
+
+    def control(self, pose):
+        first, second = self.route.routeSplit(pose[:2])
+        if len(second) <= 1:
+            return 0, 0
+        pt = Route(second).pointAtDist(dist=0.2)  # maybe speed dependent
+        angle = Route(second).turnAngleAt(pt)
+        return self.max_speed, pose[2] - angle
+
     def on_pose2d(self, data):
-        pass  # ignore for now
+        x, y, heading = data
+        self.last_position = [x / 1000.0, y / 1000.0, math.radians(heading / 100.0)]
+        speed, angular_speed = self.control(self.last_position)
+        self.send_speed_cmd(speed, angular_speed)
 
     def on_emergency_stop(self, data):
         if self.raise_exception_on_stop and data:

--- a/osgar/followpath.py
+++ b/osgar/followpath.py
@@ -28,6 +28,16 @@ class FollowPath(Node):
         self.verbose = False
 
     def control(self, pose):
+        """
+        Based on current "pose2d" robot position and "self.route" return desired speed and angular speed.
+
+        The current implementation takes nearest point on the route and predicts next position following
+        the route (now hardcoded 20cm). Then calculate absolute direction (via following another 10cm)
+        and define angular speed to reach this absolute direction within 1 second. If the nearest position
+        is already by the end of route then stop.
+
+        Note, that there is no correction based on signed distance from route.
+        """
         first, second = self.route.routeSplit(pose[:2])
         if len(second) <= 1:
             return 0, 0

--- a/osgar/followpath.py
+++ b/osgar/followpath.py
@@ -4,6 +4,7 @@
 import math
 
 from osgar.lib.route import Route as GPSRoute, DummyConvertor
+from osgar.lib.mathex import normalizeAnglePIPI
 from osgar.node import Node
 from osgar.followme import EmergencyStopException
 
@@ -57,8 +58,11 @@ class FollowPath(Node):
         if len(second) <= 1:
             return 0, 0
         pt = Route(second).pointAtDist(dist=0.2)  # maybe speed dependent
-        angle = Route(second).turnAngleAt(pt, radius=0.1)
-        return self.max_speed, angle - pose[2]
+        pt2 = Route(second).pointAtDist(dist=0.2+0.1)
+        angle = math.atan2(pt2[1]-pt[1], pt2[0]-pt[0])
+        if self.verbose:
+            print(second, pt, angle)
+        return self.max_speed, normalizeAnglePIPI(angle - pose[2])
 
     def on_pose2d(self, data):
         x, y, heading = data

--- a/osgar/test_followpath.py
+++ b/osgar/test_followpath.py
@@ -48,6 +48,8 @@ class FollowPathTest(unittest.TestCase):
         app = FollowPath(config=config, bus=bus.handle('app'))
         self.assertEqual(app.control([0, 0, 0]), (max_speed, 0))
 
+        self.assertEqual(app.control([0, 0, 0.1]), (max_speed, -0.1))
+
     def test_follow_path(self):
         bus = Bus(MagicMock())
         config = {

--- a/osgar/test_followpath.py
+++ b/osgar/test_followpath.py
@@ -20,24 +20,6 @@ class FollowPathTest(unittest.TestCase):
         with self.assertRaises(EmergencyStopException):
             app.run()
 
-    def test_nearest(self):
-        app = FollowPath(config={}, bus=MagicMock())
-        a, b = app.nearest([0, 0, 0], [])
-        self.assertIsNone(a)
-        self.assertIsNone(b)
-
-        a, b = app.nearest([0, 0, 0], [[1, 2]])
-        self.assertEqual(a, [1, 2])  # take into account heading?
-        self.assertIsNone(b)
-
-        a, b = app.nearest([0, 0, 0], [[0, 0], [2, 0]])
-        self.assertEqual(a, [0, 0])
-        self.assertEqual(b, [2, 0])
-
-        a, b = app.nearest([2, 0.9, 0], [[0, 0], [2, 0], [2, 2]])
-        self.assertEqual(a, [2, 0])
-        self.assertEqual(b, [2, 2])
-
     def test_control(self):
         max_speed = 0.5
         bus = Bus(MagicMock())

--- a/osgar/test_followpath.py
+++ b/osgar/test_followpath.py
@@ -20,4 +20,41 @@ class FollowPathTest(unittest.TestCase):
         with self.assertRaises(EmergencyStopException):
             app.run()
 
+    def test_nearest(self):
+        app = FollowPath(config={}, bus=MagicMock())
+        a, b = app.nearest([0, 0, 0], [])
+        self.assertIsNone(a)
+        self.assertIsNone(b)
+
+        a, b = app.nearest([0, 0, 0], [[1, 2]])
+        self.assertEqual(a, [1, 2])  # take into account heading?
+        self.assertIsNone(b)
+
+        a, b = app.nearest([0, 0, 0], [[0, 0], [2, 0]])
+        self.assertEqual(a, [0, 0])
+        self.assertEqual(b, [2, 0])
+
+        a, b = app.nearest([2, 0.9, 0], [[0, 0], [2, 0], [2, 2]])
+        self.assertEqual(a, [2, 0])
+        self.assertEqual(b, [2, 2])
+
+    def test_control(self):
+        max_speed = 0.5
+        bus = Bus(MagicMock())
+        config = {
+            'max_speed': max_speed,
+            'path': [[0, 0], [3, 0], [3, 3]]
+        }
+        app = FollowPath(config=config, bus=bus.handle('app'))
+        self.assertEqual(app.control([0, 0, 0]), (max_speed, 0))
+
+    def test_follow_path(self):
+        bus = Bus(MagicMock())
+        config = {
+            'path': [[0, 0], [3, 0]]
+        }
+        app = FollowPath(config=config, bus=bus.handle('app'))
+
+
+
 # vim: expandtab sw=4 ts=4

--- a/osgar/test_followpath.py
+++ b/osgar/test_followpath.py
@@ -39,6 +39,8 @@ class FollowPathTest(unittest.TestCase):
         }
         app = FollowPath(config=config, bus=bus.handle('app'))
 
+        # STOP at the end of segment!
+        self.assertEqual(app.control([2.9, 0, 0]), (0, 0))
 
 
 # vim: expandtab sw=4 ts=4

--- a/osgar/test_followpath.py
+++ b/osgar/test_followpath.py
@@ -1,0 +1,23 @@
+import unittest
+from unittest.mock import MagicMock
+
+from osgar.followpath import FollowPath, EmergencyStopException
+from osgar.bus import Bus
+
+
+class FollowPathTest(unittest.TestCase):
+
+    def test_usage(self):
+        bus = Bus(MagicMock())
+        app = FollowPath(config={}, bus=bus.handle('app'))
+        tester = bus.handle('tester')
+        tester.register('emergency_stop')
+        bus.connect('tester.emergency_stop', 'app.emergency_stop')
+        tester.publish('emergency_stop', True)
+
+        app.raise_exception_on_stop = True
+        
+        with self.assertRaises(EmergencyStopException):
+            app.run()
+
+# vim: expandtab sw=4 ts=4


### PR DESCRIPTION
This is simple follow path tested on Eduro. Can be used with external parameters like
`python -m osgar.record --params app.max_speed=0.2 app.path="[[0,0], [1,0], [1,0.5], [0,0.5]]"`
or looping
`python -m osgar.record --params app.max_speed=0.2 app.path="[0,0], [1,0], [1,0.5], [0,0.5], [0, 0], [0.1, 0]]"`

There is expected to be further development - FR07 support, variable speed, angle correction, accept new path as message, ...