### PR TITLE
Add slerp() to lib/quaternion.py

### DIFF
--- a/osgar/lib/test_quaternion.py
+++ b/osgar/lib/test_quaternion.py
@@ -96,12 +96,41 @@ class QuaternionTest(TestCase):
             self.assertAlmostEqual(B[i], D[i], 3)
 
     def test_slerp__various_angles(self):
+        sqrt_3 = math.sqrt(3)
+        sqrt_1_7 = math.sqrt(1/7)
+        sqrt_2_7 = math.sqrt(2/7)
+        sqrt_4_7 = math.sqrt(4/7)
         for a in range(40):
             angle_A = 10*math.pi*(a - 20)/40
+            sin_A_half = math.sin(angle_A/2)
+            cos_A_half = math.cos(angle_A/2)
             for b in range(10):
                 angle_B = angle_A + math.pi*(b - 5)/10
-                A = [0.0, 0.0, math.sin(angle_A/2), math.cos(angle_A/2)]
-                B = [0.0, 0.0, math.sin(angle_B/2), math.cos(angle_B/2)]
+                sin_B_half = math.sin(angle_B/2)
+                cos_B_half = math.cos(angle_B/2)
+                # around x
+                A = [sin_A_half, 0.0, 0.0, cos_A_half]
+                B = [sin_B_half, 0.0, 0.0, cos_B_half]
+                for c in range(10):
+                    t = c / 9
+                    result = quaternion.slerp(A, B, t)
+                    expected_angle = (1 - t)*angle_A + t*angle_B
+                    expected = [math.sin(expected_angle/2), 0.0, 0.0, math.cos(expected_angle/2)]
+                    for i in range(4):
+                        self.assertAlmostEqual(result[i], expected[i], 3)
+                # around y
+                A = [0.0, sin_A_half, 0.0, cos_A_half]
+                B = [0.0, sin_B_half, 0.0, cos_B_half]
+                for c in range(10):
+                    t = c / 9
+                    result = quaternion.slerp(A, B, t)
+                    expected_angle = (1 - t)*angle_A + t*angle_B
+                    expected = [0.0, math.sin(expected_angle/2), 0.0, math.cos(expected_angle/2)]
+                    for i in range(4):
+                        self.assertAlmostEqual(result[i], expected[i], 3)
+                # around z
+                A = [0.0, 0.0, sin_A_half, cos_A_half]
+                B = [0.0, 0.0, sin_B_half, cos_B_half]
                 for c in range(10):
                     t = c / 9
                     result = quaternion.slerp(A, B, t)
@@ -109,8 +138,31 @@ class QuaternionTest(TestCase):
                     expected = [0.0, 0.0, math.sin(expected_angle/2), math.cos(expected_angle/2)]
                     for i in range(4):
                         self.assertAlmostEqual(result[i], expected[i], 3)
+                # around (1/sqrt(3), 1/sqrt(3), 1/sqrt(3))
+                A = [sin_A_half/sqrt_3, sin_A_half/sqrt_3, sin_A_half/sqrt_3, cos_A_half]
+                B = [sin_B_half/sqrt_3, sin_B_half/sqrt_3, sin_B_half/sqrt_3, cos_B_half]
+                for c in range(10):
+                    t = c / 9
+                    result = quaternion.slerp(A, B, t)
+                    expected_angle = (1 - t)*angle_A + t*angle_B
+                    exp_crd = math.sin(expected_angle/2) / sqrt_3
+                    expected = [exp_crd, exp_crd, exp_crd, math.cos(expected_angle/2)]
+                    for i in range(4):
+                        self.assertAlmostEqual(result[i], expected[i], 3)
+                # around (sqrt(1/7), sqrt(2/7), sqrt(4/7))
+                A = [sin_A_half*sqrt_1_7, sin_A_half*sqrt_2_7, sin_A_half*sqrt_4_7, cos_A_half]
+                B = [sin_B_half*sqrt_1_7, sin_B_half*sqrt_2_7, sin_B_half*sqrt_4_7, cos_B_half]
+                for c in range(10):
+                    t = c / 9
+                    result = quaternion.slerp(A, B, t)
+                    expected_angle = (1 - t)*angle_A + t*angle_B
+                    exp_sin = math.sin(expected_angle/2)
+                    exp_cos = math.cos(expected_angle/2)
+                    expected = [exp_sin*sqrt_1_7, exp_sin*sqrt_2_7, exp_sin*sqrt_4_7, exp_cos]
+                    for i in range(4):
+                        self.assertAlmostEqual(result[i], expected[i], 3)
 
-    def test_slerp__totally_random(self):
+    def test_slerp__around_z__totally_random(self):
         for i in range(20):
             t = random.random()
             angle_A = 10*math.pi*(random.random() - 0.5)

--- a/osgar/lib/test_quaternion.py
+++ b/osgar/lib/test_quaternion.py
@@ -1,8 +1,8 @@
 import math
+import random
 from osgar.lib.unittest import TestCase
 
 from . import quaternion
-
 
 class QuaternionTest(TestCase):
 
@@ -80,5 +80,47 @@ class QuaternionTest(TestCase):
         a = [1.7878716536074317e-05, 1.7878705030082886e-05, -1.656903543248786e-12, 0.9999999997613517]
         b = [1.7878712250642573e-05, 1.7878701928288437e-05, 3.354137256707306e-13, 0.9999999997613518]
         quaternion.angle_between(a, b)
+
+    def test_slerp__border_cases(self):
+        A = [random.random() for i in range(4)]
+        B = [random.random() for i in range(4)]
+        norm_A = math.sqrt(sum(value**2 for value in A))
+        norm_B = math.sqrt(sum(value**2 for value in B))
+        for i in range(4):
+            A[i] /= norm_A
+            B[i] /= norm_B
+        C = quaternion.slerp(A, B, 0.0)
+        D = quaternion.slerp(A, B, 1.0)
+        for i in range(4):
+            self.assertAlmostEqual(A[i], C[i], 3)
+            self.assertAlmostEqual(B[i], D[i], 3)
+
+    def test_slerp__various_angles(self):
+        for a in range(40):
+            angle_A = 10*math.pi*(a - 20)/40
+            for b in range(10):
+                angle_B = angle_A + math.pi*(b - 5)/10
+                A = [0.0, 0.0, math.sin(angle_A/2), math.cos(angle_A/2)]
+                B = [0.0, 0.0, math.sin(angle_B/2), math.cos(angle_B/2)]
+                for c in range(10):
+                    t = c / 9
+                    result = quaternion.slerp(A, B, t)
+                    expected_angle = (1 - t)*angle_A + t*angle_B
+                    expected = [0.0, 0.0, math.sin(expected_angle/2), math.cos(expected_angle/2)]
+                    for i in range(4):
+                        self.assertAlmostEqual(result[i], expected[i], 3)
+
+    def test_slerp__totally_random(self):
+        for i in range(20):
+            t = random.random()
+            angle_A = 10*math.pi*(random.random() - 0.5)
+            angle_B = angle_A + math.pi*(random.random() - 0.5)
+            expected_angle = (1 - t)*angle_A + t*angle_B
+            A = [0.0, 0.0, math.sin(angle_A/2), math.cos(angle_A/2)]
+            B = [0.0, 0.0, math.sin(angle_B/2), math.cos(angle_B/2)]
+            expected = [0.0, 0.0, math.sin(expected_angle/2), math.cos(expected_angle/2)]
+            result = quaternion.slerp(A, B, t)
+            for i in range(4):
+                self.assertAlmostEqual(result[i], expected[i], 3)
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
Added function slerp() which interpolates two quaternions utilizing the Spherical Linear intERPolation (SLERP).

This is needed to compute the trajectory of the robot from imprecise data given by GPS, odometry and IMU.
