### PR TITLE
Extend replay.py by --duration and handle corrupted end of log files

### DIFF
--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -157,9 +157,10 @@ class LogWriter:
 
 
 class LogReader:
-    def __init__(self, filename, follow=False, only_stream_id=None):
+    def __init__(self, filename, follow=False, only_stream_id=None, duration=None):
         self.filename = filename
         self.follow = follow
+        self.duration = duration
         self.f = open(self.filename, 'rb')
         data = self._read(4)
         assert data == MAGIC, data
@@ -194,8 +195,21 @@ class LogReader:
             if len(header) < 8:
                 break
             dt_bytes = header[:4]
-            dt =  parse_timedelta(dt_bytes)
+            dt = parse_timedelta(dt_bytes)
             stream_id, size = struct.unpack('HH', header[4:])
+            if stream_id == 0 and size == 0:
+                g_logger.error(f"                       ")
+                g_logger.error(f"Zero bytes {self.f.name} from position {start}")
+                count = 0
+                while True:
+                    data = self._read(1)
+                    count += 1
+                    if len(data) == 0:
+                        break
+                    assert data[0] == 0, data
+                g_logger.error(f"-------> {count} zeros ({100 * count / (start + count):0.2}%)")
+                g_logger.error(f"                       ")
+                return
             data = self._read(size)
             if len(data) != size:
                 g_logger.error(f"Incomplete log file {self.f.name} from position {start}")
@@ -215,11 +229,13 @@ class LogReader:
 
             if len(self.multiple_streams) == 0 or stream_id in self.multiple_streams:
                 yield dt, stream_id, data
+                if self.duration is not None and dt.total_seconds() > self.duration:
+                    g_logger.info(f"Duration limit {self.duration} reached ({dt})")
+                    break
 
     def close(self):
         self.f.close()
         self.f = None
-
 
     # context manager functions
     def __enter__(self):

--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -197,7 +197,9 @@ class LogReader:
             dt_bytes = header[:4]
             dt = parse_timedelta(dt_bytes)
             stream_id, size = struct.unpack('HH', header[4:])
+            # check for corrupted end of log file (filled with zeros)
             if stream_id == 0 and size == 0:
+                # unexpected size for system stream -> corrupted log file
                 g_logger.error(f"                       ")
                 g_logger.error(f"Zero bytes {self.f.name} from position {start}")
                 count = 0

--- a/osgar/replay.py
+++ b/osgar/replay.py
@@ -49,12 +49,13 @@ def replay(args, application=None):
         for i, name in sorted(outputs.items()):
             print(f" {i:2d} {name}")
 
+    duration = args.duration
     if args.force:
-        reader = LogReader(args.logfile, only_stream_id=inputs.keys())
+        reader = LogReader(args.logfile, only_stream_id=inputs.keys(), duration=duration)
         bus = LogBusHandlerInputsOnly(reader, inputs=inputs)
     else:
         streams = list(inputs.keys()) + list(outputs.keys())
-        reader = LogReader(args.logfile, only_stream_id=streams)
+        reader = LogReader(args.logfile, only_stream_id=streams, duration=duration)
         bus = LogBusHandler(reader, inputs, outputs)
 
     driver_name = module_config['driver']
@@ -81,6 +82,7 @@ def main():
     parser.add_argument('--verbose', '-v', help="verbose mode", action='store_true')
     parser.add_argument('--draw', help="draw debug results", action='store_true')
     parser.add_argument('--debug', help="print debug info about I/O streams", action='store_true')
+    parser.add_argument('--duration', help="limit replay to given time", type=float)
     args = parser.parse_args()
 
     if args.module is None:


### PR DESCRIPTION
Add new option `--duration` (similar one is used in `record.py`) to limit how long log file is used for replay. Useful for quick check and/or in combination with `--draw` feature.

Also handle corrupted log files (zeros at the end) and report it.