### PR TITLE
Add option --duration also to base logger

### DIFF
--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -393,6 +393,7 @@ def main():
     parser.add_argument('--format', help='use python format - available fields sec, timestamp, stream_id, data')
     parser.add_argument('--all', help='dump all messages', action='store_true')
     parser.add_argument('--raw', help='dump raw data', action='store_true')
+    parser.add_argument('--duration', help="limit extraction to given time", type=float)
     args = parser.parse_args()
 
     if args.list_names:
@@ -423,7 +424,7 @@ def main():
         for name in args.stream:
             only_stream.append(lookup_stream_id(args.logfile, name))
 
-    with LogReader(args.logfile, only_stream_id=only_stream) as log:
+    with LogReader(args.logfile, only_stream_id=only_stream, duration=args.duration) as log:
         for timestamp, stream_id, data in log:
             if stream_id != 0:
                 data = deserialize(data)


### PR DESCRIPTION
Add the same `--duration` option also to `osgar.logger` (next to `osgar.record` and `osgar.replay`). The code was already there (needed for replay), so now it is just public. Motivation is creation H264 video for YouTube from OAK-D camera where interesting is only the first part. An example:
```
python -m osgar.logger /data/pat/2024_05_18/pat-go-314-240518_082742.log --stream oak.color --raw --duration 300 > roro24-pat-1st-round.h264
```
was used to generate https://youtu.be/UKBNOBJEYZU