### PR TITLE
Allow interrupting forced replay on Ctrl+C

### DIFF
--- a/osgar/bus.py
+++ b/osgar/bus.py
@@ -247,7 +247,7 @@ class LogBusHandlerInputsOnly:
         pass
 
     def shutdown(self):
-        pass
+        raise SystemExit()
 
     def report_error(self, err):
         print(self.time, err)

--- a/osgar/test_bus.py
+++ b/osgar/test_bus.py
@@ -129,6 +129,8 @@ class BusHandlerTest(unittest.TestCase):
         self.assertEqual(bus.listen(), (timedelta(microseconds=10), 'raw', [1, 2]))
         bus.publish('new_channel', b'some data')
         self.assertEqual(bus.listen(), (timedelta(microseconds=11), 'raw', [3, 4, 5]))
+        with self.assertRaises(SystemExit):
+            bus.shutdown()
 
     def test_report_error(self):
         log = MagicMock()


### PR DESCRIPTION
- Raise SystemExit in LogBusHandlerInputsOnly.shutdown()
- Add unittest to verify LogBusHandlerInputsOnly.shutdown() behavior