### PR TITLE
Remove subt from setup.py

### DIFF
--- a/doc/sphinx/index.rst
+++ b/doc/sphinx/index.rst
@@ -8,7 +8,7 @@ OSGAR Documentation
 
 **Open Source Garden/Generic Autonomous Robot (Python library)**
 
-OSGAR is a lightweight, multi-platform library for recording and replaying data from multiple `nodes` (modules such as sensors, robots, and applications) logged into a single file.
+OSGAR is a lightweight, multi-platform Python library for recording and replaying data from multiple `nodes` (modules such as sensors, robots, and applications) logged into a single file.
 
 Key Features
 ------------

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/robotika/osgar",
     python_requires=">=3.6",
-    packages=['osgar', 'osgar.drivers', 'osgar.lib', 'osgar.tools', 'subt'],
+    packages=['osgar', 'osgar.drivers', 'osgar.lib', 'osgar.tools'],
     package_data={
         '': ['config/*.json'],
     },
@@ -31,8 +31,6 @@ setuptools.setup(
             'logger = osgar.logger:main',
             'record = osgar.record:main',
             'replay = osgar.replay:main',
-            'subt = subt.main:main',
-            'allsync = subt.tools.allsync:main',
         ],
     },
     classifiers=[


### PR DESCRIPTION
SubT is now deprecated and this is blocking proper deployment (including documentation)