### PR TITLE
Configure sphinx-build to separate doctrees cache from output HTML

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Build documentation
         run: |
-          uv run sphinx-build -b html doc/sphinx doc/sphinx/_build/html
+          uv run sphinx-build -d doc/sphinx/_build/doctrees -b html doc/sphinx doc/sphinx/_build/html
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4


### PR DESCRIPTION
Specifying the '-d' option ensures intermediate doctree pickle files are generated outside of the published HTML output directory. This prevents deployment of intermediate build caches and eliminates binary git noise on the gh-pages branch when documentation content hasn't changed.

m3d: motivation is to skip unnecessary gh-pages update whenever we merge ANY pull-request (independently on documentation change).