### PR TITLE
Add optional output log to osgar.replay tool

### DIFF
--- a/osgar/replay.py
+++ b/osgar/replay.py
@@ -7,7 +7,7 @@ import logging
 from ast import literal_eval
 
 from osgar import logger
-from osgar.logger import LogReader
+from osgar.logger import LogReader, LogWriter
 from osgar.lib.config import config_load, get_class_by_name
 from osgar.bus import LogBusHandler, LogBusHandlerInputsOnly
 
@@ -52,7 +52,10 @@ def replay(args, application=None):
     duration = args.duration
     if args.force:
         reader = LogReader(args.logfile, only_stream_id=inputs.keys(), clip_end_time_sec=duration)
-        bus = LogBusHandlerInputsOnly(reader, inputs=inputs)
+        writer=None
+        if args.output is not None:
+            writer = LogWriter(filename=args.output)
+        bus = LogBusHandlerInputsOnly(reader, inputs=inputs, writer=writer, outputs=outputs)
     else:
         streams = list(inputs.keys()) + list(outputs.keys())
         reader = LogReader(args.logfile, only_stream_id=streams, clip_end_time_sec=duration)
@@ -83,6 +86,7 @@ def main():
     parser.add_argument('--draw', help="draw debug results", action='store_true')
     parser.add_argument('--debug', help="print debug info about I/O streams", action='store_true')
     parser.add_argument('--duration', help="limit replay to given time", type=float)
+    parser.add_argument('--output', help="optional output for force replay")
     args = parser.parse_args()
 
     if args.module is None:


### PR DESCRIPTION
OSGAR provides tool `osgar.replay` which primarily verifies that recorded log files is 1:1 with the state on debugging PC. If it perfectly matches then the developer can debug the application and see influence of new changes or simply see verbose output of generated graphs. Once the fix is done the developer can re-run the log file with `--force` flag in order to see potential typos or ensure that the new change really has desired output. But if the output is completely new there is no simple way (actually there is "driver.replay", but ...) to do so.

This PR is rather "draft" at the moment, but the motivation was to fix odometry for Matty, recalculate it and visualize it in lidatview.
![fixed-odom](https://github.com/user-attachments/assets/baef0a7f-84e2-4572-a2f9-feeb837d22aa)

I am aware of missing module prefix so newly generated logfile looked like:
```
(osgar) md@md-ThinkPad-P50:~/git/osgar$ python -m osgar.logger toDel.log 
 k           name bytes | count | freq Hz
-----------------------------------------
 0            sys   365 |    6 |   0.1Hz
 1       esp_data 25128 | 2362 |  19.8Hz
 2 emergency_stop     0 |    0 |   0.0Hz
 3         pose2d 11390 | 1191 |  10.0Hz
 4  bumpers_front     9 |    9 |   0.1Hz
 5   bumpers_rear     1 |    1 |   0.0Hz
 6     gps_serial     0 |    0 |   0.0Hz

Total time 0:01:59.102393
```