### PR TITLE
Extend osgar.logger with --stream-format option

### DIFF
--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -447,6 +447,8 @@ def main():
     parser = argparse.ArgumentParser(description='Extract data from log')
     parser.add_argument('logfile', help='filename of stored file')
     parser.add_argument('--stream', help='stream ID or name', default=None, nargs='*')
+    parser.add_argument('--stream-format', help='stream output format',
+                        choices=['index', 'name', 'full'], default='index')
     parser.add_argument('--list-names', '-l', help='list stream names', action='store_true')
     parser.add_argument('--sec', help='display timestamps in seconds', action='store_true')
     parser.add_argument('--format', help='use python format - available fields sec, timestamp, stream_id, data')
@@ -493,24 +495,37 @@ def main():
         for name in args.stream:
             only_stream.append(lookup_stream_id(args.logfile, name))
 
+    names = None
+    if args.stream_format in ('name', 'full'):
+        names = ['sys'] + lookup_stream_names(args.logfile)
+
     with LogReader(args.logfile, only_stream_id=only_stream, clip_start_time_sec=args.start_time_sec, clip_end_time_sec=args.end_time_sec) as log:
         for timestamp, stream_id, data in log:
             if stream_id != 0:
                 data = deserialize(data)
+
+            if names is not None and stream_id < len(names):
+                if args.stream_format == 'name':
+                    stream_identifier = names[stream_id].split('.')[-1]
+                else:
+                    stream_identifier = names[stream_id]
+            else:
+                stream_identifier = stream_id
+
             if args.sec:
-                print(timestamp.total_seconds(), stream_id, data)
+                print(timestamp.total_seconds(), stream_identifier, data)
             elif args.format:
                 kw = dict(sec=timestamp.total_seconds(),
                           timestamp=timestamp,
                           walltime=log.start_time+timestamp,
-                          stream_id=stream_id,
+                          stream_id=stream_identifier,
                           data=data,
                           )
                 print(eval(f"f'{args.format}'", kw))
             elif args.raw:
                 sys.stdout.buffer.write(data)
             else:
-                print(timestamp, stream_id, data)
+                print(timestamp, stream_identifier, data)
 
 if __name__ == "__main__":
     main()

--- a/osgar/test_logger.py
+++ b/osgar/test_logger.py
@@ -385,6 +385,45 @@ class LoggerStreamingTest(unittest.TestCase):
                     with self.assertRaises(StopIteration):
                         next(l)
 
+    def test_logger_main_stream_format(self):
+        import io
+        from contextlib import redirect_stdout
+        with LogWriter(prefix='tmp_main_test', note='test_logger_main_stream_format') as log:
+            filename = log.filename
+            log.register('platform.gear')   # ID 1
+            log.register('platform.brakes') # ID 2
+            log.write(1, serialize(4))
+            log.write(2, serialize(False))
+
+        # Test name choice
+        with patch('sys.argv', ['logger.py', filename, '--stream', 'platform.gear', 'platform.brakes', '--stream-format', 'name']):
+            f = io.StringIO()
+            with redirect_stdout(f):
+                osgar.logger.main()
+            output = f.getvalue()
+            self.assertIn('gear 4', output)
+            self.assertIn('brakes False', output)
+
+        # Test full choice
+        with patch('sys.argv', ['logger.py', filename, '--stream', 'platform.gear', 'platform.brakes', '--stream-format', 'full']):
+            f = io.StringIO()
+            with redirect_stdout(f):
+                osgar.logger.main()
+            output = f.getvalue()
+            self.assertIn('platform.gear 4', output)
+            self.assertIn('platform.brakes False', output)
+
+        # Test index choice (default)
+        with patch('sys.argv', ['logger.py', filename, '--stream', 'platform.gear', 'platform.brakes', '--stream-format', 'index']):
+            f = io.StringIO()
+            with redirect_stdout(f):
+                osgar.logger.main()
+            output = f.getvalue()
+            self.assertIn('1 4', output)
+            self.assertIn('2 False', output)
+
+        os.remove(filename)
+
 
 class LoggerIndexedTest(unittest.TestCase):
 


### PR DESCRIPTION
choices ['index', 'name', 'full'] defaulting to index

--------
My motivation is to replace:
```
python -m osgar.logger ~/git/osgar-apps/lidarroad/toDel.log --stream platform.manual platform.brakes | tail -15
0:16:46.752133 4 False
0:17:19.413129 7 True
0:17:20.230240 4 True
0:17:20.462803 7 False
0:17:20.513865 7 True
```
with
```
(python) md@md-ThinkPad-P50:~/git/osgar$ python -m osgar.logger ~/git/osgar-apps/lidarroad/toDel.log --stream platform.manual platform.brakes --stream-format name | tail -15
0:16:46.752133 manual False
0:17:19.413129 brakes True
0:17:20.230240 manual True
0:17:20.462803 brakes False
0:17:20.513865 brakes True
0:17:20.711501 brakes False
```
or
```
(python) md@md-ThinkPad-P50:~/git/osgar$ python -m osgar.logger ~/git/osgar-apps/lidarroad/toDel.log --stream platform.manual platform.brakes --stream-format full | tail -15
0:16:46.752133 platform.manual False
0:17:19.413129 platform.brakes True
0:17:20.230240 platform.manual True
0:17:20.462803 platform.brakes False
0:17:20.513865 platform.brakes True
0:17:20.711501 platform.brakes False
```
