### PR TITLE
Add tool for listing inputs and outputs of OSGAR module

### DIFF
--- a/osgar/tools/get_module_io.py
+++ b/osgar/tools/get_module_io.py
@@ -2,6 +2,7 @@
 Get OSGAR Node module I/O names
 """
 from unittest.mock import MagicMock
+import itertools
 
 from osgar.lib.config import get_class_by_name
 
@@ -17,7 +18,7 @@ def get_module_io(module_name):
     except KeyError:
         pass  # due to missing required config parameters
 
-    outputs = [c.args[0] for c in bus.mock_calls]
+    outputs = list(itertools.chain.from_iterable([c.args for c in bus.mock_calls]))
     return inputs, outputs
 
 

--- a/osgar/tools/get_module_io.py
+++ b/osgar/tools/get_module_io.py
@@ -11,13 +11,23 @@ def get_module_io(module_name):
     inputs = [o[3:] for o in dir(klass) if o.startswith('on_')]
 
     bus = MagicMock()
-    inst = klass(bus=bus, config={})
+    config = MagicMock()
+    try:
+        klass(bus=bus, config={})
+    except KeyError:
+        pass  # due to missing required config parameters
 
     outputs = [c.args[0] for c in bus.mock_calls]
     return inputs, outputs
 
 
 if __name__ == '__main__':
-    import sys
-    name = sys.argv[1]
-    print(name, get_module_io(name))
+    import argparse
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--name', help='name of the Node class like "doctor:Doctor"', required=True)
+    args = parser.parse_args()
+
+    print('Module:', args.name)
+    i,o = get_module_io(args.name)
+    print('Inputs:', i)
+    print('Outputs:', o)

--- a/osgar/tools/get_module_io.py
+++ b/osgar/tools/get_module_io.py
@@ -1,0 +1,23 @@
+"""
+Get OSGAR Node module I/O names
+"""
+from unittest.mock import MagicMock
+
+from osgar.lib.config import get_class_by_name
+
+
+def get_module_io(module_name):
+    klass = get_class_by_name(module_name)
+    inputs = [o[3:] for o in dir(klass) if o.startswith('on_')]
+
+    bus = MagicMock()
+    inst = klass(bus=bus, config={})
+
+    outputs = [c.args[0] for c in bus.mock_calls]
+    return inputs, outputs
+
+
+if __name__ == '__main__':
+    import sys
+    name = sys.argv[1]
+    print(name, get_module_io(name))


### PR DESCRIPTION
This is a simple (i.e. not perfect) tool for listing OSGAR module inputs and outputs:
```
(osgar) md@md-ThinkPad-P50:~/git/osgar-apps/dtc-systems$ python -m osgar.tools.get_module_io doctor:Doctor
doctor:Doctor (['audio', 'h265_video', 'report_latlon', 'scanning_person'], ['report'])

(osgar) md@md-ThinkPad-P50:~/git/osgar-apps/dtc-systems$ python -m osgar.tools.get_module_io osgar.drivers.lora:LoRa
osgar.drivers.lora:LoRa (['artf', 'cmd', 'pose2d', 'pose3d', 'radio', 'raw'], ['raw'])
```