### PR TITLE
Extend Go by option to specify steering angle or angular speed

### DIFF
--- a/osgar/test_go.py
+++ b/osgar/test_go.py
@@ -1,0 +1,18 @@
+import unittest
+from unittest.mock import MagicMock
+
+from osgar.go import Go
+
+
+class GoTest(unittest.TestCase):
+
+    def test_usage(self):
+        bus = MagicMock()
+        app = Go(bus=bus, config={
+            # required parameters
+            'max_speed': 0.5,
+            'dist': 1.0,
+            'timeout': 10
+        })
+        app.on_pose2d([0, 0, 0])
+#        bus.publish.assert_called_with('emergency_stop', True)


### PR DESCRIPTION
It is useful to test not only straight motion there and back, but maybe also turn. More over we have some robots which have steering (Pat, Spider, Matty, John Deere) and other (Eduro, Freya) have differential drive. By default Go will publish both `desired_speed` and `desired_steering` with 0. If you specify angle for steering or angular speed, then only one interface is used.