### PR TITLE
Improve osgar.replay --output to match original recording

### DIFF
--- a/osgar/bus.py
+++ b/osgar/bus.py
@@ -257,10 +257,11 @@ class LogBusHandlerInputsReaderOutputsWriter(LogBusHandlerInputsOnly):
     """
     Integrated reprocessing of given module and writing outputs into new log file
     """
-    def __init__(self, log, inputs, writer, outputs):
+    def __init__(self, log, inputs, writer, outputs, module_name):
         super().__init__(log, inputs)
         self.writer = writer
         self.outputs = outputs
+        self.module_name = module_name
         self.new_output_index = {}
 
     def register(self, *outputs):
@@ -268,7 +269,7 @@ class LogBusHandlerInputsReaderOutputsWriter(LogBusHandlerInputsOnly):
             # ignore :gz and :null modifiers
             if o.split(':')[0] not in self.outputs.values():
                 print('Warning - not defined output times for new stream:', (o, self.outputs))
-            self.new_output_index[o.split(':')[0]] = self.writer.register(o)
+            self.new_output_index[o.split(':')[0]] = self.writer.register(f'{self.module_name}.{o}')
 
     def publish(self, channel, data):
         self.writer.write(stream_id=self.new_output_index[channel],

--- a/osgar/replay.py
+++ b/osgar/replay.py
@@ -3,6 +3,7 @@
 """
 
 import argparse
+import sys
 import logging
 import inspect
 from ast import literal_eval
@@ -60,8 +61,10 @@ def replay(args, application=None):
         if args.output is None:
             bus = LogBusHandlerInputsOnly(reader, inputs=inputs)
         else:
-            writer = LogWriter(filename=args.output)
-            bus = LogBusHandlerInputsReaderOutputsWriter(reader, inputs=inputs, writer=writer, outputs=outputs)
+            writer = LogWriter(filename=args.output, note=str(sys.argv))  # new command line
+            writer.write(0, bytes(str(config), 'ascii'))  # original config
+            bus = LogBusHandlerInputsReaderOutputsWriter(reader, inputs=inputs, writer=writer,
+                                                         outputs=outputs, module_name=module)
     else:
         streams = list(inputs.keys()) + list(outputs.keys())
         reader = LogReader(args.logfile, only_stream_id=streams, clip_end_time_sec=duration)


### PR DESCRIPTION
- log command line arguments
- log used configuration file

--------
Again motivation is AI agents which (to my surprise) started to use the `--output` functionality instead of adding debug prints. Also if the output is JPEG image and some extra analysis is needed then it makes sense. I wanted to compare some results in `osgar.tools.lidarview`, but it failed to load due to missing config file --- added now (the original, or the one use passes it to `osgar.replay`. Finally I also extend the output names with "module_name", so "one day" we can replay multiple modules and it would not collide, maybe.