### PR TITLE
Support environment variables in config

### DIFF
--- a/osgar/replay.py
+++ b/osgar/replay.py
@@ -64,8 +64,11 @@ def replay(args, application=None):
 
     driver_name = module_config['driver']
     module_class = get_class_by_name(driver_name)
-    module_instance = module_class(module_config.get('init', {}), bus=bus)
-
+    module_config_init = module_config.get('init', {})
+    env = config['robot'].get('env')
+    if env is not None:
+        module_config_init['env'] = env
+    module_instance = module_class(module_config_init, bus=bus)
     bus.node = module_instance # needed for slots
     return module_instance
 

--- a/osgar/test_record.py
+++ b/osgar/test_record.py
@@ -159,7 +159,7 @@ class RecorderTest(unittest.TestCase):
             'version': 2,
             'robot': {
                 'env': {
-                    'OSGAR_LOG_PREFIX': None
+                    'OSGAR_LOGS_PREFIX': None
                 },
                 'modules': {
                     "app": {

--- a/osgar/test_record.py
+++ b/osgar/test_record.py
@@ -9,12 +9,15 @@ import subprocess
 import tempfile
 import sys
 
-from osgar.record import Recorder
+from osgar.record import Recorder, record
 
 
 class Sleeper:
 
     def __init__(self, cfg, bus):
+        # dedicated part for test of environment variables
+        if cfg.get('assert_env'):
+            assert 'env' in cfg, cfg
         self.e = threading.Event()
 
     def start(self):
@@ -131,6 +134,48 @@ class RecorderTest(unittest.TestCase):
                 self.assertEqual(len(stdout), 0, stdout)
                 self.assertEqual(len(stderr.splitlines()), 1, stderr)
             os.unlink(log_filename)
+
+    def test_config_env(self):
+        config = {
+            'version': 2,
+            'robot': {
+                'env': {
+                    'OSGAR_LOG_PREFIX': None
+                },
+                'modules': {
+                    "app": {
+                        "driver": "osgar.test_record:Sleeper",
+                        "init": {
+                            'assert_env': True
+                        }
+                    },
+                }, 'links':[]
+            }
+        }
+        record(config, 'log-env-', duration_sec=0.1)
+
+    def test_config_env_assert(self):
+        config = {
+            'version': 2,
+            'robot': {
+                'env': {
+                    'OSGAR_LOG_PREFIX': None
+                },
+                'modules': {
+                    "app": {
+                        "driver": "osgar.test_record:Sleeper",
+                        "init": {
+                            'assert_env': True,
+                            'env': 'This will collide -> intentionally assert'
+                        }
+                    },
+                }, 'links':[]
+            }
+        }
+        with self.assertRaises(AssertionError) as err:
+            record(config, 'log-env2-', duration_sec=0.1)
+        self.assertEqual(str(err.exception),
+                         "{'assert_env': True, 'env': 'This will collide -> intentionally assert'}")
 
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
The motivation is 5 robots which should behave differently in particular situations. There is already `OSGAR_LOGS_PREFIX` to distinguish origin of the logfile, so this is step further, that the robots can use this info and behave differently base on this info. OTOH we still want to keep the replay capability and this saving this environment info into config.

Example of new config (automatically filled):
```
0:00:00.000459 0 b"{'version': 2, 'robot': {'env': {'OSGAR_LOGS_PREFIX': 'm05-'}, 'modules': {'app': {'driver': 'dtc:DARPATriageChallenge', 'in': ['emergency_stop', 'pose2d',
```