### PR TITLE
OAK camera - add config param to sleep on start

### DIFF
--- a/osgar/drivers/oak_camera.py
+++ b/osgar/drivers/oak_camera.py
@@ -204,7 +204,9 @@ class OakCamera:
 
     def start(self):
         if self.sleep_on_start_sec is not None:
+            print(f'sleeping for {self.sleep_on_start_sec}s')
             self.bus.sleep(self.sleep_on_start_sec)
+            print(f'END of sleep, starting ...')
         self.input_thread.start()
 
     def join(self, timeout=None):

--- a/osgar/drivers/oak_camera.py
+++ b/osgar/drivers/oak_camera.py
@@ -126,6 +126,8 @@ class OakCamera:
         self.labels = config.get("mappings", {}).get("labels", [])
 
         self.is_debug_mode = config.get('debug', False)  # run with debug output level
+        self.sleep_on_start_sec = config.get('sleep_on_start_sec')
+        self.verbose_detections = config.get('verbose_detections', True)
 
     def config_oak_nn(self, pipeline, cam, night=False):
         """
@@ -201,6 +203,8 @@ class OakCamera:
         detectionNetwork.out.link(nnOut.input)
 
     def start(self):
+        if self.sleep_on_start_sec is not None:
+            self.bus.sleep(self.sleep_on_start_sec)
         self.input_thread.start()
 
     def join(self, timeout=None):
@@ -414,7 +418,8 @@ class OakCamera:
                                 bbox_list = []
                                 for detection in detections:
                                     bbox = (detection.xmin, detection.ymin, detection.xmax, detection.ymax)
-                                    print(self.labels[detection.label], detection.confidence, bbox)
+                                    if self.verbose_detections:
+                                        print(self.labels[detection.label], detection.confidence, bbox)
                                     bbox_list.append([self.labels[detection.label], detection.confidence, list(bbox)])
                                 self.bus.publish("detections_seq", [seq_num, timestamp_us])
                                 self.bus.publish('detections', bbox_list)


### PR DESCRIPTION
... and reduce verbosity of detections. I am not sure if Jirka was right, but the test I did tonight both with 10s and 5s delay worked ... could be coincidence, but let's have there this possibility to set it.