### PR TITLE
osgar.replay - optionally ignore selected stream for output assert

### DIFF
--- a/osgar/bus.py
+++ b/osgar/bus.py
@@ -145,10 +145,11 @@ class _BusHandler:
 
 
 class LogBusHandler:
-    def __init__(self, log, inputs, outputs):
+    def __init__(self, log, inputs, outputs, ignore_streams=None):
         self.reader = log
         self.inputs = inputs
         self.outputs = outputs
+        self.ignore_streams = ignore_streams
         self.buffer_queue = deque()
         self.max_delay = timedelta()
         self.max_delay_timestamp = timedelta()
@@ -204,7 +205,8 @@ class LogBusHandler:
             if delay > ASSERT_QUEUE_DELAY:
                 print(dt, "maximum delay overshot:", delay)
         ref_data = deserialize(bytes_data)
-        assert almost_equal(data, ref_data), (data, ref_data, dt)
+        if self.ignore_streams is None or channel not in self.ignore_streams:
+            assert almost_equal(data, ref_data), (data, ref_data, dt)
         return dt
 
     def sleep(self, secs):

--- a/osgar/replay.py
+++ b/osgar/replay.py
@@ -60,7 +60,7 @@ def replay(args, application=None):
     else:
         streams = list(inputs.keys()) + list(outputs.keys())
         reader = LogReader(args.logfile, only_stream_id=streams, clip_end_time_sec=duration)
-        bus = LogBusHandler(reader, inputs, outputs)
+        bus = LogBusHandler(reader, inputs, outputs, ignore_streams=args.ignore)
 
     driver_name = module_config['driver']
     module_class = get_class_by_name(driver_name)
@@ -91,6 +91,7 @@ def main():
     parser.add_argument('--debug', help="print debug info about I/O streams", action='store_true')
     parser.add_argument('--duration', help="limit replay to given time", type=float)
     parser.add_argument('--output', help="optional output for force replay")
+    parser.add_argument('--ignore', nargs='+', help="do not assert particular stream(s) output")
     args = parser.parse_args()
 
     if args.module is None:


### PR DESCRIPTION
Some processing depends on the system where the program runs and it is just debug info. An example is profiling output of external doctor in DTC:
```
python -m osgar.replay --module doctor m05-dtc-day-251002_211012.log -v --ignore doctor.debug_profile
```