### PR TITLE
Add missing "osgar.platforms" into setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/robotika/osgar",
     python_requires=">=3.6",
-    packages=['osgar', 'osgar.drivers', 'osgar.lib', 'osgar.tools'],
+    packages=['osgar', 'osgar.drivers', 'osgar.lib', 'osgar.tools', 'osgar.platforms'],
     package_data={
         '': ['config/*.json'],
     },


### PR DESCRIPTION
Well, I did not realize until now, that it is not possible to import `osgar.platforms` from released packages :( ... this is a fix.