### PR TITLE
Draw all layers for VanJee lidar

### DIFF
--- a/osgar/drivers/vanjee.py
+++ b/osgar/drivers/vanjee.py
@@ -76,11 +76,11 @@ class VanJeeLidar(Node):
         line03, = ax.plot(self.debug_arr[i][1][7::8], 'o', linewidth=2, label='0.3 deg')
 
         # adjust the main plot to make room for the sliders
-        fig.subplots_adjust(bottom=0.25, left=0.2)
+        fig.subplots_adjust(bottom=0.25)
         plt.xlabel('angle index')
         plt.ylabel('distance (mm)')
 
-        axfreq = fig.add_axes([0.25, 0.1, 0.65, 0.03])
+        axfreq = fig.add_axes([0.1, 0.1, 0.8, 0.03])
         freq_slider = Slider(
             ax=axfreq,
             label='Frame',


### PR DESCRIPTION
This is another "integration branch", where I was analyzing missing reflections of some layers (so individual commits are misleading as they were already merged into master in separate PRs).

The new functionality provides views per scan and they look like:
 
![vanjee-all4](https://github.com/robotika/osgar/assets/5664353/ef89f395-ee31-4177-a9f3-9f0ebe98d010)
