### PR TITLE
Support Multi-Log

### DIFF
--- a/doc/multilog.md
+++ b/doc/multilog.md
@@ -54,20 +54,22 @@ To prevent name collisions between overlapping streams (e.g., both logs having a
 ### B. Virtual Stream IDs
 To maintain strict compatibility with OSGAR's internal mechanics and existing post-processing scripts, the Multi-Log reader assigns sequential **Virtual Stream IDs** starting from `1` across all logs.
 
+Since individual logs contain streams structured as `module.stream` (e.g., `platform.pose2d` or `oak.color`), prefixing them with the log nickname results in names with two dots (e.g., `pat.platform.pose2d` or `m03.oak.color`).
+
 Suppose:
-- `pat` has 2 streams: `["raw", "pose2d"]`
-- `m03` has 2 streams: `["raw", "color"]`
+- `pat` has 2 streams: `["platform.raw", "platform.pose2d"]`
+- `m03` has 2 streams: `["oak.raw", "oak.color"]`
 
 The reader maps them to virtual stream IDs as follows:
 
-| Virtual ID | Full Prefixed Name | Source Log | Source Local Stream ID |
-|------------|--------------------|------------|------------------------|
-| `1`        | `pat.raw`          | `pat`      | `1`                    |
-| `2`        | `pat.pose2d`       | `pat`      | `2`                    |
-| `3`        | `m03.raw`          | `m03`      | `1`                    |
-| `4`        | `m03.color`        | `m03`      | `2`                    |
+| Virtual ID | Full Prefixed Name (with two dots) | Source Log | Source Local Stream ID |
+|------------|------------------------------------|------------|------------------------|
+| `1`        | `pat.platform.raw`                 | `pat`      | `1`                    |
+| `2`        | `pat.platform.pose2d`              | `pat`      | `2`                    |
+| `3`        | `m03.oak.raw`                      | `m03`      | `1`                    |
+| `4`        | `m03.oak.color`                    | `m03`      | `2`                    |
 
-Calling `lookup_stream_names()` on a Multi-Log configuration returns `['pat.raw', 'pat.pose2d', 'm03.raw', 'm03.color']`.
+Calling `lookup_stream_names()` on a Multi-Log configuration returns `['pat.platform.raw', 'pat.platform.pose2d', 'm03.oak.raw', 'm03.oak.color']`.
 
 ---
 

--- a/doc/multilog.md
+++ b/doc/multilog.md
@@ -18,16 +18,9 @@ To analyze these systems holistically, we need a unified time domain where strea
 
 ## 2. Configuration Schema
 
-A Multi-Log session is defined via a JSON configuration. The simplest form maps a nickname to a log file path:
+A Multi-Log session is defined via a JSON configuration. Each nickname maps to an object specifying the file path and an optional time offset (in seconds) to align log timelines. 
 
-```json
-{
-  "m03": "m03-matty-on-pat-redroad-260801_105050.log",
-  "pat": "pat-dh26-260801_105022.log"
-}
-```
-
-To support advanced options (like manual clock synchronization offsets), the configuration also supports a detailed object-based structure per nickname:
+If `offset_sec` is omitted, it defaults to `0.0`, which is ideal for systems that are already temporally synchronized (e.g., when multiple sensors or robots record on the same machine/network using synchronized clocks).
 
 ```json
 {
@@ -36,8 +29,7 @@ To support advanced options (like manual clock synchronization offsets), the con
     "offset_sec": -1.23
   },
   "pat": {
-    "file": "pat-dh26-260801_105022.log",
-    "offset_sec": 0.0
+    "file": "pat-dh26-260801_105022.log"
   }
 }
 ```

--- a/doc/multilog.md
+++ b/doc/multilog.md
@@ -64,6 +64,13 @@ The reader maps them as follows:
 Calling `lookup_stream_names()` on a Multi-Log configuration returns:
 `['pat.platform.raw', 'pat.platform.pose2d', 'm03.oak.raw', 'm03.oak.color']`.
 
+### C. Handling of Stream 0 (System/Info Stream)
+Stream ID `0` in standard OSGAR logs is a special system stream containing metadata such as stream names and driver configurations. 
+
+When merging multiple logs:
+1. **Upfront Metadata Retrieval**: The global configuration, stream names, and local settings are retrieved during the initialization of `MultiLogReader` (or via extended helper functions like `lookup_stream_names` and `lookup_config`).
+2. **Filtering During Stream Iteration**: During chronological packet merging, `MultiLogReader` **explicitly filters out and skips all local stream ID `0` packets**. This avoids polluting the unified stream with multiple conflicting system configuration packets, which could break tools expecting a single metadata block.
+
 ---
 
 ## 4. Time Synchronization & Merging

--- a/doc/multilog.md
+++ b/doc/multilog.md
@@ -43,16 +43,16 @@ To prevent name collisions between overlapping streams (e.g., both logs having a
 - Stream `platform.pose2d` from `pat` becomes `pat.platform.pose2d`.
 - Stream `oak.color` from `m03` becomes `m03.oak.color`.
 
-### B. Virtual Stream IDs
-To maintain strict compatibility with OSGAR's internal mechanics and existing post-processing scripts, the Multi-Log reader assigns sequential **Virtual Stream IDs** starting from `1` across all logs.
+### B. String-Based Stream Names (Primary User-Facing Interface)
+While integer stream IDs are used internally for backwards compatibility, the primary and recommended way for users and post-processing tools to identify and consume streams is via their **string-based names** (e.g., `"pat.platform.pose2d"`, `"m03.oak.color"`). String names are far more obvious and intuitive when combining multiple log sources.
 
-Since individual logs contain streams structured as `module.stream` (e.g., `platform.pose2d` or `oak.color`), prefixing them with the log nickname results in names with two dots (e.g., `pat.platform.pose2d` or `m03.oak.color`).
+For internal mapping and compatibility with low-level readers, the Multi-Log reader assigns sequential **Virtual Stream IDs** starting from `1` across all logs.
 
 Suppose:
 - `pat` has 2 streams: `["platform.raw", "platform.pose2d"]`
 - `m03` has 2 streams: `["oak.raw", "oak.color"]`
 
-The reader maps them to virtual stream IDs as follows:
+The reader maps them as follows:
 
 | Virtual ID | Full Prefixed Name (with two dots) | Source Log | Source Local Stream ID |
 |------------|------------------------------------|------------|------------------------|
@@ -61,7 +61,8 @@ The reader maps them to virtual stream IDs as follows:
 | `3`        | `m03.oak.raw`                      | `m03`      | `1`                    |
 | `4`        | `m03.oak.color`                    | `m03`      | `2`                    |
 
-Calling `lookup_stream_names()` on a Multi-Log configuration returns `['pat.platform.raw', 'pat.platform.pose2d', 'm03.oak.raw', 'm03.oak.color']`.
+Calling `lookup_stream_names()` on a Multi-Log configuration returns:
+`['pat.platform.raw', 'pat.platform.pose2d', 'm03.oak.raw', 'm03.oak.color']`.
 
 ---
 
@@ -91,22 +92,43 @@ def merged_generator(readers):
     generators = []
     for nick, reader in readers.items():
         generators.append(
-            (global_time(dt, nick), nick, stream_id, data)
-            for dt, stream_id, data in reader
+            (global_time(dt, nick), nick, stream_name, deserialized_data)
+            for dt, stream_name, deserialized_data in reader
         )
-    for dt_g, nick, local_id, data in heapq.merge(*generators, key=lambda x: x[0]):
-        virtual_id = to_virtual_id(nick, local_id)
-        yield dt_g, virtual_id, data
+    for dt_g, nick, stream_name, deserialized_data in heapq.merge(*generators, key=lambda x: x[0]):
+        # Yield absolute timeline packet
+        yield dt_g, f"{nick}.{stream_name}", deserialized_data
 ```
 
 ---
 
 ## 5. API Design & Proposed Classes
 
-We introduce a new module/classes to handle Multi-Log reading transparently.
+We introduce and support two main levels of log reading, with a strong focus on `LogReaderEx`.
 
-### A. `MultiLogReader` (Subclass or drop-in wrapper of `LogReader`)
-This class provides the exact same iterator interface as `LogReader`, making it seamless for existing tools.
+### A. `LogReaderEx` (Primary User-Facing Interface)
+`LogReaderEx` is the primary utility we support. It is the most user-friendly reader because it automatically resolves stream names and deserializes the payload.
+
+In the first round, `LogReaderEx` will be extended to transparently handle Multi-Log configurations. When initialized with a Multi-Log JSON file, it will instantiate a multi-log session and yield fully deserialized stream data identified by their intuitive string-based names:
+
+```python
+# Usage Example:
+with LogReaderEx("multi_config.json") as log:
+    for dt, stream_name, data in log:
+        # stream_name will be e.g. "pat.platform.pose2d"
+        # data will be fully deserialized
+        print(dt, stream_name, data)
+```
+
+We can also filter streams by name during initialization:
+```python
+with LogReaderEx("multi_config.json", names=["pat.platform.pose2d", "m03.oak.color"]) as log:
+    for dt, stream_name, data in log:
+        ...
+```
+
+### B. `MultiLogReader` (Underlying Low-Level Reader)
+A subclass or drop-in wrapper of `LogReader`. It works with raw bytes and Virtual Stream IDs for low-level compatibility.
 
 ```python
 class MultiLogReader:
@@ -114,21 +136,21 @@ class MultiLogReader:
         # 1. Load configuration (dictionary or JSON path)
         # 2. Open LogReader instances for each file
         # 3. Calculate T_ref and construct virtual stream map
-        # 4. If only_stream_id is provided, map virtual IDs back to local IDs and filter local readers
+        # 4. Filter local readers if only_stream_id is provided
         pass
 
     def __iter__(self):
-        # Yields (global_dt, virtual_stream_id, data)
+        # Yields (global_dt, virtual_stream_id, data_bytes)
         pass
 ```
 
-### B. Transparent Helper Functions
-We will extend existing functions in `osgar/logger.py` to seamlessly detect Multi-Log configurations (e.g., if the passed path ends with `.json` or is recognized as a JSON file):
+### C. Transparent Helper Functions
+We will extend existing functions in `osgar/logger.py` to seamlessly detect Multi-Log configurations:
 
 - **`lookup_stream_names(filename)`**:
   If `filename` is a Multi-Log JSON, it loads the config, fetches names for each log, prefixes them with nicknames, and returns the flat combined list of prefixed names.
 - **`lookup_stream_id(filename, stream_name)`**:
-  If the target is a Multi-Log, it translates a prefixed name (e.g. `pat.platform.pose2d`) to its **Virtual Stream ID**.
+  If the target is a Multi-Log, it translates a prefixed name (e.g., `pat.platform.pose2d`) to its **Virtual Stream ID**.
 - **`lookup_config(filename)`**:
   Returns a merged dictionary of configurations nested by nicknames (e.g., `{"pat": pat_config, "m03": m03_config}`).
 
@@ -137,16 +159,10 @@ We will extend existing functions in `osgar/logger.py` to seamlessly detect Mult
 ## 6. Open Points & Future Enhancements
 
 1. **How should we handle non-overlapping logs?**
-   - *Current thought*: Raise a warning during initialization if the logs have absolutely no overlap, but still allow processing if the user explicitly wants to stitch consecutive logs.
+   - *Current thought*: Because we do not know the end of a logfile in advance (especially with growing logfiles read with `follow=True`), we cannot reliably determine time span overlap at startup. For the initial version, we will ignore time-span overlap checking and simply merge whatever packets are available sequentially. Complex stitching and alignment of disjoint log spans will be deferred to future releases.
 
 2. **LogIndexedReader Compatibility**
-   - For rapid indexing and random access via `__getitem__`, `LogIndexedReader` uses `mmap` and building an index.
-   - For Multi-Log, we could build a combined virtual index: a list of `(pos_in_sub_log, global_dt, nickname, local_stream_id)`.
-   - Should we implement `MultiLogIndexedReader` if random access is required by UI/analysis tools?
+   - *Current thought*: `LogIndexedReader` is highly useful for visualization and analysis (e.g., in `osgar.tools.lidarview`). However, there is already an inherent challenge in handling backward steps with H.264 or H.265 encoded video streams due to keyframe/inter-frame dependencies. For the Multi-Log feature, we will focus on simplified forward-only stepping. If building a unified merged index and supporting general random-access becomes too complex, the implementation of `MultiLogIndexedReader` will be postponed to a subsequent iteration.
 
 3. **Time Synchronization Calibration**
-   - Hand-tuning `offset_sec` is tedious.
-   - We could support an automatic time calibration tool or a configuration property that aligns logs based on matching events or cross-correlation of signals (e.g. aligning GPS logs, or detecting a physical flash/bump visible in multiple logs).
-
-4. **Integration with `LogReaderEx`**
-   - `LogReaderEx` is highly used as it automatically deserializes data. `MultiLogReader` should be fully compatible with `LogReaderEx` so that calling `LogReaderEx` on a multi-log JSON yields `(global_dt, "nickname.stream_name", deserialized_data)`.
+   - *Current thought*: Hand-tuning `offset_sec` is tedious. While we could eventually support an automatic time calibration tool or a configuration property that aligns logs based on matching events or cross-correlation of signals (such as aligning GPS logs, or detecting a physical flash/bump visible in multiple logs), we will postpone any automatic alignment tools to a future iteration. The first version will rely strictly on manual `offset_sec` definitions in the configuration.

--- a/doc/multilog.md
+++ b/doc/multilog.md
@@ -1,0 +1,158 @@
+# Multi-Log Feature Design
+
+This document details the design and implementation strategy for the **Multi-Log** feature in OSGAR. 
+The goal of this feature is to allow users to process and replay multiple independent, temporally overlapping log files under a unified interface, as if they were reading from a single "virtual" log file.
+
+---
+
+## 1. Use Cases
+
+In real-world operations, data often comes from multiple independent sources:
+1. **Multi-Robot Operations**: Coordinating or analyzing the behavior of multiple autonomous robots (e.g., `pat` and `m03`).
+2. **Robot with External Sensors**: A robot logging its internal states (pose, lidar) while an external stationary camera or motion capture system logs ground-truth data in a separate file.
+3. **Algorithmic Reprocessing**: An old recording of raw sensor data replayed/reprocessed into a new log with updated pose estimations. We want to read the raw streams from the old log and the processed streams from the new log simultaneously.
+
+To analyze these systems holistically, we need a unified time domain where streams from different logs can be accessed synchronously.
+
+---
+
+## 2. Configuration Schema
+
+A Multi-Log session is defined via a JSON configuration. The simplest form maps a nickname to a log file path:
+
+```json
+{
+  "m03": "m03-matty-on-pat-redroad-260801_105050.log",
+  "pat": "pat-dh26-260801_105022.log"
+}
+```
+
+To support advanced options (like manual clock synchronization offsets), the configuration also supports a detailed object-based structure per nickname:
+
+```json
+{
+  "m03": {
+    "file": "m03-matty-on-pat-redroad-260801_105050.log",
+    "offset_sec": -1.23
+  },
+  "pat": {
+    "file": "pat-dh26-260801_105022.log",
+    "offset_sec": 0.0
+  }
+}
+```
+
+---
+
+## 3. Core Concepts
+
+### A. Prefixed Stream Names
+To prevent name collisions between overlapping streams (e.g., both logs having a `platform.pose2d` stream), all streams from a source are prefixed with their nickname.
+- Stream `platform.pose2d` from `pat` becomes `pat.platform.pose2d`.
+- Stream `oak.color` from `m03` becomes `m03.oak.color`.
+
+### B. Virtual Stream IDs
+To maintain strict compatibility with OSGAR's internal mechanics and existing post-processing scripts, the Multi-Log reader assigns sequential **Virtual Stream IDs** starting from `1` across all logs.
+
+Suppose:
+- `pat` has 2 streams: `["raw", "pose2d"]`
+- `m03` has 2 streams: `["raw", "color"]`
+
+The reader maps them to virtual stream IDs as follows:
+
+| Virtual ID | Full Prefixed Name | Source Log | Source Local Stream ID |
+|------------|--------------------|------------|------------------------|
+| `1`        | `pat.raw`          | `pat`      | `1`                    |
+| `2`        | `pat.pose2d`       | `pat`      | `2`                    |
+| `3`        | `m03.raw`          | `m03`      | `1`                    |
+| `4`        | `m03.color`        | `m03`      | `2`                    |
+
+Calling `lookup_stream_names()` on a Multi-Log configuration returns `['pat.raw', 'pat.pose2d', 'm03.raw', 'm03.color']`.
+
+---
+
+## 4. Time Synchronization & Merging
+
+Each individual log contains its own absolute UTC `start_time` in its header, and relative `timedelta` offsets for subsequent packets.
+
+### A. Global Timeline Reference
+We define the global reference start time $T_{\text{ref}}$ as the absolute earliest start time among all configured logs:
+
+$$T_{\text{ref}} = \min_{i} (start\_time_i + offset\_sec_i)$$
+
+For any log $i$, a packet with a local relative timestamp $t_{\text{local}}$ is mapped to the global timeline as:
+
+$$t_{\text{global}} = (start\_time_i + offset\_sec_i - T_{\text{ref}}) + t_{\text{local}}$$
+
+Since $T_{\text{ref}}$ is the absolute minimum, $t_{\text{global}}$ is guaranteed to be a positive `timedelta` (assuming no negative local timestamps).
+
+### B. Efficient K-Way Stream Merging
+To yield packets chronologically, we perform a $k$-way merge of the generators of each log file. Since each file's packets are already written in chronological order, we can use Python's `heapq.merge` for highly efficient, constant-memory streaming:
+
+```python
+import heapq
+
+# Concept implementation of merging
+def merged_generator(readers):
+    generators = []
+    for nick, reader in readers.items():
+        generators.append(
+            (global_time(dt, nick), nick, stream_id, data)
+            for dt, stream_id, data in reader
+        )
+    for dt_g, nick, local_id, data in heapq.merge(*generators, key=lambda x: x[0]):
+        virtual_id = to_virtual_id(nick, local_id)
+        yield dt_g, virtual_id, data
+```
+
+---
+
+## 5. API Design & Proposed Classes
+
+We introduce a new module/classes to handle Multi-Log reading transparently.
+
+### A. `MultiLogReader` (Subclass or drop-in wrapper of `LogReader`)
+This class provides the exact same iterator interface as `LogReader`, making it seamless for existing tools.
+
+```python
+class MultiLogReader:
+    def __init__(self, config_file_or_dict, only_stream_id=None, clip_start_time_sec=0.0, clip_end_time_sec=None):
+        # 1. Load configuration (dictionary or JSON path)
+        # 2. Open LogReader instances for each file
+        # 3. Calculate T_ref and construct virtual stream map
+        # 4. If only_stream_id is provided, map virtual IDs back to local IDs and filter local readers
+        pass
+
+    def __iter__(self):
+        # Yields (global_dt, virtual_stream_id, data)
+        pass
+```
+
+### B. Transparent Helper Functions
+We will extend existing functions in `osgar/logger.py` to seamlessly detect Multi-Log configurations (e.g., if the passed path ends with `.json` or is recognized as a JSON file):
+
+- **`lookup_stream_names(filename)`**:
+  If `filename` is a Multi-Log JSON, it loads the config, fetches names for each log, prefixes them with nicknames, and returns the flat combined list of prefixed names.
+- **`lookup_stream_id(filename, stream_name)`**:
+  If the target is a Multi-Log, it translates a prefixed name (e.g. `pat.platform.pose2d`) to its **Virtual Stream ID**.
+- **`lookup_config(filename)`**:
+  Returns a merged dictionary of configurations nested by nicknames (e.g., `{"pat": pat_config, "m03": m03_config}`).
+
+---
+
+## 6. Open Points & Future Enhancements
+
+1. **How should we handle non-overlapping logs?**
+   - *Current thought*: Raise a warning during initialization if the logs have absolutely no overlap, but still allow processing if the user explicitly wants to stitch consecutive logs.
+
+2. **LogIndexedReader Compatibility**
+   - For rapid indexing and random access via `__getitem__`, `LogIndexedReader` uses `mmap` and building an index.
+   - For Multi-Log, we could build a combined virtual index: a list of `(pos_in_sub_log, global_dt, nickname, local_stream_id)`.
+   - Should we implement `MultiLogIndexedReader` if random access is required by UI/analysis tools?
+
+3. **Time Synchronization Calibration**
+   - Hand-tuning `offset_sec` is tedious.
+   - We could support an automatic time calibration tool or a configuration property that aligns logs based on matching events or cross-correlation of signals (e.g. aligning GPS logs, or detecting a physical flash/bump visible in multiple logs).
+
+4. **Integration with `LogReaderEx`**
+   - `LogReaderEx` is highly used as it automatically deserializes data. `MultiLogReader` should be fully compatible with `LogReaderEx` so that calling `LogReaderEx` on a multi-log JSON yields `(global_dt, "nickname.stream_name", deserialized_data)`.

--- a/doc/multilog_handoff.md
+++ b/doc/multilog_handoff.md
@@ -34,6 +34,10 @@ For each log $i$ under nickname $nick_i$:
 - Virtual stream IDs are assigned sequentially starting from `1` matching the index $+ 1$ of the stream in the combined flat list.
 - Keep a bidirectional map or structured lookup for nickname + local stream ID $\longleftrightarrow$ Virtual Stream ID.
 
+### D. Handling of Stream 0 (System Stream)
+- Stream ID `0` contains local metadata (configurations and registered stream names).
+- Since metadata is parsed upfront during initialization, the Multi-Log reader generator **MUST explicitly filter out and skip all local stream ID 0 packets** during the merging step. This prevents multiple competing system packets from polluting the merged data stream.
+
 ---
 
 ## 2. Implementation Plan

--- a/doc/multilog_handoff.md
+++ b/doc/multilog_handoff.md
@@ -1,0 +1,148 @@
+# Multi-Log Feature Implementation Handoff
+
+This document provides a detailed step-by-step technical blueprint and codebase handoff for implementing the Multi-Log feature in OSGAR.
+
+---
+
+## 1. Architectural Checklist & Concepts
+
+### A. Configuration Format
+The input is a JSON file mapping nicknames to objects with `"file"` and an optional `"offset_sec"`:
+```json
+{
+  "m03": {
+    "file": "m03-matty-on-pat-redroad-260801_105050.log",
+    "offset_sec": -1.23
+  },
+  "pat": {
+    "file": "pat-dh26-260801_105022.log"
+  }
+}
+```
+
+### B. Timeline Reference
+For each log $i$ under nickname $nick_i$:
+- $start\_time_i$ is read from the log header.
+- $offset\_sec_i$ defaults to `0.0`.
+- The reference starting point is:
+  $$T_{\text{ref}} = \min_{i} (start\_time_i + offset\_sec_i)$$
+- A local packet timestamp $t_{\text{local}}$ is transformed to global time $t_{\text{global}}$ via:
+  $$t_{\text{global}} = (start\_time_i + offset\_sec_i - T_{\text{ref}}) + t_{\text{local}}$$
+
+### C. Stream Naming & Virtual IDs
+- Stream names are prefixed: `"{nickname}.{original_stream_name}"` (e.g., `"pat.platform.pose2d"`).
+- Virtual stream IDs are assigned sequentially starting from `1` matching the index $+ 1$ of the stream in the combined flat list.
+- Keep a bidirectional map or structured lookup for nickname + local stream ID $\longleftrightarrow$ Virtual Stream ID.
+
+---
+
+## 2. Implementation Plan
+
+### Step 1: Support Multi-Log in `osgar/logger.py` Helpers
+We must extend the standard helper functions to transparently detect a Multi-Log configuration (typically by checking if the filename is a dictionary, or ends with `.json`).
+
+#### A. `lookup_stream_names(filename)`
+```python
+def lookup_stream_names(filename):
+    if isinstance(filename, dict) or filename.endswith('.json'):
+        # 1. Load config if it is a JSON path
+        # 2. For each nickname:
+        #    a. Get local stream names using standard lookup_stream_names
+        #    b. Prefix each stream: f"{nickname}.{local_name}"
+        # 3. Return the consolidated flat list of prefixed names
+        pass
+```
+
+#### B. `lookup_stream_id(filename, stream_name)`
+```python
+def lookup_stream_id(filename, stream_name):
+    if isinstance(filename, dict) or filename.endswith('.json'):
+        # 1. Resolve flat stream names list via lookup_stream_names(filename)
+        # 2. Return stream_names.index(stream_name) + 1
+        pass
+```
+
+#### C. `lookup_config(filename)`
+```python
+def lookup_config(filename):
+    if isinstance(filename, dict) or filename.endswith('.json'):
+        # Return a dictionary where keys are nicknames and values are local log configurations
+        # e.g., { nickname: lookup_config(file) }
+        pass
+```
+
+---
+
+### Step 2: Implement the Low-Level `MultiLogReader`
+
+Create a clean class `MultiLogReader` (either as a standalone class or subclassing `LogReader` to replicate its iterator/context manager API).
+
+#### Core Responsibilities:
+1. **Initialize and Parse Sub-Logs**:
+   - Load the JSON/dictionary configuration.
+   - Instantiate a standard `LogReader` for each source file.
+   - Collect each reader's `start_time`, compute $T_{\text{ref}}$, and compile the map of Virtual IDs.
+2. **Handle filtering (`only_stream_id`)**:
+   - If `only_stream_id` is passed, map those Virtual IDs back to their local log sources and local stream IDs.
+   - Configure each sub-`LogReader` with its corresponding local stream ID filter. This keeps file-parsing extremely fast and lightweight!
+3. **Chronological Stream Merging (`heapq.merge`)**:
+   - Convert the generator of each individual sub-log to output adjusted global timestamps and virtual stream IDs:
+     ```python
+     def sub_generator(nickname, reader, local_to_virtual_map, delta_offset):
+         for dt, local_id, data in reader._read_gen():
+             global_dt = dt + delta_offset
+             virtual_id = local_to_virtual_map[local_id]
+             yield global_dt, virtual_id, data
+     ```
+   - Feed these individual generators into `heapq.merge(..., key=lambda packet: x[0])`.
+
+---
+
+### Step 3: Extend `LogReaderEx` (The Primary User API)
+
+Update `LogReaderEx` to cleanly support Multi-Logs, providing automatic deserialization and friendly string-based names.
+
+```python
+class LogReaderEx:
+    def __init__(self, filename, names=None):
+        if isinstance(filename, dict) or filename.endswith('.json'):
+            # Multi-Log mode
+            self.stream_names = lookup_stream_names(filename)
+            # Map requested names to virtual stream IDs
+            only_stream_id = None
+            if names is not None:
+                only_stream_id = [self.stream_names.index(name) + 1 for name in names]
+            self.reader = MultiLogReader(filename, only_stream_id=only_stream_id)
+        else:
+            # Standard single-log mode
+            ...
+```
+
+For its generator:
+```python
+def _read_gen(self):
+    if self.is_multi_log:
+        for dt, virtual_id, raw_data in self.reader:
+            # Yield (dt, prefixed_name, deserialized_data)
+            stream_name = self.stream_names[virtual_id - 1]
+            yield dt, stream_name, deserialize(raw_data)
+```
+
+---
+
+## 3. Recommended Test Suite
+
+We should write automated unit tests in `osgar/test_multilog.py` (or as a new test case class inside `osgar/test_logger.py`).
+
+### Verification Checklist:
+1. **Mock Data Creation**:
+   - Generate two small temporary OSGAR log files with known `start_time` values (e.g. 10 seconds apart) and some dummy messages.
+   - Create a corresponding Multi-Log configuration JSON.
+2. **Metadata Verification**:
+   - Assert `lookup_stream_names` correctly prefixes and flattens all streams.
+   - Assert `lookup_config` correctly aggregates individual configurations.
+3. **Unified Time Sorting & Merging**:
+   - Assert that reading via `LogReaderEx` on the multi-log JSON returns packets in perfect global chronological order.
+   - Confirm timestamps are correctly offset based on the earliest start time.
+4. **Filtering**:
+   - Confirm filtering by stream names (e.g., `names=["pat.platform.pose2d"]`) correctly limits output and avoids processing unneeded sub-logs.

--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -598,7 +598,10 @@ def calculate_stat(filename):
     names = ['sys'] + lookup_stream_names(filename)
     sizes = [0] * len(names)
     counts = [0] * len(names)
-    with LogReader(filename) as log:
+    is_json = isinstance(filename, (str, pathlib.Path)) and str(filename).endswith('.json')
+    log_reader = MultiLogReader(filename) if is_json else LogReader(filename)
+    with log_reader as log:
+        timestamp = datetime.timedelta()
         for timestamp, stream_id, data in log:
             sizes[stream_id] += len(data)
             counts[stream_id] += 1
@@ -666,7 +669,9 @@ def main():
     if args.stream_format in ('name', 'full'):
         names = ['sys'] + lookup_stream_names(args.logfile)
 
-    with LogReader(args.logfile, only_stream_id=only_stream, clip_start_time_sec=args.start_time_sec, clip_end_time_sec=args.end_time_sec) as log:
+    is_json = isinstance(args.logfile, (str, pathlib.Path)) and str(args.logfile).endswith('.json')
+    log_reader = MultiLogReader(args.logfile, only_stream_id=only_stream, clip_start_time_sec=args.start_time_sec, clip_end_time_sec=args.end_time_sec) if is_json else LogReader(args.logfile, only_stream_id=only_stream, clip_start_time_sec=args.start_time_sec, clip_end_time_sec=args.end_time_sec)
+    with log_reader as log:
         for timestamp, stream_id, data in log:
             if stream_id != 0:
                 data = deserialize(data)

--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -351,7 +351,37 @@ class LogIndexedReader:
         return len(self.index)-1
 
 
+def _load_multi_log_config(filename):
+    if isinstance(filename, dict):
+        return filename
+    filename_str = str(filename)
+    with open(filename_str, 'r', encoding='utf-8') as f:
+        config = json.load(f)
+    if os.path.dirname(filename_str):
+        base_dir = os.path.dirname(filename_str)
+        for nickname, info in config.items():
+            sub_file = info["file"]
+            if not os.path.isabs(sub_file):
+                cand = os.path.join(base_dir, sub_file)
+                if os.path.exists(cand):
+                    info["file"] = cand
+    return config
+
+
 def lookup_stream_names(filename):
+    is_json = False
+    if isinstance(filename, (str, pathlib.Path)):
+        if str(filename).endswith('.json'):
+            is_json = True
+    if isinstance(filename, dict) or is_json:
+        config = _load_multi_log_config(filename)
+        names = []
+        for nickname, info in config.items():
+            local_names = lookup_stream_names(info["file"])
+            for local_name in local_names:
+                names.append(f"{nickname}.{local_name}")
+        return names
+
     names = []
     with LogReader(filename) as log:
         for __, channel, line in log:
@@ -380,6 +410,112 @@ def lookup_stream_id(filename, stream_name):
     return names.index(stream_name) + 1
 
 
+import heapq
+
+class MultiLogReader:
+    def __init__(self, filename, follow=False, only_stream_id=None, clip_start_time_sec=0.0, clip_end_time_sec=None):
+        self.filename = filename
+        self.follow = follow
+        self.clip_start_time_sec = clip_start_time_sec
+        self.clip_end_time_sec = clip_end_time_sec
+        
+        if only_stream_id is None:
+            self.only_stream_id = None
+        else:
+            try:
+                self.only_stream_id = set(only_stream_id)
+            except TypeError:
+                self.only_stream_id = set([only_stream_id])
+                
+        self.config = _load_multi_log_config(filename)
+        self.stream_names = lookup_stream_names(self.config)
+        
+        # Build maps for each nickname: local stream ID -> virtual stream ID
+        name_to_virtual = {name: idx + 1 for idx, name in enumerate(self.stream_names)}
+        self.local_to_virtual = {}
+        for nickname, info in self.config.items():
+            local_names = lookup_stream_names(info["file"])
+            self.local_to_virtual[nickname] = {}
+            for idx, local_name in enumerate(local_names):
+                local_id = idx + 1
+                prefixed_name = f"{nickname}.{local_name}"
+                if prefixed_name in name_to_virtual:
+                    self.local_to_virtual[nickname][local_id] = name_to_virtual[prefixed_name]
+                    
+        self.readers = {}
+        actual_start_times = {}
+        for nickname, info in self.config.items():
+            offset_sec = info.get("offset_sec", 0.0)
+            
+            # Determine which stream IDs to read from this file
+            if self.only_stream_id is not None:
+                local_only = [
+                    local_id for local_id, virtual_id in self.local_to_virtual[nickname].items()
+                    if virtual_id in self.only_stream_id
+                ]
+                if not local_only:
+                    local_only = [-1]
+            else:
+                local_only = None
+                
+            reader = LogReader(info["file"], follow=self.follow, only_stream_id=local_only)
+            self.readers[nickname] = reader
+            
+            actual_start_time = reader.start_time + datetime.timedelta(seconds=offset_sec)
+            actual_start_times[nickname] = actual_start_time
+            
+        if actual_start_times:
+            self.start_time = min(actual_start_times.values())
+        else:
+            self.start_time = datetime.datetime.now(datetime.timezone.utc)
+            
+        self.delta_offsets = {}
+        for nickname, actual_start in actual_start_times.items():
+            self.delta_offsets[nickname] = actual_start - self.start_time
+            
+        self.gen = self._read_gen()
+        
+    def _sub_generator(self, nickname):
+        reader = self.readers[nickname]
+        delta = self.delta_offsets[nickname]
+        local_to_virtual_map = self.local_to_virtual[nickname]
+        for dt, local_id, data in reader._read_gen():
+            if local_id == 0:
+                continue
+            global_dt = dt + delta
+            virtual_id = local_to_virtual_map.get(local_id)
+            if virtual_id is not None:
+                yield global_dt, virtual_id, data
+                
+    def _read_gen(self):
+        generators = [self._sub_generator(nickname) for nickname in self.readers]
+        merged = heapq.merge(*generators, key=lambda packet: packet[0])
+        for dt, virtual_id, data in merged:
+            dt_sec = dt.total_seconds()
+            if dt_sec < self.clip_start_time_sec:
+                continue
+            if self.clip_end_time_sec is not None and dt_sec > self.clip_end_time_sec:
+                break
+            yield dt, virtual_id, data
+            
+    def close(self):
+        for reader in self.readers.values():
+            reader.close()
+        self.readers = {}
+        
+    def __enter__(self):
+        return self
+        
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        
+    def __next__(self):
+        return next(self.gen)
+        
+    def __iter__(self):
+        return self
+
+
 class LogReaderEx(LogReader):
     """
     Extended log reader which provides deserialized data and stream names.
@@ -396,11 +532,23 @@ class LogReaderEx(LogReader):
         :param names: optional list of stream names to extract. If None, all
                       streams are extracted.
         """
+        is_json = False
+        if isinstance(filename, (str, pathlib.Path)):
+            if str(filename).endswith('.json'):
+                is_json = True
+        self.is_multi_log = isinstance(filename, dict) or is_json
+        self.filename = filename
         self.stream_names = lookup_stream_names(filename)
         only_stream_id = None
         if names is not None:
             only_stream_id = [self.stream_names.index(name) + 1 for name in names]
-        super().__init__(filename, only_stream_id=only_stream_id)
+
+        if self.is_multi_log:
+            self.reader = MultiLogReader(filename, only_stream_id=only_stream_id)
+            self.start_time = self.reader.start_time
+            self.gen = self._read_gen()
+        else:
+            super().__init__(filename, only_stream_id=only_stream_id)
 
     def _read_gen(self, only_stream_id=None):
         """
@@ -408,12 +556,31 @@ class LogReaderEx(LogReader):
 
         The data is already deserialized.
         """
-        for dt, stream_id, data in super()._read_gen(only_stream_id):
-            if stream_id != 0:
-                yield dt, self.stream_names[stream_id - 1], deserialize(data)
+        if self.is_multi_log:
+            for dt, virtual_id, data in self.reader:
+                stream_name = self.stream_names[virtual_id - 1]
+                yield dt, stream_name, deserialize(data)
+        else:
+            for dt, stream_id, data in super()._read_gen(only_stream_id):
+                if stream_id != 0:
+                    yield dt, self.stream_names[stream_id - 1], deserialize(data)
+
+    def close(self):
+        if self.is_multi_log:
+            self.reader.close()
+        else:
+            super().close()
 
 
 def lookup_config(filename):
+    is_json = False
+    if isinstance(filename, (str, pathlib.Path)):
+        if str(filename).endswith('.json'):
+            is_json = True
+    if isinstance(filename, dict) or is_json:
+        config = _load_multi_log_config(filename)
+        return {nickname: lookup_config(info["file"]) for nickname, info in config.items()}
+
     with LogReader(filename) as log:
         for __, channel, line in log:
             if channel != 0:

--- a/osgar/logger.py
+++ b/osgar/logger.py
@@ -313,7 +313,7 @@ class LogIndexedReader:
         self.fd = os.open(self.filepath, os.O_RDONLY)
         self.data = mmap.mmap(self.fd, 0, access=mmap.ACCESS_READ)
         assert self.data[0:4] == b'Pyr\x00', self.data[0:4]
-        start_time = datetime.datetime(*struct.unpack('HBBBBBI', self.data[4:4+12]))
+        self.start_time = datetime.datetime(*struct.unpack('HBBBBBI', self.data[4:4+12]), datetime.timezone.utc)
         self.index = _create_index(self.data, 4+12)
         assert self.index[-1][0] <= len(self.data), (self.index[-1][0], len(self.data))
         return self
@@ -349,6 +349,83 @@ class LogIndexedReader:
 
     def __len__(self):
         return len(self.index)-1
+
+
+class LogIndexedMultiReader:
+    def __init__(self, filepath):
+        self.filepath = filepath
+        self.config = _load_multi_log_config(filepath)
+        self.stream_names = lookup_stream_names(self.config)
+        
+        # Build maps for each nickname: local stream ID -> virtual stream ID
+        name_to_virtual = {name: idx + 1 for idx, name in enumerate(self.stream_names)}
+        self.local_to_virtual = {}
+        for nickname, info in self.config.items():
+            local_names = lookup_stream_names(info["file"])
+            self.local_to_virtual[nickname] = {}
+            for idx, local_name in enumerate(local_names):
+                local_id = idx + 1
+                prefixed_name = f"{nickname}.{local_name}"
+                if prefixed_name in name_to_virtual:
+                    self.local_to_virtual[nickname][local_id] = name_to_virtual[prefixed_name]
+                    
+        self.readers = {nickname: LogIndexedReader(info["file"]) for nickname, info in self.config.items()}
+        self.global_index = []
+
+    def __enter__(self):
+        for reader in self.readers.values():
+            reader.__enter__()
+            
+        actual_start_times = {}
+        for nickname, reader in self.readers.items():
+            offset_sec = self.config[nickname].get("offset_sec", 0.0)
+            actual_start_times[nickname] = reader.start_time + datetime.timedelta(seconds=offset_sec)
+            
+        self.start_time = min(actual_start_times.values()) if actual_start_times else datetime.datetime.now(datetime.timezone.utc)
+        self.delta_offsets = {nickname: actual_start - self.start_time for nickname, actual_start in actual_start_times.items()}
+        
+        self._build_global_index()
+        return self
+
+    def _build_global_index(self):
+        all_packets = []
+        for nickname, reader in self.readers.items():
+            delta = self.delta_offsets[nickname]
+            for idx in range(len(reader)):
+                local_dt = reader.index[idx][1]
+                global_dt = local_dt + delta
+                all_packets.append((global_dt, nickname, idx))
+                
+        self.global_index = sorted(all_packets, key=lambda x: x[0])
+
+    def __exit__(self, *args):
+        for reader in self.readers.values():
+            reader.__exit__(*args)
+
+    def __len__(self):
+        return len(self.global_index)
+
+    def __getitem__(self, index):
+        if abs(index) >= len(self):
+            raise IndexError("log index {} out of range".format(index))
+        if index < 0:
+            index = len(self) + index
+            
+        global_dt, nickname, idx = self.global_index[index]
+        _, local_channel, data = self.readers[nickname][idx]
+        virtual_id = self.local_to_virtual[nickname].get(local_channel, 0)
+        return global_dt, virtual_id, data
+
+    def grow(self):
+        grown = False
+        for reader in self.readers.values():
+            old_len = len(reader)
+            reader.grow()
+            if len(reader) > old_len:
+                grown = True
+        if grown:
+            self._build_global_index()
+        return len(self)
 
 
 def _load_multi_log_config(filename):

--- a/osgar/test_multilog.py
+++ b/osgar/test_multilog.py
@@ -1,0 +1,133 @@
+import unittest
+import os
+import tempfile
+import json
+import pathlib
+import datetime
+
+from osgar.logger import (
+    LogWriter, LogReader, LogReaderEx, MultiLogReader,
+    lookup_stream_names, lookup_stream_id, lookup_config, INFO_STREAM_ID
+)
+from osgar.lib.serialize import serialize, deserialize
+
+class MultiLogTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.dir_path = self.temp_dir.name
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def test_multi_log_functionality(self):
+        # 1. Create two sub-logs with custom start times
+        start_m03 = datetime.datetime(2026, 8, 1, 10, 50, 0, tzinfo=datetime.timezone.utc)
+        start_pat = datetime.datetime(2026, 8, 1, 10, 50, 5, tzinfo=datetime.timezone.utc)
+
+        file_m03 = os.path.join(self.dir_path, "m03.log")
+        file_pat = os.path.join(self.dir_path, "pat.log")
+
+        # Create m03 log
+        with LogWriter(filename=file_m03, start_time=start_m03) as writer:
+            # Write a config dict to stream 0
+            writer.write(stream_id=INFO_STREAM_ID, data=bytes(str({"m03_cfg": True}), encoding='ascii'), dt=datetime.timedelta())
+            # Register "pose" stream -> stream ID 1
+            writer.register("pose", dt=datetime.timedelta())
+            # Write data packets
+            writer.write(1, serialize("pos1"), dt=datetime.timedelta(seconds=1.0))
+            writer.write(1, serialize("pos2"), dt=datetime.timedelta(seconds=3.0))
+
+        # Create pat log
+        with LogWriter(filename=file_pat, start_time=start_pat) as writer:
+            # Write a config dict to stream 0
+            writer.write(stream_id=INFO_STREAM_ID, data=bytes(str({"pat_cfg": 42}), encoding='ascii'), dt=datetime.timedelta())
+            # Register "speed" stream -> stream ID 1
+            writer.register("speed", dt=datetime.timedelta())
+            # Write data packets
+            writer.write(1, serialize(10), dt=datetime.timedelta(seconds=2.0))
+            writer.write(1, serialize(20), dt=datetime.timedelta(seconds=4.0))
+
+        # 2. Define Multi-Log configuration dictionary and JSON file
+        config_dict = {
+            "m03": {
+                "file": "m03.log",
+                "offset_sec": -1.0
+            },
+            "pat": {
+                "file": "pat.log"
+            }
+        }
+        
+        config_file_path = os.path.join(self.dir_path, "multilog_config.json")
+        with open(config_file_path, "w", encoding="utf-8") as f:
+            json.dump(config_dict, f)
+
+        # 3. Test lookup_stream_names
+        # Note: lookup_stream_names must correctly handle absolute/relative paths from the config file location
+        # Since files are "m03.log" and "pat.log" next to "multilog_config.json", it should resolve them.
+        names = lookup_stream_names(config_file_path)
+        self.assertEqual(names, ["m03.pose", "pat.speed"])
+
+        # Test lookup_stream_id
+        self.assertEqual(lookup_stream_id(config_file_path, "m03.pose"), 1)
+        self.assertEqual(lookup_stream_id(config_file_path, "pat.speed"), 2)
+
+        # Test lookup_config
+        cfgs = lookup_config(config_file_path)
+        self.assertEqual(cfgs, {
+            "m03": {"m03_cfg": True},
+            "pat": {"pat_cfg": 42}
+        })
+
+        # 4. Test reading from MultiLogReader directly
+        with MultiLogReader(config_file_path) as reader:
+            # T_ref = min(start_m03 + -1.0, start_pat + 0.0)
+            # T_ref = min(10:49:59, 10:50:05) = 10:49:59
+            # delta_m03 = start_m03 + -1.0 - T_ref = 0
+            # delta_pat = start_pat - T_ref = 6 seconds
+            # m03 packet 1: local 1.0 -> global 1.0
+            # m03 packet 2: local 3.0 -> global 3.0
+            # pat packet 1: local 2.0 -> global 8.0
+            # pat packet 2: local 4.0 -> global 10.0
+            expected_start_time = datetime.datetime(2026, 8, 1, 10, 49, 59, tzinfo=datetime.timezone.utc)
+            self.assertEqual(reader.start_time, expected_start_time)
+
+            packets = list(reader)
+            self.assertEqual(len(packets), 4)
+
+            # Assert order and correct virtual IDs
+            self.assertEqual(packets[0][0], datetime.timedelta(seconds=1.0))
+            self.assertEqual(packets[0][1], 1) # m03.pose virtual ID is 1
+            self.assertEqual(deserialize(packets[0][2]), "pos1")
+
+            self.assertEqual(packets[1][0], datetime.timedelta(seconds=3.0))
+            self.assertEqual(packets[1][1], 1)
+            self.assertEqual(deserialize(packets[1][2]), "pos2")
+
+            self.assertEqual(packets[2][0], datetime.timedelta(seconds=8.0))
+            self.assertEqual(packets[2][1], 2) # pat.speed virtual ID is 2
+            self.assertEqual(deserialize(packets[2][2]), 10)
+
+            self.assertEqual(packets[3][0], datetime.timedelta(seconds=10.0))
+            self.assertEqual(packets[3][1], 2)
+            self.assertEqual(deserialize(packets[3][2]), 20)
+
+        # 5. Test reading from LogReaderEx
+        with LogReaderEx(config_file_path) as reader:
+            self.assertEqual(reader.start_time, expected_start_time)
+            decoded_packets = list(reader)
+            self.assertEqual(len(decoded_packets), 4)
+            self.assertEqual(decoded_packets[0], (datetime.timedelta(seconds=1.0), "m03.pose", "pos1"))
+            self.assertEqual(decoded_packets[1], (datetime.timedelta(seconds=3.0), "m03.pose", "pos2"))
+            self.assertEqual(decoded_packets[2], (datetime.timedelta(seconds=8.0), "pat.speed", 10))
+            self.assertEqual(decoded_packets[3], (datetime.timedelta(seconds=10.0), "pat.speed", 20))
+
+        # 6. Test filtering by names under LogReaderEx
+        with LogReaderEx(config_file_path, names=["pat.speed"]) as reader:
+            filtered_packets = list(reader)
+            self.assertEqual(len(filtered_packets), 2)
+            self.assertEqual(filtered_packets[0], (datetime.timedelta(seconds=8.0), "pat.speed", 10))
+            self.assertEqual(filtered_packets[1], (datetime.timedelta(seconds=10.0), "pat.speed", 20))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/osgar/test_multilog.py
+++ b/osgar/test_multilog.py
@@ -129,5 +129,46 @@ class MultiLogTest(unittest.TestCase):
             self.assertEqual(filtered_packets[0], (datetime.timedelta(seconds=8.0), "pat.speed", 10))
             self.assertEqual(filtered_packets[1], (datetime.timedelta(seconds=10.0), "pat.speed", 20))
 
+        # 7. Test calculate_stat with Multi-Log config file
+        from osgar.logger import calculate_stat
+        stat_names, stat_sizes, stat_counts, stat_timestamp = calculate_stat(config_file_path)
+        self.assertEqual(stat_names, ["sys", "m03.pose", "pat.speed"])
+        self.assertEqual(stat_counts[0], 0)  # sys has 0 packets
+        self.assertEqual(stat_counts[1], 2)  # m03.pose has 2 packets
+        self.assertEqual(stat_counts[2], 2)  # pat.speed has 2 packets
+        self.assertEqual(stat_timestamp, datetime.timedelta(seconds=10.0))
+
+    def test_cli_main(self):
+        import sys
+        from unittest.mock import patch
+        from io import StringIO
+        from osgar.logger import main
+
+        # Create two sub-logs and a json config file
+        start_m03 = datetime.datetime(2026, 8, 1, 10, 50, 0, tzinfo=datetime.timezone.utc)
+        file_m03 = os.path.join(self.dir_path, "cli_m03.log")
+        with LogWriter(filename=file_m03, start_time=start_m03) as writer:
+            writer.register("pose", dt=datetime.timedelta())
+            writer.write(1, serialize("pos1"), dt=datetime.timedelta(seconds=1.0))
+
+        config_dict = {
+            "m03": {
+                "file": "cli_m03.log"
+            }
+        }
+        config_file_path = os.path.join(self.dir_path, "cli_multilog_config.json")
+        with open(config_file_path, "w", encoding="utf-8") as f:
+            json.dump(config_dict, f)
+
+        test_args = ["logger", config_file_path]
+        with patch.object(sys, 'argv', test_args):
+            with patch('sys.stdout', new=StringIO()) as fake_out:
+                with self.assertRaises(SystemExit) as cm:
+                    main()
+                self.assertTrue(cm.exception.code in (0, None))
+                output = fake_out.getvalue()
+                self.assertIn("m03.pose", output)
+                self.assertIn("Total time", output)
+
 if __name__ == "__main__":
     unittest.main()

--- a/osgar/tools/lidarview.py
+++ b/osgar/tools/lidarview.py
@@ -16,7 +16,7 @@ import cv2  # for video output
 import numpy as np  # faster depth data processing
 from importlib import import_module
 
-from osgar.logger import LogIndexedReader, lookup_stream_names, LogReader
+from osgar.logger import LogIndexedReader, lookup_stream_names, LogReader, LogIndexedMultiReader, _load_multi_log_config
 from osgar.lib.serialize import deserialize
 from osgar.lib.config import get_class_by_name
 from osgar.lib import quaternion
@@ -320,6 +320,13 @@ def get_config(logfile):
     """
     Deserialize original config from logfile. Return None if missing
     """
+    is_json = isinstance(logfile, (str, pathlib.Path)) and str(logfile).endswith('.json')
+    if is_json:
+        config = _load_multi_log_config(logfile)
+        # Get the file path of the first sub-log configuration
+        first_sub_file = next(iter(config.values()))["file"]
+        return get_config(first_sub_file)
+
     log = LogReader(logfile, only_stream_id=0)
     print("original args:", next(log)[-1])  # old arguments
     config_str = next(log)[-1]
@@ -338,7 +345,8 @@ class Framer:
     def __init__(self, filepath, lidar_name=None, lidar2_name=None, pose2d_name=None, pose3d_name=None, camera_name=None,
                  camera2_name=None, bbox_name=None, rgbd_name=None, joint_name=None, keyframes_name=None, title_name=None,
                  lidar_up_name=None, lidar_down_name=None):
-        self.log = LogIndexedReader(filepath)
+        is_json = isinstance(filepath, (str, pathlib.Path)) and str(filepath).endswith('.json')
+        self.log = LogIndexedMultiReader(filepath) if is_json else LogIndexedReader(filepath)
         self.current = 0
         self.frame = Frame()
         self.pose = [0, 0, 0]


### PR DESCRIPTION
# Multi-Log Feature Design

This document details the design and implementation strategy for the **Multi-Log** feature in OSGAR. 
The goal of this feature is to allow users to process and replay multiple independent, temporally overlapping log files under a unified interface, as if they were reading from a single "virtual" log file.

---

## 1. Use Cases

In real-world operations, data often comes from multiple independent sources:
1. **Multi-Robot Operations**: Coordinating or analyzing the behavior of multiple autonomous robots (e.g., `pat` and `m03`).
2. **Robot with External Sensors**: A robot logging its internal states (pose, lidar) while an external stationary camera or motion capture system logs ground-truth data in a separate file.
3. **Algorithmic Reprocessing**: An old recording of raw sensor data replayed/reprocessed into a new log with updated pose estimations. We want to read the raw streams from the old log and the processed streams from the new log simultaneously.

To analyze these systems holistically, we need a unified time domain where streams from different logs can be accessed synchronously.

---

## 2. Configuration Schema

A Multi-Log session is defined via a JSON configuration. Each nickname maps to an object specifying the file path and an optional time offset (in seconds) to align log timelines. 

If `offset_sec` is omitted, it defaults to `0.0`, which is ideal for systems that are already temporally synchronized (e.g., when multiple sensors or robots record on the same machine/network using synchronized clocks).

```json
{
  "m03": {
    "file": "m03-matty-on-pat-redroad-260801_105050.log",
    "offset_sec": -1.23
  },
  "pat": {
    "file": "pat-dh26-260801_105022.log"
  }
}