### PR TITLE
LidarView - support for H264 video stream

### DIFF
--- a/osgar/tools/lidarview.py
+++ b/osgar/tools/lidarview.py
@@ -252,10 +252,12 @@ def get_image(data):
                 # I - key frame
                 with open('tmp.h264', 'wb') as f:
                     f.write(data)
-            elif data.startswith(bytes.fromhex('00000001 0950')):
+            elif data.startswith(bytes.fromhex('00000001 0930')):
                 # P-frame}
                 with open('tmp.h264', 'ab') as f:
                     f.write(data)
+            else:
+                assert 0, f'Unexpected data {data[:20].hex()}'
             cap = cv2.VideoCapture('tmp.h264')
             image = None
             ret = True

--- a/osgar/tools/lidarview.py
+++ b/osgar/tools/lidarview.py
@@ -214,7 +214,7 @@ def depth_map(depth):
     return pygame.image.frombuffer(
             cv2.cvtColor(
                 cv2.applyColorMap(depth, cv2.COLORMAP_JET),
-                cv2.COLOR_BGR2RGB).tostring(),
+                cv2.COLOR_BGR2RGB).tobytes(),
             depth.shape[1::-1], "RGB")
 
 def get_image(data):
@@ -231,7 +231,7 @@ def get_image(data):
             im_color = cv2.applyColorMap(img, cv2.COLORMAP_JET)
 
         # https://stackoverflow.com/questions/19306211/opencv-cv2-image-to-pygame-image
-        image = pygame.image.frombuffer(im_color.tostring(), im_color.shape[1::-1], "RGB")
+        image = pygame.image.frombuffer(im_color.tobytes(), im_color.shape[1::-1], "RGB")
         g_depth = data
     elif isinstance(data, tuple):
         img_data, depth_data = data
@@ -278,7 +278,7 @@ def pygame_to_numpy_image(pygame_img):
 
 def numpy_to_pygame_image(np_image):
     np_img = cv2.cvtColor(np_image, cv2.COLOR_BGR2RGB)
-    return pygame.image.frombuffer(np_img.tostring(), np_img.shape[1::-1], "RGB")
+    return pygame.image.frombuffer(np_img.tobytes(), np_img.shape[1::-1], "RGB")
 
 
 class Frame:


### PR DESCRIPTION
This is a hacky way of support of H264 encoding (maybe also H265, not sure) for LidarView. Note, that I still do not know better way how to convince OpenCV to read from stream, unless we would like to merge some other 3rd party library??

Also note, that this hack works only for forward motion (OAK-D has default 1 key frame and 9 update frames).