### PR TITLE
oak_camera_v3: support IMU orientation output

### DIFF
--- a/osgar/drivers/oak_camera_v3.py
+++ b/osgar/drivers/oak_camera_v3.py
@@ -127,6 +127,9 @@ class OakCamera:
         self.color_depth_alignment = config.get("color_depth_alignment", False)
 
         self.is_imu_enabled = config.get('is_imu_enabled', False)
+        # Preferred number of IMU records in one packet
+        self.number_imu_records = config.get('number_imu_records', 20)
+        self.disable_magnetometer_fusion = config.get('disable_magnetometer_fusion', False)
         self.is_visual_odom = config.get('is_visual_odom', False)
         self.is_slam = config.get('is_slam', False)
         if self.is_slam:
@@ -255,14 +258,22 @@ class OakCamera:
 
                 if self.is_visual_odom:
                     odom = pipeline.create(dai.node.BasaltVIO)
-
-                imu.enableIMUSensor([dai.IMUSensor.ACCELEROMETER_RAW, dai.IMUSensor.GYROSCOPE_RAW], 200)
-                imu.setBatchReportThreshold(1)
-                imu.setMaxBatchReports(10)
+                    imu.enableIMUSensor([dai.IMUSensor.ACCELEROMETER_RAW, dai.IMUSensor.GYROSCOPE_RAW], 200)
+                    imu.setBatchReportThreshold(1)
+                    imu.setMaxBatchReports(10)
+                else:
+                    if self.disable_magnetometer_fusion:
+                        imu.enableIMUSensor(dai.IMUSensor.GAME_ROTATION_VECTOR, 100)  # without magnetometer
+                    else:
+                        imu.enableIMUSensor(dai.IMUSensor.ROTATION_VECTOR, 100)
+                    imu.setBatchReportThreshold(self.number_imu_records)
+                    imu.setMaxBatchReports(20)
 
             if self.is_visual_odom:
                 imu.out.link(odom.imu)
                 odom_queue = odom.transform.createOutputQueue(blocking=False)
+            elif self.is_imu_enabled:
+                imu_queue = imu.out.createOutputQueue(blocking=False)
 
             if self.is_slam:
                 slam = pipeline.create(dai.node.RTABMapSLAM)
@@ -446,6 +457,19 @@ class OakCamera:
                         processed_any = True
                         gridmap = gridmaps[-1]
                         self.bus.publish('gridmap', gridmap.getFrame())
+
+                # 5. Check IMU
+                if self.is_imu_enabled and not self.is_visual_odom:
+                    imu_packets = imu_queue.tryGetAll()
+                    if imu_packets and len(imu_packets) > 0:
+                        processed_any = True
+                        for packet in imu_packets:
+                            quaternions = [[data.rotationVector.getTimestampDevice().total_seconds(),
+                                            data.rotationVector.rotationVectorAccuracy,
+                                            data.rotationVector.i, data.rotationVector.j,
+                                            data.rotationVector.k, data.rotationVector.real]
+                                           for data in packet.packets]
+                            self.bus.publish("orientation_list", quaternions)
 
                 # Only rest the CPU if no frames were pulled in this tick loop
                 if not processed_any:

--- a/osgar/drivers/test_oak_camera.py
+++ b/osgar/drivers/test_oak_camera.py
@@ -7,6 +7,7 @@ dai_mock = MagicMock()
 dai_mock.__version__ = '2.29.0.0'  # fake older version
 with patch.dict('sys.modules', {'depthai': dai_mock}):
     from osgar.drivers.oak_camera import OakCamera
+    from osgar.drivers.oak_camera_v3 import OakCamera as OakCameraV3
 
 class OakCameraTest(unittest.TestCase):
 
@@ -14,15 +15,38 @@ class OakCameraTest(unittest.TestCase):
         config = {}
         handler = MagicMock()
         cam = OakCamera(config, bus=handler)
+        cam3 = OakCameraV3(config, bus=handler)
 
     def test_nn_image_size(self):
         config = {
+            'model': 'dummy_path',
             'nn_config': {
                 'input_size': '160x120'
             }
         }
         handler = MagicMock()
         cam = OakCamera(config, bus=handler)
-        self.assertEqual(cam.oak_config_nn_image_size, (160, 120))
+        if hasattr(cam, 'models'):
+            self.assertEqual(cam.models[0]['nn_config']['input_size'], '160x120')
+        else:
+            self.assertEqual(cam.oak_config_nn_image_size, (160, 120))
+            
+        cam3 = OakCameraV3(config, bus=handler)
+        self.assertEqual(cam3.models[0]['nn_config']['input_size'], '160x120')
+
+    def test_imu_records(self):
+        config = {
+            'is_imu_enabled': True,
+            'number_imu_records': 15,
+            'disable_magnetometer_fusion': True
+        }
+        handler = MagicMock()
+        cam = OakCamera(config, bus=handler)
+        self.assertEqual(cam.number_imu_records, 15)
+        self.assertEqual(cam.disable_magnetometer_fusion, True)
+
+        cam3 = OakCameraV3(config, bus=handler)
+        self.assertEqual(cam3.number_imu_records, 15)
+        self.assertEqual(cam3.disable_magnetometer_fusion, True)
 
 # vim: expandtab sw=4 ts=4


### PR DESCRIPTION
- Add parsing for `number_imu_records` and `disable_magnetometer_fusion` configurations.
- Configure IMU node with appropriate rotation vector sensors based on configuration when visual odometry is disabled.
- Implement polling of the asynchronous IMU output queue and publish formatted `orientation_list` stream to maintain parity with v2.
- Update `test_oak_camera.py` to evaluate configuration parsing for both v2 and v3 components.

----------
@tajgr - This is the first attempt - I am going to test it a bit more, but I wanted to open PR just to avoid potential collisions in IMU integration into depthai version 3. Also if you have some methods how to test it let me know. (I have one idea, which I will persuate in separate branch, but it could be delayed ... as other priorities are popping up