### PR TITLE
OAK DepthAI v3 - support for superblobs

### DIFF
--- a/config/oak-cone-detection-dai3.json
+++ b/config/oak-cone-detection-dai3.json
@@ -1,0 +1,45 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "oak": {
+          "driver": "osgar.drivers.oak_camera:OakCamera",
+          "init": {
+            "fps": 10,
+            "is_color": true,
+            "is_depth": true,
+            "laser_projector_current": 0,
+            "flood_light_current": 500,
+            "is_imu_enabled": true,
+            "number_imu_records": 10,
+            "disable_magnetometer_fusion": false,
+
+            "mono_resolution": "THE_400_P",
+            "color_resolution": "THE_1080_P",
+            "color_manual_focus": 130,
+
+            "stereo_median_filter": "KERNEL_3x3",
+            "stereo_mode": "HIGH_ACCURACY",
+            "stereo_extended_disparity": false,
+            "stereo_subpixel": false,
+            "stereo_left_right_check": true,
+
+            "model": {
+                  "blob": "cone/coneslayer.rvc2.tar.xz"
+            },
+            "nn_config": {
+                "output_format": "detection",
+                "NN_family": "YOLO",
+                "input_size": "416x416"
+            },
+            "mappings": {
+                "labels": [
+                    "cone"
+                ]
+            }
+          }
+      }
+    },
+    "links": []
+  }
+}

--- a/config/oak-cone-detection-dai3.json
+++ b/config/oak-cone-detection-dai3.json
@@ -7,6 +7,7 @@
           "init": {
             "fps": 10,
             "is_color": true,
+            "video_encoder": "h265",
             "is_depth": true,
             "laser_projector_current": 0,
             "flood_light_current": 500,

--- a/osgar/drivers/oak_camera_v3.py
+++ b/osgar/drivers/oak_camera_v3.py
@@ -324,6 +324,8 @@ class OakCamera:
                 if not nn_path:
                     continue
                 assert Path(nn_path).exists(), "No blob found at '{}'!".format(nn_path)
+                # optionally limit number of shaves for "superblob NN archives"
+                num_shaves = model_cfg.get("model", {}).get("num_shaves")
 
                 nn_config = model_cfg.get("nn_config", {})
                 nn_family = nn_config.get("NN_family", "YOLO")
@@ -334,19 +336,23 @@ class OakCamera:
                 else:
                     W, H = 416, 416  # default fallback
 
-
-                if nn_path.endswith(".tar.xz"):
+                is_nn_archive = nn_path.endswith(".tar.xz")
+                if is_nn_archive:
                     # superblob with config
                     # detectionNetwork - NN_ARCHIVE_PATH
                     nn = pipeline.create(dai.node.DetectionNetwork)
-                    nn.setNNArchive(dai.NNArchive(nn_path))
+                    if num_shaves is None:
+                        # unfortunately the DepthAI API does not support numShaves=None
+                        nn.setNNArchive(dai.NNArchive(nn_path))
+                    else:
+                        nn.setNNArchive(dai.NNArchive(nn_path), numShaves=num_shaves)
                 else:
                     nn = pipeline.create(dai.node.NeuralNetwork)
                     nn.setBlobPath(nn_path)
                     nn.setNumInferenceThreads(2)
                 nn.input.setBlocking(False)
 
-                if nn_family == 'YOLO' and not nn_path.endswith(".tar.xz"):  # hack not to use parser for superblob
+                if nn_family == 'YOLO' and not nn_path.endswith(".tar.xz"):  # no overload for NN archives (yet)
                     metadata = nn_config.get("NN_specific_metadata", {})
                     parser = pipeline.create(dai.node.DetectionParser)
                     if "confidence_threshold" in metadata:

--- a/osgar/drivers/oak_camera_v3.py
+++ b/osgar/drivers/oak_camera_v3.py
@@ -334,12 +334,19 @@ class OakCamera:
                 else:
                     W, H = 416, 416  # default fallback
 
-                nn = pipeline.create(dai.node.NeuralNetwork)
-                nn.setBlobPath(nn_path)
-                nn.setNumInferenceThreads(2)
+
+                if nn_path.endswith(".tar.xz"):
+                    # superblob with config
+                    # detectionNetwork - NN_ARCHIVE_PATH
+                    nn = pipeline.create(dai.node.DetectionNetwork)
+                    nn.setNNArchive(dai.NNArchive(nn_path))
+                else:
+                    nn = pipeline.create(dai.node.NeuralNetwork)
+                    nn.setBlobPath(nn_path)
+                    nn.setNumInferenceThreads(2)
                 nn.input.setBlocking(False)
 
-                if nn_family == 'YOLO':
+                if nn_family == 'YOLO' and not nn_path.endswith(".tar.xz"):  # hack not to use parser for superblob
                     metadata = nn_config.get("NN_specific_metadata", {})
                     parser = pipeline.create(dai.node.DetectionParser)
                     if "confidence_threshold" in metadata:


### PR DESCRIPTION
The processing of YOLO models changed in DepthAI version 3. In particular there is now automatically generated output and the final layer is computed on host computer (if I understand it correctly). The recommended solution (also based on Luxonis customer support) is to reconvert old *.pt or *.onnx model to "superblob" (instead of "blob"), which is an archive containing also some description files, handles this extra layer and has option to use different number of shaves. I tried "hello world" with the old cones model and it seems to work fine (standalone, in the office). I still do not know what to do with "DetectionParser" and other YOLO models, so this extra "IF" is pending.