### PR TITLE
OAK-D support H264 and H265 video encoding and gzip detph data

### DIFF
--- a/config/test-oak-camera-usb.json
+++ b/config/test-oak-camera-usb.json
@@ -7,6 +7,7 @@
           "init": {
             "fps": 10,
             "is_color": true,
+            "video_encoder": "h264",
             "is_depth": true,
             "laser_projector_current": 0,
             "flood_light_current": 500,

--- a/osgar/drivers/oak_camera.py
+++ b/osgar/drivers/oak_camera.py
@@ -42,7 +42,9 @@ class OakCamera:
         self.input_thread = Thread(target=self.run_input, daemon=True)
         self.bus = bus
 
-        self.bus.register('depth:gz', 'color', 'orientation_list', 'detections',
+        compress_depth_stream = config.get('compress_depth_stream', True)
+        self.bus.register('depth:gz' if compress_depth_stream else 'depth',
+                          'color', 'orientation_list', 'detections',
                           # *_seq streams are needed for output sync amd they are published BEFORE payload data
                           'depth_seq', 'color_seq', 'detections_seq')
         self.fps = config.get('fps', 10)

--- a/osgar/drivers/oak_camera.py
+++ b/osgar/drivers/oak_camera.py
@@ -25,6 +25,18 @@ def cam_is_available(cam_ip):
     return False
 
 
+def get_video_encoder(name):
+    # https://docs.luxonis.com/projects/api/en/latest/components/nodes/video_encoder/
+    if name == 'h264':
+        return dai.VideoEncoderProperties.Profile.H264_MAIN
+    elif name == 'h265':
+        return dai.VideoEncoderProperties.Profile.H265_MAIN
+    elif name == 'mjpeg':
+        return dai.VideoEncoderProperties.Profile.MJPEG
+    else:
+        assert 0, f'"{name}" is not supported'
+
+
 class OakCamera:
     def __init__(self, config, bus):
         self.input_thread = Thread(target=self.run_input, daemon=True)
@@ -40,6 +52,8 @@ class OakCamera:
         self.flood_light_current = config.get("flood_light_current", 0)
         assert self.flood_light_current <= 1500, self.flood_light_current  # The limit is 1500 mA.
         self.is_color = config.get('is_color', False)
+        self.video_encoder = get_video_encoder(config.get('video_encoder', 'mjpeg'))
+
         self.is_imu_enabled = config.get('is_imu_enabled', False)
         # Preferred number of IMU records in one packet
         self.number_imu_records = config.get('number_imu_records', 20)
@@ -163,7 +177,7 @@ class OakCamera:
                 exposure, iso = self.color_manual_exposure
                 color.initialControl.setManualExposure(exposure, iso)  # exposure time and ISO
 
-            color_encoder.setDefaultProfilePreset(self.fps, dai.VideoEncoderProperties.Profile.MJPEG)
+            color_encoder.setDefaultProfilePreset(self.fps, self.video_encoder)
 
             color.video.link(color_encoder.input)
             color_encoder.bitstream.link(color_out.input)

--- a/osgar/drivers/oak_camera.py
+++ b/osgar/drivers/oak_camera.py
@@ -42,7 +42,7 @@ class OakCamera:
         self.input_thread = Thread(target=self.run_input, daemon=True)
         self.bus = bus
 
-        self.bus.register('depth', 'color', 'orientation_list', 'detections',
+        self.bus.register('depth:gz', 'color', 'orientation_list', 'detections',
                           # *_seq streams are needed for output sync amd they are published BEFORE payload data
                           'depth_seq', 'color_seq', 'detections_seq')
         self.fps = config.get('fps', 10)


### PR DESCRIPTION
* extend video encoders
* gzip depth data

before:
```
(osgar) md@md-ThinkPad-P50:~/git/osgar$ python -m osgar.logger /home/md/git/osgar/test-oak-camera-usb-240507_171842.log
 k                 name    bytes | count | freq Hz
--------------------------------------------------
 0                  sys     1243 |  9 |   0.9Hz
 1            oak.depth 35337246 | 69 |   6.9Hz
 2            oak.color 32602560 | 68 |   6.8Hz
 3 oak.orientation_list    36366 | 66 |   6.6Hz
 4       oak.detections        0 |  0 |   0.0Hz
 5        oak.depth_seq      759 | 69 |   6.9Hz
 6        oak.color_seq      748 | 68 |   6.8Hz
 7   oak.detections_seq        0 |  0 |   0.0Hz

Total time 0:00:10.039510
```

after
```
(osgar) md@md-ThinkPad-P50:~/git/osgar$ python -m osgar.logger /home/md/git/osgar/test-oak-camera-usb-240507_172759.log 
 k                 name   bytes | count | freq Hz
-------------------------------------------------
 0                  sys    1271 |  9 |   0.9Hz
 1            oak.depth 1823576 | 68 |   6.8Hz
 2            oak.color 2426190 | 68 |   6.8Hz
 3 oak.orientation_list   36917 | 67 |   6.7Hz
 4       oak.detections       0 |  0 |   0.0Hz
 5        oak.depth_seq     748 | 68 |   6.8Hz
 6        oak.color_seq     748 | 68 |   6.8Hz
 7   oak.detections_seq       0 |  0 |   0.0Hz

Total time 0:00:10.064269
```