### PR TITLE
osgar.replay fix initial timestamps

### DIFF
--- a/osgar/bus.py
+++ b/osgar/bus.py
@@ -269,7 +269,7 @@ class LogBusHandlerInputsReaderOutputsWriter(LogBusHandlerInputsOnly):
             # ignore :gz and :null modifiers
             if o.split(':')[0] not in self.outputs.values():
                 print('Warning - not defined output times for new stream:', (o, self.outputs))
-            self.new_output_index[o.split(':')[0]] = self.writer.register(f'{self.module_name}.{o}')
+            self.new_output_index[o.split(':')[0]] = self.writer.register(f'{self.module_name}.{o}', dt=self.time)
 
     def publish(self, channel, data):
         self.writer.write(stream_id=self.new_output_index[channel],

--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -104,7 +104,7 @@ def timedelta_parser(start_time=datetime.timedelta()):
 
 
 class LogWriter:
-    def __init__(self, prefix='', note='', filename=None, start_time=None):
+    def __init__(self, prefix='', note='', filename=None, start_time=None, dt=None):
         self.lock = RLock()
         if start_time is None:
             self.start_time = datetime.datetime.now(datetime.timezone.utc)
@@ -129,14 +129,14 @@ class LogWriter:
         self.f.write(b"".join(format_header(self.start_time)))
         self.f.flush()
         if len(note) > 0:
-            self.write(stream_id=INFO_STREAM_ID, data=bytes(note, encoding='utf-8'))
+            self.write(stream_id=INFO_STREAM_ID, data=bytes(note, encoding='utf-8'), dt=dt)
         self.names = []
 
-    def register(self, name):
+    def register(self, name, dt=None):
         with self.lock:
             assert name not in self.names, (name, self.names)
             self.names.append(name)
-            self.write(stream_id=INFO_STREAM_ID, data=bytes(str({'names': self.names}), encoding='ascii'))
+            self.write(stream_id=INFO_STREAM_ID, data=bytes(str({'names': self.names}), encoding='ascii'), dt=dt)
             return len(self.names)
 
     def write(self, stream_id, data, dt=None):

--- a/osgar/replay.py
+++ b/osgar/replay.py
@@ -7,6 +7,7 @@ import sys
 import logging
 import inspect
 from ast import literal_eval
+from datetime import timedelta
 
 from osgar import logger
 from osgar.logger import LogReader, LogWriter
@@ -69,8 +70,8 @@ def replay(args, application=None):
         if args.output is None:
             bus = LogBusHandlerInputsOnly(reader, inputs=inputs)
         else:
-            writer = LogWriter(filename=args.output, note=str(sys.argv))  # new command line
-            writer.write(0, bytes(str(config), 'ascii'))  # original config
+            writer = LogWriter(filename=args.output, note=str(sys.argv), dt=timedelta(0))  # new command line
+            writer.write(0, bytes(str(config), 'ascii'), dt=timedelta(0))  # original config
             bus = LogBusHandlerInputsReaderOutputsWriter(reader, inputs=inputs, writer=writer,
                                                          outputs=outputs, module_name=module)
     else:


### PR DESCRIPTION
This bug was introduced by saving names and config into `osgar.replay` with parameter `--output`. There are two issues:
* if you replay given log twice you will get different binary output files
* there could be time jump which I observed:
```
python -m osgar.logger /data/pat/pat-follow-matty-260614_125805.log
 k                    name     bytes |   count | freq Hz
--------------------------------------------------------
 0                     sys  46938241 |  554995 | 160.0Hz
 1       app.desired_speed    173618 |   34678 |  10.0Hz
 2            platform.can   7075876 |  416228 | 120.0Hz
 3 platform.emergency_stop         2 |       2 |   0.0Hz
 4         platform.pose2d   1092949 |   86654 |  25.0Hz
 5                 can.can  37729171 | 2219363 | 639.8Hz
 6            gps.position     38148 |    3468 |   1.0Hz
 7        gps.rel_position         0 |       0 |   0.0Hz
 8           gps.nmea_data    638112 |    3468 |   1.0Hz
 9          gps_serial.raw   1207733 |  181330 |  52.3Hz
10              vanjee.raw        36 |       1 |   0.0Hz
11              vanjee.xyz         0 |       0 |   0.0Hz
12             vanjee.scan  99682484 |   34687 |  10.0Hz
13           vanjee.scan10 130047231 |   34687 |  10.0Hz
14           vanjee.scanup  99248434 |   34687 |  10.0Hz
15          vanjee_udp.raw 769775327 |  554994 | 160.0Hz
16      obstdet3d.obstacle         0 |       0 |   0.0Hz

Total time 0:57:48.675976
```
vs.
```
python -m osgar.logger vanjee-260614_125805.log 
 k                       name     bytes | count | freq Hz
---------------------------------------------------------
 0                        sys      2040 |     9 |   0.0Hz
 1                 vanjee.raw        36 |     1 |   0.0Hz
 2                 vanjee.xyz         0 |     0 |   0.0Hz
 3                vanjee.scan  99682484 | 34687 |   4.5Hz
 4               vanjee.scan5 117395510 | 34687 |   4.5Hz
 5              vanjee.scan10 130047231 | 34687 |   4.5Hz
 6 vanjee.scan10_reflectivity  62540661 | 34687 |   4.5Hz
 7              vanjee.scanup  99248434 | 34687 |   4.5Hz

Total time 2:09:23.550362
```
The issue debugged Elena and find out that initial system data are stored with "live" timestamps. It is now enforcing it to use `timedelta(0)`, but ... as I see the output files still differ most probably due to different absolute timestamps corresponding to time of replay (to be checked).