### PR TITLE
Flush properly log file on Ctrl+C termination

### DIFF
--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -146,8 +146,10 @@ class LogWriter:
         return dt
 
     def close(self):
-        self.f.close()
-        self.f = None
+        if self.f is not None:
+            # allow closing multiple times (standard run or suicidal termination)
+            self.f.close()
+            self.f = None
 
 
     # context manager functions

--- a/osgar/record.py
+++ b/osgar/record.py
@@ -48,6 +48,7 @@ class Recorder:
                 g_logger.error(f'thread {repr(t.name)} still running!')
                 g_logger.error(f'    class: {t.__class__.__module__}.{t.__class__.__name__}')
                 g_logger.error(f'    target: {t._target}')
+        self.bus.logger.close()  # save not flushed data
         if self.sigint_received:
             g_logger.info("committing suicide by SIGINT")
             signal.signal(signal.SIGINT, signal.SIG_DFL)


### PR DESCRIPTION
This bug made me crazy for "years" :( ... if you kill some recording with Ctrl+C where there are not many data typically everything was lost (only 16 bytes header was available). This solves the problem (tested with LoRa base-station logger).