### PR TITLE
lidarview: fix export bundle data

### DIFF
--- a/osgar/tools/lidarview.py
+++ b/osgar/tools/lidarview.py
@@ -641,7 +641,7 @@ def lidarview(gen, caption_filename, callback=False, callback_img=False, out_vid
                     history.prev()
                 if event.key == K_d:  # dump scan
                     print(scan)
-                    np.savez_compressed('depth.npz', depth=g_depth, pose_xyz=pose3d[0], pose_qvat = pose3d[1],
+                    np.savez_compressed('depth.npz', depth=g_depth, pose_xyz=pose3d[0], pose_quat = pose3d[1],
                                         img=pygame_to_numpy_image(image), scan=scan)
                 if event.key == K_p:  # print position
                     print(pose)

--- a/osgar/tools/lidarview.py
+++ b/osgar/tools/lidarview.py
@@ -641,7 +641,8 @@ def lidarview(gen, caption_filename, callback=False, callback_img=False, out_vid
                     history.prev()
                 if event.key == K_d:  # dump scan
                     print(scan)
-                    np.savez_compressed('depth.npz', depth=g_depth, pose3d=pose3d, img=pygame_to_numpy_image(image), scan=scan)
+                    np.savez_compressed('depth.npz', depth=g_depth, pose_xyz=pose3d[0], pose_qvat = pose3d[1],
+                                        img=pygame_to_numpy_image(image), scan=scan)
                 if event.key == K_p:  # print position
                     print(pose)
                     x, y, heading = pose


### PR DESCRIPTION
When the d-key is pressed, the program crashes because `np.savez_compressed` tries to store pose3d as an np.array. A possible solution is to split pose3d into xyz and qvat.