### PR TITLE
OAK driver - add support for NN processing on night vision

### DIFF
--- a/osgar/drivers/oak_camera.py
+++ b/osgar/drivers/oak_camera.py
@@ -127,7 +127,7 @@ class OakCamera:
 
         self.is_debug_mode = config.get('debug', False)  # run with debug output level
 
-    def config_oak_nn(self, pipeline, camRgb, night=False):
+    def config_oak_nn(self, pipeline, cam, night=False):
         """
         Configure OAK pipeline for processing neural network
         """
@@ -165,14 +165,21 @@ class OakCamera:
 
         nnOut.setStreamName("nn")
 
-        if not night:
+        if night:
+            # for night mono image add extra manipulation node
+            manip = pipeline.create(dai.node.ImageManip)
+            # Set output format to BGR (3 channels)
+            manip.initialConfig.setFrameType(dai.RawImgFrame.Type.BGR888p)
+            manip.initialConfig.setResize(W, H)  # Resize to NN input size
+            cam.preview.link(manip.inputImage)
+        else:
             # Properties - NOTE - overwriting defaults from config!
-            camRgb.setPreviewSize(W, H)
+            cam.setPreviewSize(W, H)
 
-            camRgb.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
-            camRgb.setInterleaved(False)
-            camRgb.setColorOrder(dai.ColorCameraProperties.ColorOrder.BGR)
-            camRgb.setFps(self.fps)
+            cam.setResolution(dai.ColorCameraProperties.SensorResolution.THE_1080_P)
+            cam.setInterleaved(False)
+            cam.setColorOrder(dai.ColorCameraProperties.ColorOrder.BGR)
+            cam.setFps(self.fps)
 
         # Network specific settings
         detectionNetwork.setBlobPath(nnPath)
@@ -188,9 +195,9 @@ class OakCamera:
 
         # Linking
         if night:
-            camRgb.out.link(detectionNetwork.input)
+            manip.out.link(detectionNetwork.input)
         else:
-            camRgb.preview.link(detectionNetwork.input)
+            cam.preview.link(detectionNetwork.input)
         detectionNetwork.out.link(nnOut.input)
 
     def start(self):
@@ -326,13 +333,7 @@ class OakCamera:
                 self.config_oak_nn(pipeline, color)  # note, that "color" is RGB camera
             else:
                 assert self.is_stereo_images, 'If oak.color is not defined then stereo images have to be enabled'
-                manip = pipeline.create(dai.node.ImageManip)
-                # Set output format to BGR (3 channels)
-                manip.initialConfig.setFrameType(dai.RawImgFrame.Type.BGR888p)
-                manip.initialConfig.setResize(640, 352)  # Resize to NN input size
-                left.preview.link(manip.inputImage)
-
-                self.config_oak_nn(pipeline, manip, night=True)
+                self.config_oak_nn(pipeline, left, night=True)  # use left image for detections by default now
             queue_names.append("nn")
 
         if not queue_names:


### PR DESCRIPTION
In particular use LEFT mono camera for object detection. Note, that in the night is oak.color basically unusable and IR is visible only in stereo pair left and right cameras. This code was tested with https://github.com/robotika/osgar-apps/blob/feature/geofence/dtc-systems/config/oak-camera-night.json config.
![saveX-0000](https://github.com/user-attachments/assets/dc6cc1ea-c66e-4e2f-a236-571d8d6ddfad)
