### PR TITLE
Handle properly replay termination at the end of logfile

### DIFF
--- a/osgar/bus.py
+++ b/osgar/bus.py
@@ -164,7 +164,10 @@ class LogBusHandler:
             if self.finished.is_set():
                 raise BusShutdownException
             if len(self.buffer_queue) == 0:
-                dt, stream_id, bytes_data = next(self.reader)
+                try:
+                    dt, stream_id, bytes_data = next(self.reader)
+                except StopIteration:
+                    raise SystemExit()
             else:
                 dt, stream_id, bytes_data = self.buffer_queue.popleft()
             if stream_id not in self.inputs:
@@ -221,7 +224,10 @@ class LogBusHandlerInputsOnly:
         pass
 
     def listen(self):
-        dt, stream_id, bytes_data = next(self.reader)
+        try:
+            dt, stream_id, bytes_data = next(self.reader)
+        except StopIteration:
+            raise SystemExit()
         self.time = dt
         channel = self.inputs[stream_id]
         data = deserialize(bytes_data)

--- a/osgar/bus.py
+++ b/osgar/bus.py
@@ -186,7 +186,7 @@ class LogBusHandler:
 
     def publish(self, channel, data):
         assert channel in self.outputs.values(), (channel, tuple(self.outputs.values()))
-        dt, stream_id, bytes_data = next(self.reader)
+        dt, stream_id, bytes_data = self._read_next()
         while stream_id not in self.outputs:
             input_name = self.inputs[stream_id]
             if input_name.startswith("slot_"):


### PR DESCRIPTION
This is the old painful replay, which looked like some error:
```
Traceback (most recent call last):
  File "/usr/lib/python3.8/threading.py", line 932, in _bootstrap_inner
    self.run()
  File "/home/md/git/osgar/osgar/node.py", line 44, in run
    self.update()
  File "/home/md/git/osgar/osgar/node.py", line 32, in update
    timestamp, channel, data = self.bus.listen()
  File "/home/md/git/osgar/osgar/bus.py", line 167, in listen
    dt, stream_id, bytes_data = next(self.reader)
  File "/home/md/git/osgar/osgar/logger.py", line 252, in __next__
    return next(self.gen)
StopIteration
```
With SystemExit() [thanks Jirka!] it terminates nicely without exception ...