### PR TITLE
Use optional env variable OSGAR_LOGS_PREFIX for generated log filename

### DIFF
--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -44,7 +44,8 @@ g_logger = logging.getLogger(__name__)
 MAGIC = b'Pyr\x00'
 
 INFO_STREAM_ID = 0
-ENV_OSGAR_LOGS = 'OSGAR_LOGS'
+ENV_OSGAR_LOGS = 'OSGAR_LOGS'  # default output folder for log files
+ENV_OSGAR_LOGS_PREFIX = 'OSGAR_LOGS_PREFIX'  # default extra prefix of filename
 
 TIMESTAMP_OVERFLOW_STEP = (1 << 32)  # in microseconds resolution
 TIMESTAMP_MASK = TIMESTAMP_OVERFLOW_STEP - 1
@@ -107,7 +108,8 @@ class LogWriter:
         else:
             self.start_time = start_time
         if filename is None:
-            self.filename = prefix + self.start_time.strftime("%y%m%d_%H%M%S.log")
+            env_prefix = os.environ.get(ENV_OSGAR_LOGS_PREFIX, '')
+            self.filename = env_prefix + prefix + self.start_time.strftime("%y%m%d_%H%M%S.log")
         else:
             self.filename = filename
 

--- a/osgar/test_logger.py
+++ b/osgar/test_logger.py
@@ -43,6 +43,8 @@ class LoggerStreamingTest(unittest.TestCase):
         ref = os.environ.get('OSGAR_LOGS')
         if ref is None:
             os.environ['OSGAR_LOGS'] = "."
+        if os.environ.get('OSGAR_LOGS_PREFIX'):
+            del os.environ['OSGAR_LOGS_PREFIX']
 
     def test_timedelta_sequence(self):
         parse_timedelta = osgar.logger.timedelta_parser()
@@ -197,6 +199,12 @@ class LoggerStreamingTest(unittest.TestCase):
         with self.assertLogs(level=logging.WARNING):
             with LogWriter(prefix='tmp7', note='test_filename_after2') as log:
                 self.assertTrue(Path(log.filename).name.startswith('tmp7'))
+        os.remove(log.filename)
+
+    def test_environ_prefix(self):
+        os.environ['OSGAR_LOGS_PREFIX'] = 'm03-'
+        with LogWriter(prefix='tmp8', note='test env prefix') as log:
+            self.assertTrue(Path(log.filename).name.startswith('m03-tmp8'))
         os.remove(log.filename)
 
     def test_time_overflow(self):


### PR DESCRIPTION
This is support of extra prefix to be used with multiple Matty platforms. They should run from the same config file but it would be very useful to distinguish which one is which one.

Example of test run on local PC:
```
(osgar) md@md-ThinkPad-P50:~/git/osgar$ OSGAR_LOGS_PREFIX='m03-' python -m osgar.record --duration 5 config/test-oak-camera-usb.json --note "kamera chybi, test prefixu"
2025-07-02 05:42:12,483 root             WARNING  Environment variable OSGAR_LOGS is not set - using working directory
2025-07-02 05:42:12,484 __main__         INFO     /home/md/git/osgar/m03-test-oak-camera-usb-250702_034212.log
2025-07-02 05:42:12,592 __main__         INFO     SIGINT handler installed
2025-07-02 05:42:12,593 osgar.drivers.oak_camera INFO     Used the first available device.
```