### PR TITLE
Add scan5 stream support to VanJee Lidar driver

### DIFF
--- a/osgar/drivers/test_vanjee.py
+++ b/osgar/drivers/test_vanjee.py
@@ -19,4 +19,24 @@ class VanJeeLidarTest(unittest.TestCase):
         lidar.last_frame = 0xFFFF
         lidar.on_raw(packet)  # should not raise AssertionError: (65535, 0)
 
+    def test_scan5_publishing(self):
+        import struct
+        config = {}
+        handler = MagicMock()
+        lidar = VanJeeLidar(config, bus=handler)
+        # Create consecutive bank packets from 1 to 16
+        for bank in range(1, 17):
+            header = bytes.fromhex('ffaa0564') + struct.pack('>H', bank) + bytes(12) + struct.pack('>BH', bank, 38000)
+            data = bytes(1350)
+            padding = bytes(11)
+            footer = b'\xee\xee'
+            packet = header + data + padding + footer
+            lidar.on_raw(packet)
+        # Verify that all scans, including scan5, are published
+        published_channels = [call[0][0] for call in handler.publish.call_args_list]
+        self.assertIn('scan', published_channels)
+        self.assertIn('scan5', published_channels)
+        self.assertIn('scan10', published_channels)
+        self.assertIn('scanup', published_channels)
+
 # vim: expandtab sw=4 ts=4

--- a/osgar/drivers/vanjee.py
+++ b/osgar/drivers/vanjee.py
@@ -10,7 +10,7 @@ from osgar.bus import BusShutdownException
 
 class VanJeeLidar(Node):
     def __init__(self, config, bus):
-        bus.register('raw', 'xyz', 'scan', 'scan10', 'scanup')
+        bus.register('raw', 'xyz', 'scan', 'scan5', 'scan10', 'scanup')
         super().__init__(config, bus)
         self.last_frame = None  # not defined
         self.points = []
@@ -44,6 +44,8 @@ class VanJeeLidar(Node):
             if len(self.points) == 2*7200:
                 scan = self.points[5::8]  # -10, -5, 0, 0.3
                 self.publish('scan', scan)
+                scan5 = self.points[3::8]  # -10, -5, 0, 0.3
+                self.publish('scan5', scan5)
                 scan10 = self.points[1::8]  # -10, -5, 0, 0.3
                 self.publish('scan10', scan10)
                 scanup = self.points[7::8]  # -10, -5, 0, 0.3


### PR DESCRIPTION
Always enable the registration and publishing of the 'scan5' output representing the -5 degree scan line (from the self.points[3::8] slice) in the WLR-719C driver. This allows down-stream modules to leverage this additional vertical layer. Included an automated test to verify correct stream registration and publishing behavior.