### PR TITLE
ouster sdk driver

### DIFF
--- a/config/test-ouster-lidar.json
+++ b/config/test-ouster-lidar.json
@@ -1,0 +1,14 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "app": {
+          "driver": "osgar.drivers.ouster_lidar:OusterLidar",
+          "init": {
+            "lidar_ip": "192.168.1.93"
+          }
+      }
+    },
+    "links": []
+  }
+}

--- a/config/test-ouster-lidar.json
+++ b/config/test-ouster-lidar.json
@@ -5,7 +5,9 @@
       "app": {
           "driver": "osgar.drivers.ouster_lidar:OusterLidar",
           "init": {
-            "lidar_ip": "192.168.1.93"
+            "lidar_ip": "192.168.1.92",
+            "lidar_mode": "MODE_512x10",
+            "azimuth_window": null
           }
       }
     },

--- a/osgar/drivers/ouster_lidar.py
+++ b/osgar/drivers/ouster_lidar.py
@@ -6,7 +6,7 @@ import json
 from threading import Thread
 import logging
 
-from ouster.sdk import open_source, core
+from ouster.sdk import open_source, core, sensor
 from ouster.sdk.sensor import ClientTimeout
 
 from osgar.node import Node
@@ -60,6 +60,10 @@ class OusterLidar:
         self.bus = bus
         self.bus.register("metadata", "scan3d", "reflectivity")
         self.lidar_ip = config["lidar_ip"]
+        lidar_mode = config.get("lidar_mode", "MODE_1024x10")
+        assert lidar_mode in ["MODE_512x10", "MODE_1024x10", "MODE_2048x10", "MODE_512x20", "MODE_1024x20"], lidar_mode
+        self.lidar_mode = getattr(core.LidarMode, lidar_mode)
+        self.azimut_win = config.get("azimuth_window", [0, 360_000])
 
     def start(self):
         self.input_thread.start()
@@ -68,12 +72,22 @@ class OusterLidar:
         self.input_thread.join(timeout=timeout)
 
     def run_input(self):
+        # If we change the parameters, the configuration will take about 10 seconds.
+        config = core.SensorConfig()
+        config.lidar_mode = self.lidar_mode
+        config.azimuth_window = self.azimut_win
+
+        try:
+            sensor.set_config(self.lidar_ip, config, persist=False, udp_dest_auto=True)
+        except Exception as e:
+            logging.error(f"Configuration failed: {e}")
+            return
+
         source = open_source(self.lidar_ip, sensor_idx=0, collate=False)
         info = source.sensor_info[0]
-        print(info)  # TODO
+        self.bus.publish("metadata", info.to_json_string())
 
         scan_iterator = iter(source)
-
         while self.bus.is_alive():
             try:
                 scan_set = next(scan_iterator)
@@ -83,9 +97,9 @@ class OusterLidar:
                     if not scan.complete(info.format.column_window):
                         logging.warning(f"Scan is incompleted!")
                     range_data = scan.field(core.ChanField.RANGE)
-                    self.bus.publish("scan3d", range_data)
+                    self.bus.publish("scan3d", range_data.copy())
                     reflectivity_data = scan.field(core.ChanField.REFLECTIVITY)
-                    self.bus.publish("reflectivity", reflectivity_data)
+                    self.bus.publish("reflectivity", reflectivity_data.copy())
 
             except StopIteration:
                 # Log reading completed

--- a/osgar/drivers/ouster_lidar.py
+++ b/osgar/drivers/ouster_lidar.py
@@ -5,9 +5,13 @@
 import json
 from threading import Thread
 import logging
+g_logger = logging.getLogger(__name__)
 
-from ouster.sdk import open_source, core, sensor
-from ouster.sdk.sensor import ClientTimeout
+try:
+    from ouster.sdk import open_source, core, sensor
+    from ouster.sdk.sensor import ClientTimeout
+except ImportError as e:
+    logging.warning(f"Ouster lidar drivers not installed: {e}")
 
 from osgar.node import Node
 
@@ -112,7 +116,6 @@ class OusterLidar:
             except Exception as e:
                 logging.error(f"Unexpected error: {e}")
                 break
-
 
     def request_stop(self):
         self.bus.shutdown()

--- a/osgar/drivers/ouster_lidar.py
+++ b/osgar/drivers/ouster_lidar.py
@@ -67,7 +67,9 @@ class OusterLidar:
         lidar_mode = config.get("lidar_mode", "MODE_1024x10")
         assert lidar_mode in ["MODE_512x10", "MODE_1024x10", "MODE_2048x10", "MODE_512x20", "MODE_1024x20"], lidar_mode
         self.lidar_mode = getattr(core.LidarMode, lidar_mode)
-        self.azimut_win = config.get("azimuth_window", [0, 360_000])
+        # Azimuth_window: it allows to set the window in the horizontal FOV (mdeg).
+        # The origin is at the back of the lidar and continues clockwise.
+        self.azimuth_window = config.get("azimuth_window", [0, 360_000])
 
     def start(self):
         self.input_thread.start()
@@ -79,7 +81,7 @@ class OusterLidar:
         # If we change the parameters, the configuration will take about 10 seconds.
         config = core.SensorConfig()
         config.lidar_mode = self.lidar_mode
-        config.azimuth_window = self.azimut_win
+        config.azimuth_window = self.azimuth_window
 
         try:
             sensor.set_config(self.lidar_ip, config, persist=False, udp_dest_auto=True)

--- a/osgar/drivers/ouster_lidar.py
+++ b/osgar/drivers/ouster_lidar.py
@@ -11,7 +11,7 @@ try:
     from ouster.sdk import open_source, core, sensor
     from ouster.sdk.sensor import ClientTimeout
 except ImportError as e:
-    logging.warning(f"Ouster lidar drivers not installed: {e}")
+    g_logger.warning(f"Ouster lidar drivers not installed: {e}")
 
 from osgar.node import Node
 
@@ -84,7 +84,7 @@ class OusterLidar:
         try:
             sensor.set_config(self.lidar_ip, config, persist=False, udp_dest_auto=True)
         except Exception as e:
-            logging.error(f"Configuration failed: {e}")
+            g_logger.error(f"Configuration failed: {e}")
             return
 
         source = open_source(self.lidar_ip, sensor_idx=0, collate=False)
@@ -99,7 +99,7 @@ class OusterLidar:
 
                 if scan is not None:
                     if not scan.complete(info.format.column_window):
-                        logging.warning(f"Scan is incompleted!")
+                        g_logger.warning(f"Scan is incompleted!")
                     range_data = scan.field(core.ChanField.RANGE)
                     self.bus.publish("scan3d", range_data.copy())
                     reflectivity_data = scan.field(core.ChanField.REFLECTIVITY)
@@ -110,11 +110,11 @@ class OusterLidar:
                 break
 
             except ClientTimeout as e:
-                logging.error(f"Timeout, NO DATA: {e}")
+                g_logger.error(f"Timeout, NO DATA: {e}")
                 continue
 
             except Exception as e:
-                logging.error(f"Unexpected error: {e}")
+                g_logger.error(f"Unexpected error: {e}")
                 break
 
     def request_stop(self):

--- a/osgar/drivers/ouster_lidar.py
+++ b/osgar/drivers/ouster_lidar.py
@@ -3,6 +3,11 @@
 """
 
 import json
+from threading import Thread
+import logging
+
+from ouster.sdk import open_source, core
+from ouster.sdk.sensor import ClientTimeout
 
 from osgar.node import Node
 
@@ -47,3 +52,53 @@ class OusterLidarUDP(Node):
             print(data)
         self.publish("lidar_config", data)
         self.configuration_saved = True
+
+
+class OusterLidar:
+    def __init__(self, config, bus):
+        self.input_thread = Thread(target=self.run_input, daemon=True)
+        self.bus = bus
+        self.bus.register("metadata", "scan3d", "reflectivity")
+        self.lidar_ip = config["lidar_ip"]
+
+    def start(self):
+        self.input_thread.start()
+
+    def join(self, timeout=None):
+        self.input_thread.join(timeout=timeout)
+
+    def run_input(self):
+        source = open_source(self.lidar_ip, sensor_idx=0, collate=False)
+        info = source.sensor_info[0]
+        print(info)  # TODO
+
+        scan_iterator = iter(source)
+
+        while self.bus.is_alive():
+            try:
+                scan_set = next(scan_iterator)
+                scan = scan_set[0]
+
+                if scan is not None:
+                    if not scan.complete(info.format.column_window):
+                        logging.warning(f"Scan is incompleted!")
+                    range_data = scan.field(core.ChanField.RANGE)
+                    self.bus.publish("scan3d", range_data)
+                    reflectivity_data = scan.field(core.ChanField.REFLECTIVITY)
+                    self.bus.publish("reflectivity", reflectivity_data)
+
+            except StopIteration:
+                # Log reading completed
+                break
+
+            except ClientTimeout as e:
+                logging.error(f"Timeout, NO DATA: {e}")
+                continue
+
+            except Exception as e:
+                logging.error(f"Unexpected error: {e}")
+                break
+
+
+    def request_stop(self):
+        self.bus.shutdown()

--- a/osgar/tools/scan3d_view.py
+++ b/osgar/tools/scan3d_view.py
@@ -1,0 +1,75 @@
+"""Simple viewer for OSGAR 3D scans"""
+import matplotlib.pyplot as plt
+import matplotlib.animation as animation
+from osgar.logger import LogReader, lookup_stream_id
+from osgar.lib.serialize import deserialize
+
+
+def load_scans_from_log(log_filename, stream_name):
+    """
+    Loads a 2D array of scans from an OSGAR log.
+    """
+    try:
+        # Get the internal stream ID based on its name
+        stream_id = lookup_stream_id(log_filename, stream_name)
+    except Exception as e:
+        print(f"Error: Stream '{stream_name}' not found in the log. ({e})")
+        return []
+
+    scans = []
+    # Read the log filtering only the requested stream
+    with LogReader(log_filename, only_stream_id=stream_id) as log:
+        for dt, channel, data in log:
+            # Deserialize binary data back to the original Python/NumPy object
+            scan = deserialize(data)
+            scans.append([dt,scan])
+
+    print(f"Successfully loaded {len(scans)} scans.")
+    return scans
+
+
+def animate_scans(scans, stream, vmax, interval_ms = 20):
+    """
+    Renders a sequence of 2D arrays as an animation.
+    """
+    if not scans:
+        print("The scan list is empty, nothing to animate.")
+        return
+
+    fig, ax = plt.subplots(figsize=(12, 5))
+
+    # Initialize the first frame.
+    # Note: vmin and vmax set the colormap range. If the data is in millimeters,
+    if "reflectivity" in stream:
+        vmax = 255
+    im = ax.imshow(scans[0][1], cmap='viridis', aspect='auto', vmin=0, vmax=vmax)
+
+    fig.colorbar(im, ax=ax, label='Measured value (e.g., mm)')
+    ax.set_title("OSGAR Log Playback: 3D Scan")
+    ax.set_xlabel("Columns (Azimuth)")
+    ax.set_ylabel("Rows (Lasers)")
+
+    def update(frame_index):
+        im.set_array(scans[frame_index][1])
+        ax.set_title(f"OSGAR Log Playback: 3D Scan ({scans[frame_index][0]})")
+        return [im]
+
+    # Create the animation loop
+    ani = animation.FuncAnimation(
+        fig, update, frames=len(scans), interval=interval_ms, blit=False
+    )
+
+    plt.show()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('logfile', help='recorded log file')
+    parser.add_argument('--stream', help='stream name', default='app.scan3d')
+    parser.add_argument('--vmax', help='Range limit in mm', default=10_000)
+    args = parser.parse_args()
+
+    loaded_scans = load_scans_from_log(args.logfile, args.stream)
+    animate_scans(loaded_scans, args.stream, args.vmax, interval_ms=50)


### PR DESCRIPTION
Here is the second Ouster lidar driver, this time using the Ouster SDK and the `open_source` method.
It only supports basic distance and reflectivity readings.
The testing is still continuing, but the code should be almost completed.
There is also simple 3d scan viewer (matplotlib).