### PR TITLE
osgar/drivers/pcan.py - change log level from debug to info

### DIFF
--- a/osgar/drivers/pcan.py
+++ b/osgar/drivers/pcan.py
@@ -27,6 +27,7 @@ class PeakCAN:
         self.bus = bus
         bus.register('can')
         self.canbus = can.interface.Bus(bustype='pcan', channel='PCAN_USBBUS1', bitrate=500000)
+        can.util.set_logging_level(config.get('logging_level', 'info'))
         self.input_thread = Thread(target=self.run_input, daemon=True)
         self.output_thread = Thread(target=self.run_output, daemon=True)
 


### PR DESCRIPTION
Python CAN has by default (to my surprise) log level "debug" (!), which is basically impossible to use once the communication is running (the CAN messages are printed). This one-liner allows change in config + sets as default "info".
For more info see:
https://python-can.readthedocs.io/en/v4.3.1/internal-api.html#can.util.set_logging_level

can.util.set_logging_level(level_name)[[source]](https://python-can.readthedocs.io/en/v4.3.1/_modules/can/util.html#set_logging_level)

    Set the logging level for the “can” logger.

    Parameters:

        level_name ([str](https://docs.python.org/3/library/stdtypes.html#str)) – One of: ‘critical’, ‘error’, ‘warning’, ‘info’, ‘debug’, ‘subdebug’, or the value [None](https://docs.python.org/3/library/constants.html#None) (=default). Defaults to ‘debug’.
    Return type:

        None
