### PR TITLE
gps.py: register also rel_position

### DIFF
--- a/osgar/drivers/gps.py
+++ b/osgar/drivers/gps.py
@@ -119,7 +119,7 @@ def split_buffer(data):
 
 class GPS(Thread):
     def __init__(self, config, bus):
-        bus.register('position')
+        bus.register('position', 'rel_position')
         Thread.__init__(self)
         self.setDaemon(True)
 


### PR DESCRIPTION
I found, that the gps module crashes due to attempt to publish this stream. It is related to u-blox GPS. See in `parse_bin`.