### PR TITLE
Consolidate EmergencyStopException into osgar.exceptions

### DIFF
--- a/examples/sick2018/sick2018.py
+++ b/examples/sick2018/sick2018.py
@@ -25,13 +25,12 @@ from datetime import timedelta
 from osgar.lib.config import config_load
 from osgar.lib.mathex import normalizeAnglePIPI
 from osgar.record import record
+from osgar.exceptions import EmergencyStopException
 
 from .scan_feature import detect_box, detect_transporter
 
 
 # TODO shared place for multiple applications
-class EmergencyStopException(Exception):
-    pass
 
 
 def min_dist(laser_data):

--- a/osgar/exceptions.py
+++ b/osgar/exceptions.py
@@ -1,0 +1,7 @@
+"""
+    OSGAR Exceptions
+    ~~~~~~~~~~~~~~~~
+"""
+
+class EmergencyStopException(Exception):
+    pass

--- a/osgar/followme.py
+++ b/osgar/followme.py
@@ -10,9 +10,10 @@ from osgar.node import Node
 # Expects SICK laser scan with 270 degrees field of view mounted in front.
 
 
+from osgar.exceptions import EmergencyStopException
+
+
 # TODO shared place for multiple applications
-class EmergencyStopException(Exception):
-    pass
 
 
 def min_dist(laser_data):

--- a/osgar/followme_uwb.py
+++ b/osgar/followme_uwb.py
@@ -6,7 +6,8 @@ from datetime import timedelta
 from statistics import median
 
 from osgar.node import Node
-from osgar.followme import EmergencyStopException, min_dist
+from osgar.exceptions import EmergencyStopException
+from osgar.followme import min_dist
 
 # Notes:
 # Expects 3 anchors mounted on Eduro robot

--- a/osgar/followpath.py
+++ b/osgar/followpath.py
@@ -8,7 +8,7 @@ from osgar.lib.line import Line
 from osgar.lib.mathex import normalizeAnglePIPI
 from osgar.node import Node
 from osgar.bus import BusShutdownException
-from osgar.followme import EmergencyStopException
+from osgar.exceptions import EmergencyStopException
 
 
 class Route(GPSRoute):

--- a/osgar/gpsnav.py
+++ b/osgar/gpsnav.py
@@ -9,6 +9,7 @@ from datetime import timedelta
 from osgar.lib.mathex import normalizeAnglePIPI
 from osgar.node import Node
 from osgar.drivers.gps import INVALID_COORDINATES
+from osgar.exceptions import EmergencyStopException
 
 
 def geo_length(pos1, pos2):
@@ -27,10 +28,6 @@ def geo_angle(pos1, pos2):
 
 def latlon2xy(lat, lon):
     return int(round(lon*3600000)), int(round(lat*3600000))
-
-
-class EmergencyStopException(Exception):
-    pass
 
 
 class EmergencyStopMonitor:

--- a/osgar/ro2018.py
+++ b/osgar/ro2018.py
@@ -13,6 +13,7 @@ from osgar.lib.mathex import normalizeAnglePIPI
 from osgar.record import record
 
 from osgar.drivers.gps import INVALID_COORDINATES
+from osgar.exceptions import EmergencyStopException
 
 
 def geo_length(pos1, pos2):
@@ -31,9 +32,6 @@ def geo_angle(pos1, pos2):
 
 def latlon2xy(lat, lon):
     return int(round(lon*3600000)), int(round(lat*3600000))
-
-class EmergencyStopException(Exception):
-    pass
 
 class EmergencyStopMonitor:
     def __init__(self, robot):

--- a/osgar/terminator.py
+++ b/osgar/terminator.py
@@ -2,7 +2,7 @@
   Universal Terminator - minimal logging and wait for end of STOP
 """
 from osgar.node import Node
-from osgar.followme import EmergencyStopException
+from osgar.exceptions import EmergencyStopException
 
 
 class Terminator(Node):

--- a/osgar/test_followme.py
+++ b/osgar/test_followme.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import MagicMock
 
-from osgar.followme import FollowMe, EmergencyStopException
+from osgar.followme import FollowMe
+from osgar.exceptions import EmergencyStopException
 from osgar.bus import Bus
 
 

--- a/osgar/test_followpath.py
+++ b/osgar/test_followpath.py
@@ -1,7 +1,8 @@
 import unittest
 from unittest.mock import MagicMock
 
-from osgar.followpath import FollowPath, EmergencyStopException
+from osgar.followpath import FollowPath
+from osgar.exceptions import EmergencyStopException
 from osgar.bus import Bus
 
 

--- a/osgar/test_ro2018.py
+++ b/osgar/test_ro2018.py
@@ -3,7 +3,8 @@ from unittest.mock import MagicMock
 import math
 
 from osgar.ro2018 import (geo_length, geo_angle,
-                          latlon2xy, EmergencyStopMonitor, EmergencyStopException)
+                          latlon2xy, EmergencyStopMonitor)
+from osgar.exceptions import EmergencyStopException
 
 
 class RO2018Test(unittest.TestCase):

--- a/osgar/test_terminator.py
+++ b/osgar/test_terminator.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import MagicMock
 
 from osgar.terminator import Terminator
-from osgar.followme import EmergencyStopException
+from osgar.exceptions import EmergencyStopException
 
 class TerminatorTest(unittest.TestCase):
 

--- a/subt/main.py
+++ b/subt/main.py
@@ -62,8 +62,7 @@ class Collision(Exception):
     pass
 
 
-class EmergencyStopException(Exception):
-    pass
+from osgar.exceptions import EmergencyStopException
 
 
 class NewWaypointsException(Exception):


### PR DESCRIPTION
- Create a new `osgar/exceptions.py` file for shared OSGAR exceptions.
- Move `EmergencyStopException` from `osgar.followme` and various local definitions to the centralized `osgar.exceptions` module.
- Update core library, applications (SubT), and examples to use the centralized exception.
- Remove redundant duplicate definitions of `EmergencyStopException`.