### PR TITLE
Move self.verbose to common Node

### DIFF
--- a/doc/sphinx/tutorial.rst
+++ b/doc/sphinx/tutorial.rst
@@ -105,7 +105,6 @@ Here is the code for ``myapp.py``:
           bus.register('desired_speed')
           self.max_speed = config.get('max_speed', 0.1)
           self.max_angular_speed = math.radians(50)  # TODO config
-          self.verbose = False
           self.last_position = (0, 0, 0)
           self.is_moving = False
           self.pose2d = None  # TODO should be defined by super().__init__()

--- a/examples/demo/demo.py
+++ b/examples/demo/demo.py
@@ -17,7 +17,6 @@ class MyApp(Node):
         bus.register('desired_speed')
         self.max_speed = config.get('max_speed', 0.1)
         self.max_angular_speed = math.radians(50)  # TODO config
-        self.verbose = False
         self.last_position = (0, 0, 0)
         self.is_moving = False
         self.pose2d = None  # TODO should be defined by super().__init__()

--- a/examples/demo/spider_demo.py
+++ b/examples/demo/spider_demo.py
@@ -21,7 +21,6 @@ class MyApp(Node):
         bus.register('desired_speed')
         self.max_speed = config.get('max_speed', 0.1)
         self.max_angular_speed = math.radians(50)  # TODO config
-        self.verbose = False
         self.last_position = (0, 0, 0)
         self.is_moving = False
         self.pose2d = None  # TODO should be defined by super().__init__()

--- a/examples/gym/my_race.py
+++ b/examples/gym/my_race.py
@@ -17,7 +17,6 @@ class MyRace(Node):
         self.max_speed = config.get("max_speed", 0.8)
         use_local_planner = config.get("local_planner", False)
         self.scan = None
-        self.verbose = False
         if use_local_planner:
             self.local_planner = LocalPlanner(
                 direction_adherence=math.radians(45),

--- a/osgar/drivers/lord_imu.py
+++ b/osgar/drivers/lord_imu.py
@@ -154,7 +154,6 @@ class LordIMU(Node):
         bus.register('orientation', 'rotation', 'gps_position')
         self._buf = b''
         self.raw = None  # not automatically defined yet
-        self.verbose = False
 
     def on_raw(self, data):
         self.raw = data

--- a/osgar/drivers/ouster_lidar.py
+++ b/osgar/drivers/ouster_lidar.py
@@ -25,7 +25,6 @@ class OusterLidarUDP(Node):
         self.headers = {'Accept': 'application/json', 'Content-Type': 'application/json'}
         self.configuration_done = False
         self.configuration_saved = False
-        self.verbose = False
 
     def send_conf_params(self):
         data = json.dumps(self.config_params).encode('utf-8')

--- a/osgar/drivers/pozyx.py
+++ b/osgar/drivers/pozyx.py
@@ -23,7 +23,6 @@ class Pozyx(Node):
         self.devices.append(None)  # extra range to the base (must be last, 2nd param)
         self.pozyx = pypozyx.PozyxSerial(serial_port)
         self.my_id = None  # unknown
-        self.verbose = False
 
     def get_settings(self):
         settings = pypozyx.UWBSettings()

--- a/osgar/drivers/qorvo.py
+++ b/osgar/drivers/qorvo.py
@@ -9,7 +9,6 @@ class Qorvo(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
         bus.register('range', 'raw')
-        self.verbose = False
         self.initialized = False
 
     def on_raw(self, data):

--- a/osgar/drivers/rtk_filter.py
+++ b/osgar/drivers/rtk_filter.py
@@ -9,7 +9,6 @@ class RTKFilter(Node):
     def __init__(self, config, bus):
         super().__init__(config, bus)
         bus.register('filtered')
-        self.verbose = False
         self.trigger_time = None  # not defined
         self.buf = b''
 

--- a/osgar/drivers/vanjee.py
+++ b/osgar/drivers/vanjee.py
@@ -15,7 +15,6 @@ class VanJeeLidar(Node):
         self.last_frame = None  # not defined
         self.points = []
         self.debug_arr = []
-        self.verbose = False
 
     def on_raw(self, data):
         assert len(data) in [34, 1384], len(data)

--- a/osgar/drivers/vesc.py
+++ b/osgar/drivers/vesc.py
@@ -51,7 +51,6 @@ class MotorDriverVESC(Node):
         bus.register('can')
         self.debug_arr = []
         self.prev = {}
-        self.verbose = False  # TODO move into Node
         self.packet = [[], [], [], []]
         self.tachometer = [None, None, None, None]  # for motors #1, #2, #3 and #4
 

--- a/osgar/followme.py
+++ b/osgar/followme.py
@@ -30,7 +30,6 @@ class FollowMe(Node):
         bus.register('desired_speed')
         self.last_position = [0, 0, 0]  # proper should be None, but we really start from zero
         self.raise_exception_on_stop = False
-        self.verbose = False
         self.last_scan = None
         self.scan_size = config.get('scan_size', 271)
         self.scan_fov_deg = config.get('scan_fov_deg', 270)

--- a/osgar/followme_uwb.py
+++ b/osgar/followme_uwb.py
@@ -21,7 +21,6 @@ class FollowMeUWB(Node):
         bus.register('desired_speed')
         self.last_position = [0, 0, 0]  # proper should be None, but we really start from zero
         self.raise_exception_on_stop = False
-        self.verbose = False
         self.last_min_dist = None  # unknown
         self.follow_enabled = None  # unknown
 

--- a/osgar/followpath.py
+++ b/osgar/followpath.py
@@ -29,7 +29,6 @@ class FollowPath(Node):
         self.obstacle_stop_dist = config.get('obstacle_stop_dist', None)  # default no restriction
         self.last_obstacle = None  # no info available
         self.raise_exception_on_stop = False
-        self.verbose = False
         self.finished = False
 
     def control(self, pose):

--- a/osgar/go.py
+++ b/osgar/go.py
@@ -13,7 +13,6 @@ class Go(Node):
         bus.register('desired_speed', 'desired_steering')
         self.start_pose = None
         self.traveled_dist = 0.0
-        self.verbose = False
         self.speed = config['max_speed']
         self.dist = config['dist']
         self.timeout = timedelta(seconds=config['timeout'])

--- a/osgar/node.py
+++ b/osgar/node.py
@@ -15,6 +15,7 @@ class Node(Thread):
         self.setDaemon(True)
         self.bus = bus
         self.time = None
+        self.verbose = False  # set externally via "osgar.replay --verbose ..."
 
     def publish(self, channel, data):
         return self.bus.publish(channel, data)

--- a/osgar/platforms/cortexpilot.py
+++ b/osgar/platforms/cortexpilot.py
@@ -58,7 +58,6 @@ class Cortexpilot(Node):
         self.lidar_valid = False
         self.lidar_timestamp = 0
         self.uptime = None
-        self.verbose = False
         self.last_cmd = (0, 0, None)  # motors + timestamp
         self.last_processed_cmd = None  # i.e. already accepted by cortexpilot
         self.watchdog_count = 0  # how many times was watchdog triggered?

--- a/osgar/platforms/kloubak.py
+++ b/osgar/platforms/kloubak.py
@@ -279,7 +279,6 @@ class RobotKloubak(Node):
         self.epoch = None  # unknown
         self.partial_encoders = [None, None,] * self.num_axis
 
-        self.verbose = False  # should be in Node
         self.enc_debug_arr = []
         self.joint_debug_arr = []
         self.speed_debug_arr = []

--- a/osgar/platforms/maria.py
+++ b/osgar/platforms/maria.py
@@ -90,7 +90,6 @@ class RobotMaria(Node):
         self.pose2d = (0.0, 0.0, 0.0)  # x, y in meters, heading in radians (not corrected to 2PI)
         self.buttons = None
 
-        self.verbose = False  # should be in Node
         self.buf = b''
         self.encoder = None
         self.led = GREEN_LED

--- a/osgar/platforms/matty.py
+++ b/osgar/platforms/matty.py
@@ -75,7 +75,6 @@ class Matty(Node):
         self.desired_steering_angle_deg = 0.0  # degrees
         self.debug_arr = []
         self.debug_array_bumpers = []
-        self.verbose = False
         self.counter = 0
         self.buf = b''
         self.odometry_requested = False

--- a/osgar/platforms/spider.py
+++ b/osgar/platforms/spider.py
@@ -59,7 +59,6 @@ class Spider(Node):
         self.speed_history_left = []
         self.speed_history_right = []
         self.speed = 0.0  # suppose we start from standstill
-        self.verbose = False  # TODO node
         self.debug_arr = []
         self.pose2d = (0.0, 0.0, 0.0)  # x, y in meters, heading in radians (not corrected to 2PI)
         self.prev_enc = None  # not defined

--- a/osgar/platforms/yuhesen.py
+++ b/osgar/platforms/yuhesen.py
@@ -40,7 +40,6 @@ class FR07(Node):
         self.desired_speed = 0.0  # m/s
         self.desired_steering_angle_deg = 0.0  # degrees
         self.debug_arr = []
-        self.verbose = False
 
     def publish_pose2d(self, left, right):
         dt = 0.04  # 25Hz

--- a/osgar/turn.py
+++ b/osgar/turn.py
@@ -14,7 +14,6 @@ class Turn(Node):
         super().__init__(config, bus)
         bus.register('desired_speed')
         self.start_pose = None
-        self.verbose = False
         self.speed = config['max_speed']
         self.desired_angle = math.radians(config['angle_deg'])
         self.timeout = timedelta(seconds=config['timeout'])


### PR DESCRIPTION
Finally cleaning of `self.verbose` for nodes inherited from `osgar.node.Node`. Note, that this fix is primarily for AI so it does not try to load the value from config ;)