### PR TITLE
osgar/logger.py - support gzipped logfiles

### DIFF
--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -38,6 +38,7 @@ from threading import RLock
 from ast import literal_eval
 import mmap
 import pathlib
+import gzip
 
 g_logger = logging.getLogger(__name__)
 
@@ -160,7 +161,10 @@ class LogReader:
     def __init__(self, filename, follow=False, only_stream_id=None):
         self.filename = filename
         self.follow = follow
-        self.f = open(self.filename, 'rb')
+        if str(self.filename).endswith('gz'):  # support both string and pathlib.Path
+            self.f = gzip.open(self.filename)
+        else:
+            self.f = open(self.filename, 'rb')
         data = self._read(4)
         assert data == MAGIC, data
 


### PR DESCRIPTION
Sometimes the content of OSGAR logs is wasteful, for example if you need to log raw sensor data and they are mostly zeros. One possibility is to gzip the stream, but an alternative (potentially faster for run-time) is to gzip OSGAR log file in some post-processing. I see now on robot Pat relatively large file and gzip helps a little bit there:
```
(osgar) robot@screwbot-ODYSSEY-X86J4125:~/git/osgar$ ls -lh *240302*
-rw-rw-r-- 1 robot robot 784M bře  2 15:38 fr07-followpath-240302_143722.log
-rw-rw-r-- 1 robot robot 677M bře  2 15:43 fr07-followpath-240302_144238.log
-rw-rw-r-- 1 robot robot 205M bře  2 15:46 fr07-followpath-240302_144603.log
-rw-rw-r-- 1 robot robot  52M bře  2 15:46 fr07-followpath-240302_144650.log
-rw-rw-r-- 1 robot robot 406M bře  2 15:49 fr07-followpath-240302_144850.log
-rw-rw-r-- 1 robot robot 373M bře  2 15:55 fr07-followpath-240302_145525.log
-rw-rw-r-- 1 robot robot 337M bře  2 15:58 fr07-followpath-240302_145817.log
-rw-rw-r-- 1 robot robot  63M bře  2 15:40 fr07-go-240302_144020.log
-rw-rw-r-- 1 robot robot 6,3M bře  2 15:41 fr07-go-240302_144126.log
-rw-rw-r-- 1 robot robot 107M bře  2 15:44 fr07-go-240302_144432.log

robot@screwbot-ODYSSEY-X86J4125:~/git/osgar$ ls -lh *240302*
-rw-rw-r-- 1 robot robot 540M bře  2 15:38 fr07-followpath-240302_143722.log.gz
-rw-rw-r-- 1 robot robot 469M bře  2 15:43 fr07-followpath-240302_144238.log.gz
-rw-rw-r-- 1 robot robot 136M bře  2 15:46 fr07-followpath-240302_144603.log.gz
-rw-rw-r-- 1 robot robot  31M bře  2 15:46 fr07-followpath-240302_144650.log.gz
-rw-rw-r-- 1 robot robot 281M bře  2 15:49 fr07-followpath-240302_144850.log.gz
-rw-rw-r-- 1 robot robot 255M bře  2 15:55 fr07-followpath-240302_145525.log.gz
-rw-rw-r-- 1 robot robot 227M bře  2 15:58 fr07-followpath-240302_145817.log.gz
-rw-rw-r-- 1 robot robot  42M bře  2 15:40 fr07-go-240302_144020.log.gz
-rw-rw-r-- 1 robot robot 3,9M bře  2 15:41 fr07-go-240302_144126.log.gz
-rw-rw-r-- 1 robot robot  71M bře  2 15:44 fr07-go-240302_144432.log.gz
```
