### PR TITLE
Oak color isp, compress on computer

### DIFF
--- a/config/test-oak-isp-color.json
+++ b/config/test-oak-isp-color.json
@@ -1,0 +1,34 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "app": {
+          "driver": "osgar.drivers.oak_camera:OakCamera",
+          "init": {
+            "fps": 10,
+            "is_color": true,
+            "is_depth": true,
+            "laser_projector_current": 1200,
+            "is_imu_enabled": true,
+            "number_imu_records": 10,
+            "disable_magnetometer_fusion": false,
+            "cam_id": "192.168.1.54",
+
+            "mono_resolution": "THE_400_P",
+            "color_resolution": "THE_800_P",
+            "color_isp": false,
+            "color_manual_focus": 130,
+            "color_manual_exposure": null,
+
+            "stereo_median_filter": "KERNEL_3x3",
+            "stereo_mode": "HIGH_ACCURACY",
+            "stereo_extended_disparity": false,
+            "stereo_subpixel": false,
+            "stereo_left_right_check": true,
+            "color_depth_alignment": true
+          }
+      }
+    },
+    "links": []
+  }
+}

--- a/config/test-oak-isp-color.json
+++ b/config/test-oak-isp-color.json
@@ -8,15 +8,11 @@
             "fps": 10,
             "is_color": true,
             "is_depth": true,
-            "laser_projector_current": 1200,
-            "is_imu_enabled": true,
-            "number_imu_records": 10,
-            "disable_magnetometer_fusion": false,
             "cam_id": "192.168.1.54",
 
             "mono_resolution": "THE_400_P",
             "color_resolution": "THE_800_P",
-            "color_isp": false,
+            "color_isp": true,
             "color_manual_focus": 130,
             "color_manual_exposure": null,
 
@@ -24,8 +20,7 @@
             "stereo_mode": "HIGH_ACCURACY",
             "stereo_extended_disparity": false,
             "stereo_subpixel": false,
-            "stereo_left_right_check": true,
-            "color_depth_alignment": true
+            "stereo_left_right_check": true
           }
       }
     },

--- a/config/test-oak-isp-color.json
+++ b/config/test-oak-isp-color.json
@@ -13,6 +13,7 @@
             "mono_resolution": "THE_400_P",
             "color_resolution": "THE_800_P",
             "color_isp": true,
+            "color_isp_scale": [2,3],
             "color_manual_focus": 130,
             "color_manual_exposure": null,
 

--- a/osgar/drivers/oak_camera.py
+++ b/osgar/drivers/oak_camera.py
@@ -374,7 +374,9 @@ class OakCamera:
                         if queue_name == "color":
                             if self.is_isp_color:
                                 cv_frame = packets[-1].getCvFrame()
-                                __, color_frame = cv2.imencode('*.jpeg', cv_frame)
+                                success, encoded_image = cv2.imencode('*.jpeg', cv_frame)
+                                if success:
+                                    color_frame = encoded_image.tobytes()
                             else:
                                 color_frame = packets[-1].getData().tobytes()  # use latest packet
                             self.bus.publish("color_seq", [seq_num, timestamp_us])

--- a/osgar/drivers/oak_camera.py
+++ b/osgar/drivers/oak_camera.py
@@ -74,6 +74,7 @@ class OakCamera:
         self.video_encoder = get_video_encoder(config.get('video_encoder', 'mjpeg'))
         self.video_encoder_h264_bitrate = config.get('h264_bitrate', 0)  # 0 = automatic
         self.is_isp_color = config.get("color_isp", False)
+        self.isp_scale = config.get("color_isp_scale")
         self.is_stereo_images = config.get('is_stereo_images', False)
 
         self.is_imu_enabled = config.get('is_imu_enabled', False)
@@ -226,7 +227,8 @@ class OakCamera:
             color_encoder.setBitrateKbps(self.video_encoder_h264_bitrate)
 
             if self.is_isp_color:
-                #color.setIspScale(1, 3)
+                if self.isp_scale:
+                    color.setIspScale(*self.isp_scale)
                 color.isp.link(color_out.input)
             else:
                 color.video.link(color_encoder.input)


### PR DESCRIPTION
This was a quick attempt at transferring jpeg compressions from the camera to the computer. It uses the isp output from the ColorCamera.