### PR TITLE
Fix support of NN grayscale input in oak_camera_v3.py

### DIFF
--- a/osgar/drivers/oak_camera_v3.py
+++ b/osgar/drivers/oak_camera_v3.py
@@ -380,7 +380,7 @@ class OakCamera:
                     assert self.is_stereo_images
                     nn_cam_out = mono_left.requestOutput((W, H), type=dai.ImgFrame.Type.BGR888p)
                 # make sure that there is no delay and only the latest image is processed
-                nn.input.setQueueSize(1)
+                nn.input.setMaxSize(1)
                 nn.input.setBlocking(False)
                 nn_cam_out.link(nn.input)
 

--- a/osgar/drivers/oak_camera_v3.py
+++ b/osgar/drivers/oak_camera_v3.py
@@ -374,7 +374,11 @@ class OakCamera:
                     queue = nn.out.createOutputQueue(blocking=False)
 
                 # Feed from color camera via specific requested output resolution per model
-                nn_cam_out = cam_rgb.requestOutput((W, H), type=dai.ImgFrame.Type.BGR888p)
+                if self.is_color:
+                    nn_cam_out = cam_rgb.requestOutput((W, H), type=dai.ImgFrame.Type.BGR888p)
+                else:
+                    assert self.is_stereo_images
+                    nn_cam_out = mono_left.requestOutput((W, H), type=dai.ImgFrame.Type.BGR888p)
                 nn_cam_out.link(nn.input)
 
                 nn_queues.append({

--- a/osgar/drivers/oak_camera_v3.py
+++ b/osgar/drivers/oak_camera_v3.py
@@ -379,6 +379,9 @@ class OakCamera:
                 else:
                     assert self.is_stereo_images
                     nn_cam_out = mono_left.requestOutput((W, H), type=dai.ImgFrame.Type.BGR888p)
+                # make sure that there is no delay and only the latest image is processed
+                nn.input.setQueueSize(1)
+                nn.input.setBlocking(False)
                 nn_cam_out.link(nn.input)
 
                 nn_queues.append({


### PR DESCRIPTION
Minor fix that input to NN does not have to be RGB camera - using left camera for now. This fix is related to `matty-redroad-night.json`, which combines road detection and YOLO26 but from grayscale camera:
* https://github.com/robotika/osgar-apps/pull/22

Edit:
Plus support processing of the latest image for YOLO model