### PR TITLE
Allow option to restring full scan to narrow cone only

### DIFF
--- a/config/pat-follow-matty.json
+++ b/config/pat-follow-matty.json
@@ -1,0 +1,78 @@
+{
+  "version": 2,
+  "robot": {
+    "modules": {
+      "app": {
+          "driver": "osgar.followme:FollowMe",
+          "in": ["encoders", "scan", "emergency_stop", "pose2d"],
+          "out": ["desired_speed"],
+          "init": {
+            "max_speed": 0.7,
+            "max_dist_limit": 3.0,
+            "desired_dist": 1.5,
+            "laser_pose2d": [0.13, 0.055, 0],
+            "scan_size": 1800,
+            "scan_fov_deg": -360,
+            "track_front_deg": 90
+          }
+      },
+      "platform": {
+        "driver": "osgar.platforms.yuhesen:FR07",
+        "in": ["can"],
+        "out": ["can"],
+        "init": {
+            "max_speed": 0.7
+        }
+      },
+      "can": {
+        "driver": "pcan",
+        "in": ["can"],
+        "out": ["can"],
+        "init": {}
+      },
+      "gps": {
+          "driver": "gps",
+          "in": ["raw"],
+          "out": ["position"],
+          "init": {}
+      },
+      "gps_serial": {
+          "driver": "serial",
+          "in": [],
+          "out": ["raw"],
+          "init": {"port": "/dev/ttyUSB0", "speed": 4800}
+      },
+      "vanjee": {
+          "driver": "vanjee",
+          "in": ["raw"],
+          "out": ["raw", "xyz"],
+          "init": {}
+      },
+      "vanjee_udp": {
+          "driver": "udp",
+          "in": ["raw"],
+          "out": ["raw"],
+          "init": {"host": "192.168.0.2", "port": 6050, "timeout": 3.0, "bufsize": 100000}
+      },
+      "obstdet3d": {
+          "driver": "osgar.obstdet3d:ObstacleDetector3D",
+          "in": ["depth"],
+          "out": ["obstacle"],
+          "init": {}
+      }
+    },
+    "links": [
+      ["can.can", "platform.can"],
+      ["platform.can", "can.can"],
+      ["app.desired_speed", "platform.desired_steering"],
+      ["platform.emergency_stop", "app.emergency_stop"],
+      ["platform.pose2d", "app.pose2d"],
+
+      ["gps_serial.raw", "gps.raw"],
+
+      ["vanjee_udp.raw", "vanjee.raw"],
+      ["vanjee.raw", "vanjee_udp.raw"],
+      ["vanjee.scan10", "app.scan"]
+    ]
+  }
+}

--- a/osgar/followme.py
+++ b/osgar/followme.py
@@ -36,6 +36,7 @@ class FollowMe(Node):
         self.max_speed = config.get('max_speed', 0.5)  # m/s
         self.max_dist_limit = config.get('max_dist_limit', 1.3)  # m
         self.desired_dist = config.get('desired_dist', 0.4)  # m
+        # optionally limit tracking to the smaller field of view (say due to internal obstruction of lidar)
         self.track_front_deg = config.get('track_front_deg', None)
         self.debug_arr = []
 

--- a/osgar/followme.py
+++ b/osgar/followme.py
@@ -36,6 +36,7 @@ class FollowMe(Node):
         self.max_speed = config.get('max_speed', 0.5)  # m/s
         self.max_dist_limit = config.get('max_dist_limit', 1.3)  # m
         self.desired_dist = config.get('desired_dist', 0.4)  # m
+        self.track_front_deg = config.get('track_front_deg', None)
         self.debug_arr = []
 
     def on_pose2d(self, data):
@@ -67,9 +68,15 @@ class FollowMe(Node):
         SCAN_SIZE = self.scan_size
         SCANS_PER_DEG = abs(SCAN_SIZE//self.scan_fov_deg)  # FOV can be negative for flipped lidar
 
-        # limit tracking to front 180deg only due to mounting (back laser is blocked by robot body)
-        LIMIT_LOW = 0  # SCAN_SIZE//6
-        LIMIT_HIGH = SCAN_SIZE  # 5*SCAN_SIZE//6
+        # limit tracking to front tracking cone if specified
+        if self.track_front_deg is not None:
+            fraction = min(1.0, float(self.track_front_deg) / abs(self.scan_fov_deg))
+            remove_side_fraction = (1.0 - fraction) / 2.0
+            LIMIT_LOW = int(remove_side_fraction * SCAN_SIZE)
+            LIMIT_HIGH = SCAN_SIZE - LIMIT_LOW
+        else:
+            LIMIT_LOW = 0
+            LIMIT_HIGH = SCAN_SIZE
         CLOSE_REFLECTIONS = 10  # ignore readings closer than 10mm, where 0 = infinite (no response)
 
         thresholds = []


### PR DESCRIPTION
Based on experience from "Tulak po krasu 2026" where we did not want to see the back of the robot on 360 degree VanJee lidar and even 180 degrees was too much, so 90deg was final choice.

The goal is to remove "followme_vanjee.py" almost identical copy from: https://github.com/robotika/osgar-apps/pull/30