### PR TITLE
Fix platform Matty odometry calculation

### DIFF
--- a/osgar/platforms/matty.py
+++ b/osgar/platforms/matty.py
@@ -118,7 +118,7 @@ class Matty(Node):
             # Not needed: heading += angle
         else:
             # Arc
-            radius = (FRONT_REAR_AXIS_DISTANCE/2) / math.tan(joint_angle)
+            radius = (FRONT_REAR_AXIS_DISTANCE/2) / math.tan(joint_angle/2)
             angle = dist / radius
             x += dist * math.cos(heading)
             y += dist * math.sin(heading)

--- a/osgar/platforms/test_matty.py
+++ b/osgar/platforms/test_matty.py
@@ -73,12 +73,12 @@ class MattyTest(unittest.TestCase):
         self.assertAlmostEqual(robot.pose[2], 0.00)
 
         # turn
-        robot.publish_pose2d(0.5, math.radians(45))
+        robot.publish_pose2d(0.5, math.radians(90))
         self.assertAlmostEqual(robot.pose[0], 0.1)  # simplified interpolation
         self.assertAlmostEqual(robot.pose[1], 0.00)
         self.assertAlmostEqual(robot.pose[2], 0.5 * 0.1 / (FRONT_REAR_AXIS_DISTANCE/2))
 
-        robot.publish_pose2d(0.5, math.radians(45))
+        robot.publish_pose2d(0.5, math.radians(90))
         self.assertAlmostEqual(robot.pose[0], 0.14757839740240863)
         self.assertAlmostEqual(robot.pose[1], 0.015371925729019041)
         self.assertAlmostEqual(robot.pose[2], 2 * 0.5 * 0.1 / (FRONT_REAR_AXIS_DISTANCE/2))


### PR DESCRIPTION
Yeah, I should divide the steering angle by 2 ...
... because for 90 deg (not feasible for the robot) it would be radius = 1/2 of the body length (axis to center joint).

The odometry was recalculated with this fix and the result is in #1010 description.